### PR TITLE
Bespoke Sockets

### DIFF
--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -249,7 +249,6 @@ pub mod well_known;
 pub use address::Address;
 pub use net_stack::{NetStack, NetStackSendError};
 use postcard_rpc::Key;
-use socket::SocketTy;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
@@ -274,16 +273,6 @@ impl FrameKind {
             FrameKind::EndpointRequest => 0,
             FrameKind::EndpointResponse => 1,
             FrameKind::Topic => 2,
-        }
-    }
-
-    pub fn matches(&self, other: &SocketTy) -> bool {
-        #[allow(clippy::match_like_matches_macro)]
-        match (self, other) {
-            (FrameKind::EndpointRequest, SocketTy::EndpointReq(_)) => true,
-            (FrameKind::EndpointResponse, SocketTy::EndpointResp(_)) => true,
-            (FrameKind::Topic, SocketTy::TopicIn(_)) => true,
-            _ => false,
         }
     }
 }

--- a/crates/ergot/src/socket/endpoint.rs
+++ b/crates/ergot/src/socket/endpoint.rs
@@ -8,7 +8,7 @@ use serde::{Serialize, de::DeserializeOwned};
 use crate::{FrameKind, Header, NetStack, NetStackSendError, interface_manager::InterfaceManager};
 
 use super::{
-    OwnedMessage,
+    OwnedMessage, SocketHeaderEndpointReq,
     owned::{OwnedSocket, OwnedSocketHdl},
     std_bounded::{StdBoundedSocket, StdBoundedSocketHdl},
 };
@@ -22,7 +22,7 @@ where
     M: InterfaceManager + 'static,
 {
     #[pin]
-    sock: OwnedSocket<E::Request, R, M>,
+    sock: OwnedSocket<SocketHeaderEndpointReq, E::Request, R, M>,
 }
 
 impl<E, R, M> OwnedEndpointSocket<E, R, M>
@@ -40,7 +40,7 @@ where
 
     pub fn attach<'a>(self: Pin<&'a mut Self>) -> OwnedEndpointSocketHdl<'a, E, R, M> {
         let this = self.project();
-        let hdl: OwnedSocketHdl<'_, E::Request, R, M> = this.sock.attach();
+        let hdl: OwnedSocketHdl<'_, SocketHeaderEndpointReq, E::Request, R, M> = this.sock.attach();
         OwnedEndpointSocketHdl { hdl }
     }
 }
@@ -52,7 +52,7 @@ where
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
-    hdl: OwnedSocketHdl<'a, E::Request, R, M>,
+    hdl: OwnedSocketHdl<'a, SocketHeaderEndpointReq, E::Request, R, M>,
 }
 
 impl<E, R, M> OwnedEndpointSocketHdl<'_, E, R, M>
@@ -101,7 +101,7 @@ where
     M: InterfaceManager + 'static,
 {
     #[pin]
-    sock: StdBoundedSocket<E::Request, R, M>,
+    sock: StdBoundedSocket<SocketHeaderEndpointReq, E::Request, R, M>,
 }
 
 impl<E, R, M> StdBoundedEndpointSocket<E, R, M>
@@ -119,7 +119,8 @@ where
 
     pub fn attach<'a>(self: Pin<&'a mut Self>) -> StdBoundedEndpointSocketHdl<'a, E, R, M> {
         let this = self.project();
-        let hdl: StdBoundedSocketHdl<'_, E::Request, R, M> = this.sock.attach();
+        let hdl: StdBoundedSocketHdl<'_, SocketHeaderEndpointReq, E::Request, R, M> =
+            this.sock.attach();
         StdBoundedEndpointSocketHdl { hdl }
     }
 }
@@ -131,7 +132,7 @@ where
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
-    hdl: StdBoundedSocketHdl<'a, E::Request, R, M>,
+    hdl: StdBoundedSocketHdl<'a, SocketHeaderEndpointReq, E::Request, R, M>,
 }
 
 impl<E, R, M> StdBoundedEndpointSocketHdl<'_, E, R, M>

