### PR TITLE
feat: Smarter Port Alloc

### DIFF
--- a/crates/ergot/src/net_stack.rs
+++ b/crates/ergot/src/net_stack.rs
@@ -33,14 +33,14 @@ use crate::{
 
 /// The Ergot Netstack
 pub struct NetStack<R: ScopedRawMutex, M: InterfaceManager> {
-    pub(crate) inner: BlockingMutex<R, NetStackInner<M>>,
+    inner: BlockingMutex<R, NetStackInner<M>>,
 }
 
 pub(crate) struct NetStackInner<M: InterfaceManager> {
     sockets: List<SocketHeader>,
-    pub(crate) manager: M,
-    pub(crate) port_ctr: u8,
-    pub(crate) seq_no: u16,
+    manager: M,
+    port_ctr: u8,
+    seq_no: u16,
 }
 
 /// An error from calling a [`NetStack`] "send" method
@@ -401,9 +401,12 @@ where
     }
 
     pub(crate) unsafe fn detach_socket(&'static self, node: NonNull<SocketHeader>) {
-        self.inner.with_lock(|inner| unsafe {
-            inner.sockets.remove(node)
-        });
+        self.inner
+            .with_lock(|inner| unsafe { inner.sockets.remove(node) });
+    }
+
+    pub(crate) unsafe fn with_lock<U, F: FnOnce() -> U>(&'static self, f: F) -> U {
+        self.inner.with_lock(|_inner| f())
     }
 }
 

--- a/crates/ergot/src/net_stack.rs
+++ b/crates/ergot/src/net_stack.rs
@@ -37,7 +37,7 @@ pub struct NetStack<R: ScopedRawMutex, M: InterfaceManager> {
 }
 
 pub(crate) struct NetStackInner<M: InterfaceManager> {
-    pub(crate) sockets: List<SocketHeader>,
+    sockets: List<SocketHeader>,
     pub(crate) manager: M,
     pub(crate) port_ctr: u8,
     pub(crate) seq_no: u16,
@@ -398,6 +398,12 @@ where
             inner.sockets.push_front(node);
             inner.port_ctr
         })
+    }
+
+    pub(crate) unsafe fn detach_socket(&'static self, node: NonNull<SocketHeader>) {
+        self.inner.with_lock(|inner| unsafe {
+            inner.sockets.remove(node)
+        });
     }
 }
 

--- a/crates/ergot/src/socket/owned.rs
+++ b/crates/ergot/src/socket/owned.rs
@@ -215,7 +215,7 @@ where
     }
 
     pub fn stack(&self) -> &'static NetStack<R, M> {
-        unsafe { &*addr_of!((*self.ptr.as_ptr()).net) }
+        unsafe { *addr_of!((*self.ptr.as_ptr()).net) }
     }
 
     // TODO: This future is !Send? I don't fully understand why, but rustc complains
@@ -234,13 +234,10 @@ where
 {
     fn drop(&mut self) {
         println!("Dropping OwnedSocket!");
-        // first things first, remove the item from the list
-        self.net.inner.with_lock(|net| {
-            let node: NonNull<SocketHeader> = NonNull::from(&self.hdr);
-            unsafe {
-                net.sockets.remove(node);
-            }
-        });
+        unsafe {
+            let this = NonNull::from(&self.hdr);
+            self.net.detach_socket(this);
+        }
     }
 }
 

--- a/crates/ergot/src/socket/std_bounded.rs
+++ b/crates/ergot/src/socket/std_bounded.rs
@@ -218,7 +218,7 @@ where
     }
 
     pub fn stack(&self) -> &'static NetStack<R, M> {
-        unsafe { &*addr_of!((*self.ptr.as_ptr()).net) }
+        unsafe { *addr_of!((*self.ptr.as_ptr()).net) }
     }
 
     // TODO: This future is !Send? I don't fully understand why, but rustc complains
@@ -237,13 +237,10 @@ where
 {
     fn drop(&mut self) {
         println!("Dropping StdBoundedSocket!");
-        // first things first, remove the item from the list
-        self.net.inner.with_lock(|net| {
-            let node: NonNull<SocketHeader> = NonNull::from(&self.hdr);
-            unsafe {
-                net.sockets.remove(node);
-            }
-        });
+        unsafe {
+            let this = NonNull::from(&self.hdr);
+            self.net.detach_socket(this);
+        }
     }
 }
 


### PR DESCRIPTION
Add a port allocator that is inspired by littlefs2's block id allocator.

We keep a bitmask of the current range of available ports, when it fills up, we go looking for the lowest range with ports available.