### PR TITLE
Serialize Means Clone

### DIFF
--- a/crates/ergot-base/src/socket/mod.rs
+++ b/crates/ergot-base/src/socket/mod.rs
@@ -101,7 +101,7 @@ pub struct OwnedMessage<T: 'static> {
 
 // TODO: replace with header and handle kind and stuff right!
 
-// Morally: &mut ManuallyDrop<T>, TypeOf<T>, src, dst
+// Morally: &T, TypeOf<T>, src, dst
 // If return OK: the type has been moved OUT of the source
 // May serialize, or may be just moved.
 pub type SendOwned = fn(

--- a/crates/ergot-base/src/socket/owned.rs
+++ b/crates/ergot-base/src/socket/owned.rs
@@ -19,7 +19,7 @@ use super::{OwnedMessage, SocketHeader, SocketSendError, SocketVTable};
 #[repr(C)]
 pub struct OwnedSocket<T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -33,7 +33,7 @@ where
 
 pub struct OwnedSocketHdl<'a, T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -44,7 +44,7 @@ where
 
 pub struct Recv<'a, 'b, T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -66,7 +66,7 @@ struct OneBox<T: 'static> {
 
 impl<T, R, M> OwnedSocket<T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -178,7 +178,7 @@ where
 // TODO: impl drop, remove waker, remove socket
 impl<'a, T, R, M> OwnedSocketHdl<'a, T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -200,7 +200,7 @@ where
 
 impl<T, R, M> Drop for OwnedSocket<T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -216,7 +216,7 @@ where
 unsafe impl<T, R, M> Send for OwnedSocketHdl<'_, T, R, M>
 where
     T: Send,
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -225,7 +225,7 @@ where
 unsafe impl<T, R, M> Sync for OwnedSocketHdl<'_, T, R, M>
 where
     T: Send,
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -235,7 +235,7 @@ where
 
 impl<T, R, M> Future for Recv<'_, '_, T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -273,7 +273,7 @@ where
 unsafe impl<T, R, M> Sync for Recv<'_, '_, T, R, M>
 where
     T: Send,
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {

--- a/crates/ergot-base/src/socket/owned.rs
+++ b/crates/ergot-base/src/socket/owned.rs
@@ -123,6 +123,7 @@ where
             return Err(SocketSendError::TypeMismatch);
         }
         let that: NonNull<T> = that.cast();
+        let that: &T = unsafe { that.as_ref() };
         let this: NonNull<Self> = this.cast();
         let this: &Self = unsafe { this.as_ref() };
         let mutitem: &mut OneBox<T> = unsafe { &mut *this.inner.get() };
@@ -133,7 +134,7 @@ where
 
         mutitem.t = Some(OwnedMessage {
             hdr,
-            t: unsafe { that.read() },
+            t: that.clone(),
         });
         if let Some(w) = mutitem.wait.take() {
             w.wake();

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -5,8 +5,8 @@ pub use ergot_base;
 pub use ergot_base::Address;
 pub use ergot_base::interface_manager;
 
+pub mod net_stack;
 pub mod socket;
 pub mod well_known;
-pub mod net_stack;
 
 pub use net_stack::NetStack;

--- a/crates/ergot/src/net_stack.rs
+++ b/crates/ergot/src/net_stack.rs
@@ -191,12 +191,12 @@ where
     pub async fn req_resp<E>(
         &'static self,
         dst: Address,
-        req: E::Request,
+        req: &E::Request,
     ) -> Result<E::Response, NetStackSendError>
     where
         E: Endpoint,
-        E::Request: Serialize + DeserializeOwned + 'static,
-        E::Response: Serialize + DeserializeOwned + 'static,
+        E::Request: Serialize + Clone + DeserializeOwned + 'static,
+        E::Response: Serialize + Clone + DeserializeOwned + 'static,
     {
         let resp_sock = crate::socket::owned::OwnedSocket::new_endpoint_resp::<E>(self);
         let resp_sock = pin!(resp_sock);
@@ -241,10 +241,10 @@ where
     /// [`Endpoint::RESP_KEY`], or [`Topic::TOPIC_KEY`].
     ///
     /// [`Topic::TOPIC_KEY`]: postcard_rpc::Topic::TOPIC_KEY
-    pub fn send_ty<T: 'static + Serialize>(
+    pub fn send_ty<T: 'static + Serialize + Clone>(
         &'static self,
         hdr: Header,
-        t: T,
+        t: &T,
     ) -> Result<(), NetStackSendError> {
         self.inner.send_ty(hdr, t)
     }

--- a/crates/ergot/src/socket/owned.rs
+++ b/crates/ergot/src/socket/owned.rs
@@ -12,7 +12,7 @@ use serde::{Serialize, de::DeserializeOwned};
 #[pin_project]
 pub struct OwnedSocket<T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -22,7 +22,7 @@ where
 
 pub struct OwnedSocketHdl<'a, T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -35,13 +35,11 @@ where
 
 impl<T, R, M> OwnedSocket<T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
-    pub const fn new_topic_in<U: Topic<Message = T>>(
-        net: &'static crate::NetStack<R, M>,
-    ) -> Self {
+    pub const fn new_topic_in<U: Topic<Message = T>>(net: &'static crate::NetStack<R, M>) -> Self {
         Self {
             inner: base::socket::owned::OwnedSocket::new(
                 &net.inner,
@@ -78,7 +76,7 @@ where
 
 impl<T, R, M> OwnedSocket<T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -94,7 +92,7 @@ where
 
 impl<'a, T, R, M> OwnedSocketHdl<'a, T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {

--- a/crates/ergot/src/socket/std_bounded.rs
+++ b/crates/ergot/src/socket/std_bounded.rs
@@ -13,7 +13,7 @@ use crate::interface_manager::InterfaceManager;
 #[pin_project]
 pub struct StdBoundedSocket<T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -23,7 +23,7 @@ where
 
 pub struct StdBoundedSocketHdl<'a, T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -36,7 +36,7 @@ where
 
 impl<T, R, M> StdBoundedSocket<T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {
@@ -99,7 +99,7 @@ where
 
 impl<'a, T, R, M> StdBoundedSocketHdl<'a, T, R, M>
 where
-    T: Serialize + DeserializeOwned + 'static,
+    T: Serialize + Clone + DeserializeOwned + 'static,
     R: ScopedRawMutex + 'static,
     M: InterfaceManager + 'static,
 {

--- a/crates/ergot/tests/smoke.rs
+++ b/crates/ergot/tests/smoke.rs
@@ -2,7 +2,8 @@ use std::{pin::pin, time::Duration};
 
 use ergot::{
     NetStack,
-    ergot_base::{Address, FrameKind, Header}, interface_manager::null::NullInterfaceManager,
+    ergot_base::{Address, FrameKind, Header},
+    interface_manager::null::NullInterfaceManager,
     socket::endpoint::OwnedEndpointSocket,
 };
 use ergot_base::Key;
@@ -10,7 +11,10 @@ use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use postcard_rpc::{Endpoint, endpoint};
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
-use tokio::{spawn, time::{sleep, timeout}};
+use tokio::{
+    spawn,
+    time::{sleep, timeout},
+};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Schema)]
 pub struct Example {
@@ -200,12 +204,14 @@ async fn req_resp() {
 
     // normally you'd do this in a loop...
     for _i in 0..3 {
-        let srv = timeout(Duration::from_secs(1), server_hdl
-            .serve(async |req| {
+        let srv = timeout(
+            Duration::from_secs(1),
+            server_hdl.serve(async |req| {
                 // fn(Example) -> u32
                 req.b + 5
-            }))
-            .await;
+            }),
+        )
+        .await;
         println!("SERV: {srv:?}");
     }
 

--- a/demos/ergot-router/src/main.rs
+++ b/demos/ergot-router/src/main.rs
@@ -49,7 +49,7 @@ async fn ping_all() {
                         node_id: 2,
                         port_id: 0,
                     },
-                    pg,
+                    &pg,
                 );
             let fut = timeout(Duration::from_millis(100), rr);
             let res = fut.await;


### PR DESCRIPTION
If a type is serializable, then it must also be clone.

This change makes this part of the signature, and also removes the need to send message by value.