--- a/crates/ergot/src/socket/mod.rs
+++ b/crates/ergot/src/socket/mod.rs
@@ -2,11 +2,13 @@ use core::any::TypeId;
 use core::ptr::{self, NonNull};
 
 use cordyceps::{Linked, list::Links};
+use mutex::ScopedRawMutex;
 use postcard_rpc::{Endpoint, Key, Topic};
 use postcard_schema::Schema;
 use postcard_schema::schema::NamedType;
 
-use crate::HeaderSeq;
+use crate::interface_manager::InterfaceManager;
+use crate::{HeaderSeq, NetStack};
 
 pub mod endpoint;
 pub mod owned;
@@ -28,19 +30,43 @@ pub struct TopicData {
     pub msg_schema: &'static NamedType,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum SocketTy {
-    EndpointReq(&'static EndpointData),
-    EndpointResp(&'static EndpointData),
-    TopicIn(&'static TopicData),
-    // todo: TopicOut?
+pub struct SocketHeaderEndpointReq {
+    pub(crate) links: Links<SocketHeaderEndpointReq>,
+    pub(crate) port: u8,
+    pub(crate) data: &'static EndpointData,
+    pub(crate) vtable: &'static SocketVTable,
 }
 
-pub struct SocketHeader {
-    pub(crate) links: Links<SocketHeader>,
+impl SocketHeaderEndpointReq {
+    pub fn key(&self) -> Key {
+        self.data.req_key
+    }
+}
+
+pub struct SocketHeaderEndpointResp {
+    pub(crate) links: Links<SocketHeaderEndpointResp>,
     pub(crate) port: u8,
-    pub(crate) kind: SocketTy,
+    pub(crate) data: &'static EndpointData,
     pub(crate) vtable: &'static SocketVTable,
+}
+
+impl SocketHeaderEndpointResp {
+    pub fn key(&self) -> Key {
+        self.data.resp_key
+    }
+}
+
+pub struct SocketHeaderTopicIn {
+    pub(crate) links: Links<SocketHeaderTopicIn>,
+    pub(crate) port: u8,
+    pub(crate) data: &'static TopicData,
+    pub(crate) vtable: &'static SocketVTable,
+}
+
+impl SocketHeaderTopicIn {
+    pub fn key(&self) -> Key {
+        self.data.msg_key
+    }
 }
 
 // TODO: Way of signaling "socket consumed"?
@@ -127,34 +153,12 @@ impl TopicData {
     }
 }
 
-impl SocketTy {
-    pub const fn endpoint_req<E: Endpoint>() -> Self {
-        Self::EndpointReq(&const { EndpointData::for_endpoint::<E>() })
-    }
-
-    pub const fn endpoint_resp<E: Endpoint>() -> Self {
-        Self::EndpointResp(&const { EndpointData::for_endpoint::<E>() })
-    }
-
-    pub const fn topic_in<T: Topic>() -> Self {
-        Self::TopicIn(&const { TopicData::for_topic::<T>() })
-    }
-
-    pub fn key(&self) -> Key {
-        match *self {
-            SocketTy::EndpointReq(endpoint_data) => endpoint_data.req_key,
-            SocketTy::EndpointResp(endpoint_data) => endpoint_data.resp_key,
-            SocketTy::TopicIn(topic_data) => topic_data.msg_key,
-        }
-    }
-}
-
 // --------------------------------------------------------------------------
 // impl SocketHeader
 // --------------------------------------------------------------------------
 
-unsafe impl Linked<Links<SocketHeader>> for SocketHeader {
-    type Handle = NonNull<SocketHeader>;
+unsafe impl Linked<Links<SocketHeaderEndpointReq>> for SocketHeaderEndpointReq {
+    type Handle = NonNull<SocketHeaderEndpointReq>;
 
     fn into_ptr(r: Self::Handle) -> std::ptr::NonNull<Self> {
         r
@@ -164,10 +168,126 @@ unsafe impl Linked<Links<SocketHeader>> for SocketHeader {
         ptr
     }
 
-    unsafe fn links(target: NonNull<Self>) -> NonNull<Links<SocketHeader>> {
+    unsafe fn links(target: NonNull<Self>) -> NonNull<Links<SocketHeaderEndpointReq>> {
         // Safety: using `ptr::addr_of!` avoids creating a temporary
         // reference, which stacked borrows dislikes.
         let node = unsafe { ptr::addr_of_mut!((*target.as_ptr()).links) };
         unsafe { NonNull::new_unchecked(node) }
+    }
+}
+
+unsafe impl Linked<Links<SocketHeaderEndpointResp>> for SocketHeaderEndpointResp {
+    type Handle = NonNull<SocketHeaderEndpointResp>;
+
+    fn into_ptr(r: Self::Handle) -> std::ptr::NonNull<Self> {
+        r
+    }
+
+    unsafe fn from_ptr(ptr: std::ptr::NonNull<Self>) -> Self::Handle {
+        ptr
+    }
+
+    unsafe fn links(target: NonNull<Self>) -> NonNull<Links<SocketHeaderEndpointResp>> {
+        // Safety: using `ptr::addr_of!` avoids creating a temporary
+        // reference, which stacked borrows dislikes.
+        let node = unsafe { ptr::addr_of_mut!((*target.as_ptr()).links) };
+        unsafe { NonNull::new_unchecked(node) }
+    }
+}
+
+unsafe impl Linked<Links<SocketHeaderTopicIn>> for SocketHeaderTopicIn {
+    type Handle = NonNull<SocketHeaderTopicIn>;
+
+    fn into_ptr(r: Self::Handle) -> std::ptr::NonNull<Self> {
+        r
+    }
+
+    unsafe fn from_ptr(ptr: std::ptr::NonNull<Self>) -> Self::Handle {
+        ptr
+    }
+
+    unsafe fn links(target: NonNull<Self>) -> NonNull<Links<SocketHeaderTopicIn>> {
+        // Safety: using `ptr::addr_of!` avoids creating a temporary
+        // reference, which stacked borrows dislikes.
+        let node = unsafe { ptr::addr_of_mut!((*target.as_ptr()).links) };
+        unsafe { NonNull::new_unchecked(node) }
+    }
+}
+
+/// ## Safety
+/// Some.
+pub unsafe trait SocketHeader {
+    /// ## Safety
+    /// Some.
+    unsafe fn attach<R: ScopedRawMutex, M: InterfaceManager>(
+        this: NonNull<Self>,
+        stack: &'static NetStack<R, M>,
+    ) -> Option<u8>;
+
+    /// ## Safety
+    /// Some.
+    unsafe fn detach<R: ScopedRawMutex, M: InterfaceManager>(
+        this: NonNull<Self>,
+        stack: &'static NetStack<R, M>,
+    );
+}
+
+unsafe impl SocketHeader for SocketHeaderTopicIn {
+    #[inline(always)]
+    unsafe fn attach<R: ScopedRawMutex, M: InterfaceManager>(
+        this: NonNull<Self>,
+        stack: &'static NetStack<R, M>,
+    ) -> Option<u8> {
+        unsafe { stack.try_attach_socket_tpc_in(this) }
+    }
+
+    #[inline(always)]
+    unsafe fn detach<R: ScopedRawMutex, M: InterfaceManager>(
+        this: NonNull<Self>,
+        stack: &'static NetStack<R, M>,
+    ) {
+        unsafe {
+            stack.detach_socket_tpc_in(this);
+        }
+    }
+}
+
+unsafe impl SocketHeader for SocketHeaderEndpointReq {
+    #[inline(always)]
+    unsafe fn attach<R: ScopedRawMutex, M: InterfaceManager>(
+        this: NonNull<Self>,
+        stack: &'static NetStack<R, M>,
+    ) -> Option<u8> {
+        unsafe { stack.try_attach_socket_edpt_req(this) }
+    }
+
+    #[inline(always)]
+    unsafe fn detach<R: ScopedRawMutex, M: InterfaceManager>(
+        this: NonNull<Self>,
+        stack: &'static NetStack<R, M>,
+    ) {
+        unsafe {
+            stack.detach_socket_edpt_req(this);
+        }
+    }
+}
+
+unsafe impl SocketHeader for SocketHeaderEndpointResp {
+    #[inline(always)]
+    unsafe fn attach<R: ScopedRawMutex, M: InterfaceManager>(
+        this: NonNull<Self>,
+        stack: &'static NetStack<R, M>,
+    ) -> Option<u8> {
+        unsafe { stack.try_attach_socket_edpt_resp(this) }
+    }
+
+    #[inline(always)]
+    unsafe fn detach<R: ScopedRawMutex, M: InterfaceManager>(
+        this: NonNull<Self>,
+        stack: &'static NetStack<R, M>,
+    ) {
+        unsafe {
+            stack.detach_socket_edpt_resp(this);
+        }
     }
 }

--- a/crates/ergot/src/socket/mod.rs
+++ b/crates/ergot/src/socket/mod.rs
@@ -230,6 +230,10 @@ pub unsafe trait SocketHeader {
         this: NonNull<Self>,
         stack: &'static NetStack<R, M>,
     );
+
+    fn port(&self) -> u8;
+    fn key(&self) -> Key;
+    fn vtable(&self) -> &'static SocketVTable;
 }
 
 unsafe impl SocketHeader for SocketHeaderTopicIn {
@@ -249,6 +253,18 @@ unsafe impl SocketHeader for SocketHeaderTopicIn {
         unsafe {
             stack.detach_socket_tpc_in(this);
         }
+    }
+
+    fn port(&self) -> u8 {
+        self.port
+    }
+
+    fn key(&self) -> Key {
+        self.data.msg_key
+    }
+
+    fn vtable(&self) -> &'static SocketVTable {
+        self.vtable
     }
 }
 
@@ -270,6 +286,18 @@ unsafe impl SocketHeader for SocketHeaderEndpointReq {
             stack.detach_socket_edpt_req(this);
         }
     }
+
+    fn port(&self) -> u8 {
+        self.port
+    }
+
+    fn key(&self) -> Key {
+        self.data.req_key
+    }
+
+    fn vtable(&self) -> &'static SocketVTable {
+        self.vtable
+    }
 }
 
 unsafe impl SocketHeader for SocketHeaderEndpointResp {
@@ -289,5 +317,17 @@ unsafe impl SocketHeader for SocketHeaderEndpointResp {
         unsafe {
             stack.detach_socket_edpt_resp(this);
         }
+    }
+
+    fn port(&self) -> u8 {
+        self.port
+    }
+
+    fn key(&self) -> Key {
+        self.data.resp_key
+    }
+
+    fn vtable(&self) -> &'static SocketVTable {
+        self.vtable
     }
 }

--- a/crates/ergot/src/socket/std_bounded.rs
+++ b/crates/ergot/src/socket/std_bounded.rs
@@ -15,42 +15,48 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{HeaderSeq, NetStack, interface_manager::InterfaceManager};
 
-use super::{OwnedMessage, SocketHeader, SocketSendError, SocketTy, SocketVTable};
+use super::{
+    EndpointData, OwnedMessage, SocketHeader, SocketHeaderEndpointReq, SocketHeaderEndpointResp,
+    SocketHeaderTopicIn, SocketSendError, SocketVTable, TopicData,
+};
 
 // Owned Socket
 #[repr(C)]
-pub struct StdBoundedSocket<T, R, M>
+pub struct StdBoundedSocket<H, T, R, M>
 where
+    H: SocketHeader,
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
     // LOAD BEARING: must be first
-    hdr: SocketHeader,
+    hdr: H,
     net: &'static NetStack<R, M>,
     // TODO: just a single item, we probably want a more ring-buffery
     // option for this.
     inner: UnsafeCell<BoundedQueue<T>>,
 }
 
-pub struct StdBoundedSocketHdl<'a, T, R, M>
+pub struct StdBoundedSocketHdl<'a, H, T, R, M>
 where
+    H: SocketHeader,
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
-    pub(crate) ptr: NonNull<StdBoundedSocket<T, R, M>>,
-    _lt: PhantomData<Pin<&'a mut StdBoundedSocket<T, R, M>>>,
+    pub(crate) ptr: NonNull<StdBoundedSocket<H, T, R, M>>,
+    _lt: PhantomData<Pin<&'a mut StdBoundedSocket<H, T, R, M>>>,
     port: u8,
 }
 
-pub struct Recv<'a, 'b, T, R, M>
+pub struct Recv<'a, 'b, H, T, R, M>
 where
+    H: SocketHeader,
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
-    hdl: &'a mut StdBoundedSocketHdl<'b, T, R, M>,
+    hdl: &'a mut StdBoundedSocketHdl<'b, H, T, R, M>,
 }
 
 struct BoundedQueue<T: 'static> {
@@ -70,7 +76,7 @@ struct BoundedQueue<T: 'static> {
 
 // impl StdBoundedSocket
 
-impl<T, R, M> StdBoundedSocket<T, R, M>
+impl<T, R, M> StdBoundedSocket<SocketHeaderTopicIn, T, R, M>
 where
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
@@ -78,52 +84,74 @@ where
 {
     pub fn new_topic_in<U: Topic>(net: &'static NetStack<R, M>, bound: usize) -> Self {
         Self {
-            hdr: SocketHeader {
+            hdr: SocketHeaderTopicIn {
                 links: Links::new(),
                 vtable: const { &Self::vtable() },
                 port: 0,
-                kind: const { SocketTy::topic_in::<U>() },
+                data: const { &TopicData::for_topic::<U>() },
             },
             inner: UnsafeCell::new(BoundedQueue::new(bound)),
             net,
         }
     }
+}
 
+impl<T, R, M> StdBoundedSocket<SocketHeaderEndpointReq, T, R, M>
+where
+    T: Serialize + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
     pub fn new_endpoint_req<E: Endpoint>(net: &'static NetStack<R, M>, bound: usize) -> Self {
         Self {
-            hdr: SocketHeader {
+            hdr: SocketHeaderEndpointReq {
                 links: Links::new(),
                 vtable: const { &Self::vtable() },
                 port: 0,
-                kind: const { SocketTy::endpoint_req::<E>() },
+                data: const { &EndpointData::for_endpoint::<E>() },
             },
             inner: UnsafeCell::new(BoundedQueue::new(bound)),
             net,
         }
     }
+}
 
+impl<T, R, M> StdBoundedSocket<SocketHeaderEndpointResp, T, R, M>
+where
+    T: Serialize + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
     pub fn new_endpoint_resp<E: Endpoint>(net: &'static NetStack<R, M>, bound: usize) -> Self {
         Self {
-            hdr: SocketHeader {
+            hdr: SocketHeaderEndpointResp {
                 links: Links::new(),
                 vtable: const { &Self::vtable() },
                 port: 0,
-                kind: const { SocketTy::endpoint_resp::<E>() },
+                data: const { &EndpointData::for_endpoint::<E>() },
             },
             inner: UnsafeCell::new(BoundedQueue::new(bound)),
             net,
         }
     }
+}
 
+impl<H, T, R, M> StdBoundedSocket<H, T, R, M>
+where
+    H: SocketHeader,
+    T: Serialize + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
     pub fn stack(&self) -> &'static NetStack<R, M> {
         self.net
     }
 
-    pub fn attach<'a>(self: Pin<&'a mut Self>) -> StdBoundedSocketHdl<'a, T, R, M> {
+    pub fn attach<'a>(self: Pin<&'a mut Self>) -> StdBoundedSocketHdl<'a, H, T, R, M> {
         let stack = self.net;
         let ptr_self: NonNull<Self> = NonNull::from(unsafe { self.get_unchecked_mut() });
-        let ptr_erase: NonNull<SocketHeader> = ptr_self.cast();
-        let port = unsafe { stack.attach_socket(ptr_erase) };
+        let ptr_erase: NonNull<H> = ptr_self.cast();
+        let port = unsafe { H::attach(ptr_erase, stack).unwrap() };
         StdBoundedSocketHdl {
             ptr: ptr_self,
             _lt: PhantomData,
@@ -207,8 +235,9 @@ where
 // impl StdBoundedSocketHdl
 
 // TODO: impl drop, remove waker, remove socket
-impl<'a, T, R, M> StdBoundedSocketHdl<'a, T, R, M>
+impl<'a, H, T, R, M> StdBoundedSocketHdl<'a, H, T, R, M>
 where
+    H: SocketHeader,
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
@@ -224,13 +253,14 @@ where
     // TODO: This future is !Send? I don't fully understand why, but rustc complains
     // that since `NonNull<StdBoundedSocket<E>>` is !Sync, then this future can't be Send,
     // BUT impl'ing Sync unsafely on StdBoundedSocketHdl + StdBoundedSocket doesn't seem to help.
-    pub fn recv<'b>(&'b mut self) -> Recv<'b, 'a, T, R, M> {
+    pub fn recv<'b>(&'b mut self) -> Recv<'b, 'a, H, T, R, M> {
         Recv { hdl: self }
     }
 }
 
-impl<T, R, M> Drop for StdBoundedSocket<T, R, M>
+impl<H, T, R, M> Drop for StdBoundedSocket<H, T, R, M>
 where
+    H: SocketHeader,
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
@@ -238,14 +268,16 @@ where
     fn drop(&mut self) {
         println!("Dropping StdBoundedSocket!");
         unsafe {
+            let net = self.net;
             let this = NonNull::from(&self.hdr);
-            self.net.detach_socket(this);
+            H::detach(this, net);
         }
     }
 }
 
-unsafe impl<T, R, M> Send for StdBoundedSocketHdl<'_, T, R, M>
+unsafe impl<H, T, R, M> Send for StdBoundedSocketHdl<'_, H, T, R, M>
 where
+    H: SocketHeader,
     T: Send,
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
@@ -253,8 +285,9 @@ where
 {
 }
 
-unsafe impl<T, R, M> Sync for StdBoundedSocketHdl<'_, T, R, M>
+unsafe impl<H, T, R, M> Sync for StdBoundedSocketHdl<'_, H, T, R, M>
 where
+    H: SocketHeader,
     T: Send,
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
@@ -264,8 +297,9 @@ where
 
 // impl Recv
 
-impl<T, R, M> Future for Recv<'_, '_, T, R, M>
+impl<H, T, R, M> Future for Recv<'_, '_, H, T, R, M>
 where
+    H: SocketHeader,
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
@@ -275,7 +309,7 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let net = self.hdl.stack();
         let f = || {
-            let this_ref: &StdBoundedSocket<T, R, M> = unsafe { self.hdl.ptr.as_ref() };
+            let this_ref: &StdBoundedSocket<H, T, R, M> = unsafe { self.hdl.ptr.as_ref() };
             let box_ref: &mut BoundedQueue<T> = unsafe { &mut *this_ref.inner.get() };
             if let Some(t) = box_ref.queue.pop_front() {
                 Some(t)
@@ -301,8 +335,9 @@ where
     }
 }
 
-unsafe impl<T, R, M> Sync for Recv<'_, '_, T, R, M>
+unsafe impl<H, T, R, M> Sync for Recv<'_, '_, H, T, R, M>
 where
+    H: SocketHeader,
     T: Send,
     T: Serialize + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,


### PR DESCRIPTION
This change splits the sockets into three distinct kinds.

This ended up being a bit messier (with generics) than I had hoped. The goal of this is to allow different behaviors for different kinds of sockets, as well as spending less time iterating over "wrong" sockets when processing incoming messages, which is a fairly hot part of the system.