### PR TITLE
Implement broadcast topics, add `log` crate support

### DIFF
--- a/crates/ergot-base/Cargo.lock
+++ b/crates/ergot-base/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "cobs 0.3.0",
  "cordyceps",
  "critical-section",
+ "log",
  "maitake-sync",
  "mutex",
  "postcard",

--- a/crates/ergot-base/Cargo.toml
+++ b/crates/ergot-base/Cargo.toml
@@ -19,6 +19,7 @@ cobs                = "0.3.0"
 cordyceps           = "0.3.4"
 
 critical-section    = { version = "1.2.0",  features = ["std"] }
+log = "0.4.27"
 maitake-sync        = { version = "0.2.1",  features = ["std"] }
 mutex               = { version = "1.0.0",  features = ["std", "impl-critical-section"] }
 postcard            = { version = "1.1.1",  features = ["use-std"] }

--- a/crates/ergot-base/src/interface_manager/mod.rs
+++ b/crates/ergot-base/src/interface_manager/mod.rs
@@ -76,7 +76,7 @@ pub trait ConstInit {
 // to this is "send raw", where serialization has already been done, e.g.
 // if we are routing a packet.
 pub trait InterfaceManager {
-    fn send<T: Serialize>(&mut self, hdr: Header, data: &T) -> Result<(), InterfaceSendError>;
+    fn send<T: Serialize>(&mut self, hdr: &Header, data: &T) -> Result<(), InterfaceSendError>;
 
-    fn send_raw(&mut self, hdr: Header, data: &[u8]) -> Result<(), InterfaceSendError>;
+    fn send_raw(&mut self, hdr: &Header, data: &[u8]) -> Result<(), InterfaceSendError>;
 }

--- a/crates/ergot-base/src/interface_manager/null.rs
+++ b/crates/ergot-base/src/interface_manager/null.rs
@@ -13,7 +13,7 @@ impl ConstInit for NullInterfaceManager {
 }
 
 impl InterfaceManager for NullInterfaceManager {
-    fn send<T: Serialize>(&mut self, hdr: Header, _data: &T) -> Result<(), InterfaceSendError> {
+    fn send<T: Serialize>(&mut self, hdr: &Header, _data: &T) -> Result<(), InterfaceSendError> {
         if hdr.dst.net_node_any() {
             Err(InterfaceSendError::DestinationLocal)
         } else {
@@ -21,7 +21,7 @@ impl InterfaceManager for NullInterfaceManager {
         }
     }
 
-    fn send_raw(&mut self, hdr: Header, _data: &[u8]) -> Result<(), InterfaceSendError> {
+    fn send_raw(&mut self, hdr: &Header, _data: &[u8]) -> Result<(), InterfaceSendError> {
         if hdr.dst.net_node_any() {
             Err(InterfaceSendError::DestinationLocal)
         } else {

--- a/crates/ergot-base/src/interface_manager/std_tcp_client.rs
+++ b/crates/ergot-base/src/interface_manager/std_tcp_client.rs
@@ -82,10 +82,6 @@ impl InterfaceManager for StdTcpClientIm {
         hdr: &Header,
         data: &T,
     ) -> Result<(), InterfaceSendError> {
-        if hdr.dst.port_id == 255 {
-            todo!("Figure out sending broadcast messages");
-        }
-
         let Some(intfc) = self.inner.as_mut() else {
             return Err(InterfaceSendError::NoRouteToDest);
         };
@@ -117,6 +113,13 @@ impl InterfaceManager for StdTcpClientIm {
             // addresses
             hdr.src.network_id = intfc.net_id;
             hdr.src.node_id = 2;
+        }
+
+        // If this is a broadcast message, update the destination, ignoring
+        // whatever was there before
+        if hdr.dst.port_id == 255 {
+            hdr.dst.network_id = intfc.net_id;
+            hdr.dst.node_id = 1;
         }
 
         let seq_no = self.seq_no;
@@ -145,10 +148,6 @@ impl InterfaceManager for StdTcpClientIm {
     }
 
     fn send_raw(&mut self, hdr: &Header, data: &[u8]) -> Result<(), InterfaceSendError> {
-        if hdr.dst.port_id == 255 {
-            todo!("Figure out sending broadcast messages");
-        }
-
         let Some(intfc) = self.inner.as_mut() else {
             return Err(InterfaceSendError::NoRouteToDest);
         };
@@ -180,6 +179,13 @@ impl InterfaceManager for StdTcpClientIm {
             // addresses
             hdr.src.network_id = intfc.net_id;
             hdr.src.node_id = 2;
+        }
+
+        // If this is a broadcast message, update the destination, ignoring
+        // whatever was there before
+        if hdr.dst.port_id == 255 {
+            hdr.dst.network_id = intfc.net_id;
+            hdr.dst.node_id = 1;
         }
 
         let seq_no = self.seq_no;

--- a/crates/ergot-base/src/interface_manager/std_tcp_router.rs
+++ b/crates/ergot-base/src/interface_manager/std_tcp_router.rs
@@ -164,7 +164,7 @@ impl<R: ScopedRawMutex + 'static> StdTcpRecvHdl<R> {
                                 Ok(()) => {}
                                 Err(e) => {
                                     // TODO: match on error, potentially try to send NAK?
-                                    panic!("recv->send error: {e:?}");
+                                    warn!("recv->send error: {e:?}");
                                 }
                             }
                         } else {

--- a/crates/ergot-base/src/interface_manager/std_tcp_router.rs
+++ b/crates/ergot-base/src/interface_manager/std_tcp_router.rs
@@ -21,6 +21,7 @@ use std::{cell::UnsafeCell, mem::MaybeUninit};
 
 use crate::{Header, NetStack, interface_manager::std_utils::ser_frame};
 
+use log::{debug, error, info, trace, warn};
 use maitake_sync::WaitQueue;
 use mutex::ScopedRawMutex;
 use tokio::sync::mpsc::Sender;
@@ -113,7 +114,7 @@ impl<R: ScopedRawMutex + 'static> StdTcpRecvHdl<R> {
                 r = rd => {
                     match r {
                         Ok(0) | Err(_) => {
-                            println!("recv run {} closed", self.net_id);
+                            warn!("recv run {} closed", self.net_id);
                             return Err(ReceiverError::SocketClosed)
                         },
                         Ok(ct) => ct,
@@ -167,7 +168,7 @@ impl<R: ScopedRawMutex + 'static> StdTcpRecvHdl<R> {
                                 }
                             }
                         } else {
-                            println!("Decode error! Ignoring frame on net_id {}", self.net_id);
+                            warn!("Decode error! Ignoring frame on net_id {}", self.net_id);
                         }
 
                         remaining
@@ -348,10 +349,10 @@ impl StdTcpImInner {
                 skt_tx: ctx,
                 closer: closer.clone(),
             });
-            println!("Alloc'd net_id 1");
+            debug!("Alloc'd net_id 1");
             return Some((net_id, closer));
         } else if self.interfaces.len() >= 65534 {
-            println!("Out of netids!");
+            warn!("Out of netids!");
             return None;
         }
 
@@ -360,7 +361,7 @@ impl StdTcpImInner {
             self.interfaces.retain(|int| {
                 let closed = int.closer.is_closed();
                 if closed {
-                    println!("Collecting interface {}", int.net_id);
+                    info!("Collecting interface {}", int.net_id);
                 }
                 !closed
             });
@@ -371,7 +372,7 @@ impl StdTcpImInner {
         // indexes, and if we find a discontinuity, allocate the first one.
         for intfc in self.interfaces.iter() {
             if intfc.net_id > net_id {
-                println!("Found gap: {net_id}");
+                trace!("Found gap: {net_id}");
                 break;
             }
             debug_assert!(intfc.net_id == net_id);
@@ -382,7 +383,7 @@ impl StdTcpImInner {
         // have not exhausted the range.
         debug_assert!(net_id > 0 && net_id != u16::MAX);
         let (ctx, crx) = channel(64);
-        println!("allocated net_id {net_id}");
+        debug!("allocated net_id {net_id}");
 
         tokio::task::spawn(tx_worker(net_id, tx, crx, closer.clone()));
         self.interfaces.push(StdTcpTxHdl {
@@ -403,7 +404,7 @@ async fn tx_worker(
     mut rx: Receiver<OwnedFrame>,
     closer: Arc<WaitQueue>,
 ) {
-    println!("Started tx_worker for net_id {net_id}");
+    info!("Started tx_worker for net_id {net_id}");
     loop {
         let rxf = rx.recv();
         let clf = closer.wait();
@@ -413,7 +414,7 @@ async fn tx_worker(
                 if let Some(frame) = r {
                     frame
                 } else {
-                    println!("tx_worker {net_id} rx closed!");
+                    warn!("tx_worker {net_id} rx closed!");
                     closer.close();
                     break;
                 }
@@ -424,15 +425,15 @@ async fn tx_worker(
         };
 
         let msg = ser_frame(frame);
-        println!("sending pkt len:{} on net_id {net_id}", msg.len());
+        debug!("sending pkt len:{} on net_id {net_id}", msg.len());
         let res = tx.write_all(&msg).await;
         if let Err(e) = res {
-            println!("Err: {e:?}");
+            error!("Err: {e:?}");
             break;
         }
     }
     // TODO: GC waker?
-    println!("Closing interface {net_id}");
+    warn!("Closing interface {net_id}");
 }
 
 pub fn register_interface<R: ScopedRawMutex>(

--- a/crates/ergot-base/src/interface_manager/std_utils.rs
+++ b/crates/ergot-base/src/interface_manager/std_utils.rs
@@ -11,7 +11,7 @@ pub enum ReceiverError {
 }
 
 pub(crate) fn ser_frame(frame: OwnedFrame) -> Vec<u8> {
-    let dst_any = frame.hdr.dst.port_id == 0;
+    let dst_any = [0, 255].contains(&frame.hdr.dst.port_id);
     let src = frame.hdr.src.as_u32();
     let dst = frame.hdr.dst.as_u32();
     let seq = frame.hdr.seq_no;
@@ -44,7 +44,7 @@ pub(crate) fn de_frame(remain: &[u8]) -> Option<OwnedFrame> {
     let kind = FrameKind(*kind);
     let (ttl, remain) = remain.split_first()?;
     let ttl = *ttl;
-    let (key, remain) = if dst.port_id == 0 {
+    let (key, remain) = if [0, 255].contains(&dst.port_id) {
         if remain.len() < 8 {
             return None;
         }

--- a/crates/ergot-base/src/lib.rs
+++ b/crates/ergot-base/src/lib.rs
@@ -7,6 +7,7 @@ pub mod socket;
 
 pub use address::Address;
 use interface_manager::InterfaceSendError;
+use log::warn;
 pub use net_stack::{NetStack, NetStackSendError};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -80,7 +81,10 @@ impl Header {
         self.ttl = self
             .ttl
             .checked_sub(1)
-            .ok_or(InterfaceSendError::TtlExpired)?;
+            .ok_or_else(|| {
+                warn!("Header TTL expired: {self:?}");
+                InterfaceSendError::TtlExpired
+            })?;
         Ok(())
     }
 }

--- a/crates/ergot-base/src/lib.rs
+++ b/crates/ergot-base/src/lib.rs
@@ -78,13 +78,10 @@ impl Header {
 
     #[inline]
     pub fn decrement_ttl(&mut self) -> Result<(), InterfaceSendError> {
-        self.ttl = self
-            .ttl
-            .checked_sub(1)
-            .ok_or_else(|| {
-                warn!("Header TTL expired: {self:?}");
-                InterfaceSendError::TtlExpired
-            })?;
+        self.ttl = self.ttl.checked_sub(1).ok_or_else(|| {
+            warn!("Header TTL expired: {self:?}");
+            InterfaceSendError::TtlExpired
+        })?;
         Ok(())
     }
 }

--- a/crates/ergot-base/src/net_stack.rs
+++ b/crates/ergot-base/src/net_stack.rs
@@ -311,8 +311,8 @@ where
         match res {
             Ok(()) => {
                 debug!("Externally routed msg unicast");
-                return Ok(())
-            },
+                return Ok(());
+            }
             Err(InterfaceSendError::DestinationLocal) => {
                 debug!("No external interest in msg unicast");
             }

--- a/crates/ergot-base/src/net_stack.rs
+++ b/crates/ergot-base/src/net_stack.rs
@@ -251,7 +251,7 @@ where
             for dst in bcast_iter {
                 let res = sskt(dst);
                 if res {
-                    debug!("delivered broadcast message");
+                    debug!("delivered broadcast message locally");
                 }
                 any_found |= res;
             }
@@ -259,6 +259,9 @@ where
         };
 
         let res_rmt = smgr();
+        if res_rmt {
+            debug!("delivered broadcast message remotely");
+        }
 
         if res_lcl || res_rmt {
             Ok(())

--- a/crates/ergot-base/src/socket/owned.rs
+++ b/crates/ergot-base/src/socket/owned.rs
@@ -94,7 +94,18 @@ where
             _lt: PhantomData,
             port,
         }
-        // TODO: once-check?
+    }
+
+    pub fn attach_broadcast<'a>(self: Pin<&'a mut Self>) -> OwnedSocketHdl<'a, T, R, M> {
+        let stack = self.net;
+        let ptr_self: NonNull<Self> = NonNull::from(unsafe { self.get_unchecked_mut() });
+        let ptr_erase: NonNull<SocketHeader> = ptr_self.cast();
+        unsafe { stack.attach_broadcast_socket(ptr_erase) };
+        OwnedSocketHdl {
+            ptr: ptr_self,
+            _lt: PhantomData,
+            port: 255,
+        }
     }
 
     const fn vtable() -> SocketVTable {

--- a/crates/ergot-base/src/socket/std_bounded.rs
+++ b/crates/ergot-base/src/socket/std_bounded.rs
@@ -103,7 +103,18 @@ where
             _lt: PhantomData,
             port,
         }
-        // TODO: once-check?
+    }
+
+    pub fn attach_broadcast<'a>(self: Pin<&'a mut Self>) -> StdBoundedSocketHdl<'a, T, R, M> {
+        let stack = self.net;
+        let ptr_self: NonNull<Self> = NonNull::from(unsafe { self.get_unchecked_mut() });
+        let ptr_erase: NonNull<SocketHeader> = ptr_self.cast();
+        unsafe { stack.attach_broadcast_socket(ptr_erase) };
+        StdBoundedSocketHdl {
+            ptr: ptr_self,
+            _lt: PhantomData,
+            port: 255,
+        }
     }
 
     const fn vtable() -> SocketVTable {

--- a/crates/ergot-base/tests/smoke.rs
+++ b/crates/ergot-base/tests/smoke.rs
@@ -1,20 +1,19 @@
 use std::{pin::pin, time::Duration};
 
 use ergot_base::{
-    Address, FrameKind, Header, Key, NetStack, interface_manager::null::NullInterfaceManager,
-    socket::owned::OwnedSocket,
+    interface_manager::null::NullInterfaceManager, socket::owned::OwnedSocket, Address, FrameKind, Header, Key, NetStack, DEFAULT_TTL
 };
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use serde::{Deserialize, Serialize};
 use tokio::{spawn, time::sleep};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Example {
     a: u8,
     b: u32,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Other {
     a: u64,
     b: i32,
@@ -48,27 +47,29 @@ async fn hello() {
             // try sending, should fail
             STACK
                 .send_ty::<Other>(
-                    Header {
+                    &Header {
                         src,
                         dst,
                         key: Some(Key(*b"1234TEST")),
                         seq_no: None,
                         kind: FrameKind::ENDPOINT_REQ,
+                        ttl: DEFAULT_TTL,
                     },
-                    Other { a: 345, b: -123 },
+                    &Other { a: 345, b: -123 },
                 )
                 .unwrap_err();
             // typed sending works
             STACK
                 .send_ty::<Example>(
-                    Header {
+                    &Header {
                         src,
                         dst,
                         key: Some(Key(*b"TEST1234")),
                         seq_no: None,
                         kind: FrameKind::ENDPOINT_REQ,
+                        ttl: DEFAULT_TTL,
                     },
-                    Example { a: 42, b: 789 },
+                    &Example { a: 42, b: 789 },
                 )
                 .unwrap();
             // raw sending works
@@ -78,12 +79,13 @@ async fn hello() {
             let body = postcard::to_stdvec(&Example { a: 56, b: 1234 }).unwrap();
             STACK
                 .send_raw(
-                    Header {
+                    &Header {
                         src,
                         dst,
                         key: Some(Key(*b"TEST1234")),
                         seq_no: None,
                         kind: FrameKind::ENDPOINT_REQ,
+                        ttl: DEFAULT_TTL,
                     },
                     &body,
                 )
@@ -135,26 +137,28 @@ async fn hello() {
     // Both sends should fail.
     STACK
         .send_ty::<Other>(
-            Header {
+            &Header {
                 src,
                 dst,
                 key: Some(Key(*b"1234TEST")),
                 seq_no: None,
                 kind: FrameKind::ENDPOINT_REQ,
+                ttl: DEFAULT_TTL,
             },
-            Other { a: 345, b: -123 },
+            &Other { a: 345, b: -123 },
         )
         .unwrap_err();
     STACK
         .send_ty::<Example>(
-            Header {
+            &Header {
                 src,
                 dst,
                 key: Some(Key(*b"TEST1234")),
                 seq_no: None,
                 kind: FrameKind::ENDPOINT_REQ,
+                ttl: DEFAULT_TTL,
             },
-            Example { a: 42, b: 789 },
+            &Example { a: 42, b: 789 },
         )
         .unwrap_err();
 }

--- a/crates/ergot-base/tests/smoke.rs
+++ b/crates/ergot-base/tests/smoke.rs
@@ -1,7 +1,8 @@
 use std::{pin::pin, time::Duration};
 
 use ergot_base::{
-    interface_manager::null::NullInterfaceManager, socket::owned::OwnedSocket, Address, FrameKind, Header, Key, NetStack, DEFAULT_TTL
+    Address, DEFAULT_TTL, FrameKind, Header, Key, NetStack,
+    interface_manager::null::NullInterfaceManager, socket::owned::OwnedSocket,
 };
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use serde::{Deserialize, Serialize};

--- a/crates/ergot/Cargo.lock
+++ b/crates/ergot/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "cobs 0.3.0",
  "cordyceps",
  "critical-section",
+ "log",
  "maitake-sync",
  "mutex",
  "postcard",

--- a/crates/ergot/src/net_stack.rs
+++ b/crates/ergot/src/net_stack.rs
@@ -229,8 +229,16 @@ where
         T::Message: Serialize + Clone + DeserializeOwned + 'static,
     {
         let hdr = Header {
-            src: Address { network_id: 0, node_id: 0, port_id: 0 },
-            dst: Address { network_id: 0, node_id: 0, port_id: 255 },
+            src: Address {
+                network_id: 0,
+                node_id: 0,
+                port_id: 0,
+            },
+            dst: Address {
+                network_id: 0,
+                node_id: 0,
+                port_id: 255,
+            },
             key: Some(base::Key(T::TOPIC_KEY.to_bytes())),
             seq_no: None,
             kind: FrameKind::TOPIC_MSG,

--- a/crates/ergot/src/net_stack.rs
+++ b/crates/ergot/src/net_stack.rs
@@ -213,7 +213,7 @@ where
             kind: FrameKind::ENDPOINT_REQ,
             ttl: base::DEFAULT_TTL,
         };
-        self.send_ty(hdr, req)?;
+        self.send_ty(&hdr, req)?;
         // TODO: assert seq nos match somewhere? do we NEED seq nos if we have
         // port ids now?
         let resp = resp_hdl.recv().await;
@@ -225,7 +225,7 @@ where
     /// This interface should almost never be used by end-users, and is instead
     /// typically used by interfaces to feed received messages into the
     /// [`NetStack`].
-    pub fn send_raw(&'static self, hdr: Header, body: &[u8]) -> Result<(), NetStackSendError> {
+    pub fn send_raw(&'static self, hdr: &Header, body: &[u8]) -> Result<(), NetStackSendError> {
         self.inner.send_raw(hdr, body)
     }
 
@@ -243,7 +243,7 @@ where
     /// [`Topic::TOPIC_KEY`]: postcard_rpc::Topic::TOPIC_KEY
     pub fn send_ty<T: 'static + Serialize + Clone>(
         &'static self,
-        hdr: Header,
+        hdr: &Header,
         t: &T,
     ) -> Result<(), NetStackSendError> {
         self.inner.send_ty(hdr, t)

--- a/crates/ergot/src/socket/endpoint.rs
+++ b/crates/ergot/src/socket/endpoint.rs
@@ -86,7 +86,7 @@ where
             kind: base::FrameKind::ENDPOINT_RESP,
             ttl: base::DEFAULT_TTL,
         };
-        self.hdl.stack().send_ty::<E::Response>(hdr, &resp)
+        self.hdl.stack().send_ty::<E::Response>(&hdr, &resp)
     }
 }
 
@@ -165,6 +165,6 @@ where
             kind: base::FrameKind::ENDPOINT_RESP,
             ttl: base::DEFAULT_TTL,
         };
-        self.hdl.stack().send_ty::<E::Response>(hdr, &resp)
+        self.hdl.stack().send_ty::<E::Response>(&hdr, &resp)
     }
 }

--- a/crates/ergot/src/socket/mod.rs
+++ b/crates/ergot/src/socket/mod.rs
@@ -56,3 +56,4 @@
 pub mod endpoint;
 pub mod owned;
 pub mod std_bounded;
+pub mod topic;

--- a/crates/ergot/src/socket/owned.rs
+++ b/crates/ergot/src/socket/owned.rs
@@ -86,6 +86,13 @@ where
             inner: this.inner.attach(),
         }
     }
+
+    pub fn attach_broadcast<'a>(self: Pin<&'a mut Self>) -> OwnedSocketHdl<'a, T, R, M> {
+        let this = self.project();
+        OwnedSocketHdl {
+            inner: this.inner.attach_broadcast(),
+        }
+    }
 }
 
 // impl OwnedSocketHdl

--- a/crates/ergot/src/socket/std_bounded.rs
+++ b/crates/ergot/src/socket/std_bounded.rs
@@ -93,6 +93,14 @@ where
         }
         // TODO: once-check?
     }
+
+    pub fn attach_broadcast<'a>(self: Pin<&'a mut Self>) -> StdBoundedSocketHdl<'a, T, R, M> {
+        let this = self.project();
+        StdBoundedSocketHdl {
+            inner: this.inner.attach_broadcast(),
+        }
+        // TODO: once-check?
+    }
 }
 
 // impl StdBoundedSocketHdl

--- a/crates/ergot/src/socket/topic.rs
+++ b/crates/ergot/src/socket/topic.rs
@@ -1,0 +1,125 @@
+use std::pin::{Pin, pin};
+
+use crate::interface_manager::InterfaceManager;
+use mutex::ScopedRawMutex;
+use pin_project::pin_project;
+use postcard_rpc::Topic;
+use serde::{Serialize, de::DeserializeOwned};
+
+use ergot_base as base;
+
+use super::{
+    owned::{OwnedSocket, OwnedSocketHdl},
+    std_bounded::{StdBoundedSocket, StdBoundedSocketHdl},
+};
+
+#[pin_project]
+pub struct OwnedTopicSocket<T, R, M>
+where
+    T: Topic,
+    T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
+    #[pin]
+    sock: OwnedSocket<T::Message, R, M>,
+}
+
+impl<T, R, M> OwnedTopicSocket<T, R, M>
+where
+    T: Topic,
+    T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
+    pub const fn new(net: &'static crate::NetStack<R, M>) -> Self {
+        Self {
+            sock: OwnedSocket::new_topic_in::<T>(net),
+        }
+    }
+
+    pub fn subscribe<'a>(self: Pin<&'a mut Self>) -> OwnedTopicSocketHdl<'a, T, R, M> {
+        let this = self.project();
+        let hdl: OwnedSocketHdl<'_, T::Message, R, M> = this.sock.attach_broadcast();
+        OwnedTopicSocketHdl { hdl }
+    }
+}
+
+pub struct OwnedTopicSocketHdl<'a, T, R, M>
+where
+    T: Topic,
+    T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
+    hdl: OwnedSocketHdl<'a, T::Message, R, M>,
+}
+
+impl<T, R, M> OwnedTopicSocketHdl<'_, T, R, M>
+where
+    T: Topic,
+    T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
+    pub async fn recv(&mut self) -> base::socket::OwnedMessage<T::Message> {
+        self.hdl.recv().await
+    }
+}
+
+// ---
+// TODO: Do we need some kind of Socket trait we can use to dedupe things like this?
+
+#[pin_project]
+pub struct StdBoundedTopicSocket<T, R, M>
+where
+    T: Topic,
+    T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
+    #[pin]
+    sock: StdBoundedSocket<T::Message, R, M>,
+}
+
+impl<T, R, M> StdBoundedTopicSocket<T, R, M>
+where
+    T: Topic,
+    T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
+    pub fn new(stack: &'static base::net_stack::NetStack<R, M>, bound: usize) -> Self {
+        Self {
+            sock: StdBoundedSocket::new_topic_in::<T>(stack, bound),
+        }
+    }
+
+    pub fn subscribe<'a>(self: Pin<&'a mut Self>) -> StdBoundedTopicSocketHdl<'a, T, R, M> {
+        let this = self.project();
+        let hdl: StdBoundedSocketHdl<'_, T::Message, R, M> = this.sock.attach_broadcast();
+        StdBoundedTopicSocketHdl { hdl }
+    }
+}
+
+pub struct StdBoundedTopicSocketHdl<'a, T, R, M>
+where
+    T: Topic,
+    T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
+    hdl: StdBoundedSocketHdl<'a, T::Message, R, M>,
+}
+
+impl<T, R, M> StdBoundedTopicSocketHdl<'_, T, R, M>
+where
+    T: Topic,
+    T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    R: ScopedRawMutex + 'static,
+    M: InterfaceManager + 'static,
+{
+    pub async fn recv(&mut self) -> base::socket::OwnedMessage<T::Message> {
+        self.hdl.recv().await
+    }
+}

--- a/crates/ergot/tests/smoke.rs
+++ b/crates/ergot/tests/smoke.rs
@@ -16,13 +16,13 @@ use tokio::{
     time::{sleep, timeout},
 };
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Schema)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Schema, Clone)]
 pub struct Example {
     a: u8,
     b: u32,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Schema)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Schema, Clone)]
 pub struct Other {
     a: u64,
     b: i32,
@@ -58,27 +58,29 @@ async fn hello() {
             // try sending, should fail
             STACK
                 .send_ty::<Other>(
-                    Header {
+                    &Header {
                         src,
                         dst,
                         key: Some(Key(OtherEndpoint::REQ_KEY.to_bytes())),
                         seq_no: None,
                         kind: FrameKind::ENDPOINT_REQ,
+                        ttl: ergot_base::DEFAULT_TTL,
                     },
-                    Other { a: 345, b: -123 },
+                    &Other { a: 345, b: -123 },
                 )
                 .unwrap_err();
             // typed sending works
             STACK
                 .send_ty::<Example>(
-                    Header {
+                    &Header {
                         src,
                         dst,
                         key: Some(Key(ExampleEndpoint::REQ_KEY.to_bytes())),
                         seq_no: None,
                         kind: FrameKind::ENDPOINT_REQ,
+                        ttl: ergot_base::DEFAULT_TTL,
                     },
-                    Example { a: 42, b: 789 },
+                    &Example { a: 42, b: 789 },
                 )
                 .unwrap();
             // raw sending works
@@ -88,12 +90,13 @@ async fn hello() {
             let body = postcard::to_stdvec(&Example { a: 56, b: 1234 }).unwrap();
             STACK
                 .send_raw(
-                    Header {
+                    &Header {
                         src,
                         dst,
                         key: Some(Key(ExampleEndpoint::REQ_KEY.to_bytes())),
                         seq_no: None,
                         kind: FrameKind::ENDPOINT_REQ,
+                        ttl: ergot_base::DEFAULT_TTL,
                     },
                     &body,
                 )
@@ -145,26 +148,28 @@ async fn hello() {
     // Both sends should fail.
     STACK
         .send_ty::<Other>(
-            Header {
+            &Header {
                 src,
                 dst,
                 key: Some(Key(OtherEndpoint::REQ_KEY.to_bytes())),
                 seq_no: None,
                 kind: FrameKind::ENDPOINT_REQ,
+                ttl: ergot_base::DEFAULT_TTL,
             },
-            Other { a: 345, b: -123 },
+            &Other { a: 345, b: -123 },
         )
         .unwrap_err();
     STACK
         .send_ty::<Example>(
-            Header {
+            &Header {
                 src,
                 dst,
                 key: Some(Key(ExampleEndpoint::REQ_KEY.to_bytes())),
                 seq_no: None,
                 kind: FrameKind::ENDPOINT_REQ,
+                ttl: ergot_base::DEFAULT_TTL,
             },
-            Example { a: 42, b: 789 },
+            &Example { a: 42, b: 789 },
         )
         .unwrap_err();
 }
@@ -190,7 +195,7 @@ async fn req_resp() {
                         node_id: 0,
                         port_id: 0,
                     },
-                    Example {
+                    &Example {
                         a: i as u8,
                         b: i * 10,
                     },

--- a/demos/ergot-client/Cargo.lock
+++ b/demos/ergot-client/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "const-fnv1a-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +199,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "ergot"
 version = "0.1.0"
 dependencies = [
@@ -167,6 +246,7 @@ dependencies = [
  "cobs 0.3.0",
  "cordyceps",
  "critical-section",
+ "log",
  "maitake-sync",
  "mutex",
  "postcard",
@@ -183,7 +263,9 @@ dependencies = [
  "const-fnv1a-hash",
  "cordyceps",
  "critical-section",
+ "env_logger",
  "ergot",
+ "log",
  "maitake-sync",
  "mutex",
  "pin-project",
@@ -254,6 +336,36 @@ checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -344,7 +456,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -395,6 +507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +549,15 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -628,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -700,7 +827,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -780,6 +907,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -922,6 +1055,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/demos/ergot-client/Cargo.toml
+++ b/demos/ergot-client/Cargo.toml
@@ -19,6 +19,8 @@ serde = { version = "1.0", features = ["derive"] }
 postcard-rpc = "0.11.9"
 postcard-schema = { version = "0.2.1", features = ["derive"] }
 cobs = { version = "0.3.0", features = ["use_std"] }
+log = "0.4.27"
+env_logger = "0.11.8"
 
 
 [dependencies.ergot]

--- a/demos/ergot-client/src/main.rs
+++ b/demos/ergot-client/src/main.rs
@@ -1,5 +1,8 @@
 use ergot::{
-    interface_manager::std_tcp_client::{register_interface, StdTcpClientIm}, socket::{endpoint::StdBoundedEndpointSocket, topic::StdBoundedTopicSocket}, well_known::ErgotPingEndpoint, NetStack
+    NetStack,
+    interface_manager::std_tcp_client::{StdTcpClientIm, register_interface},
+    socket::{endpoint::StdBoundedEndpointSocket, topic::StdBoundedTopicSocket},
+    well_known::ErgotPingEndpoint,
 };
 use log::{info, warn};
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
@@ -48,7 +51,6 @@ async fn pingserver() {
     }
 }
 
-
 async fn yeeter() {
     let mut ctr = 0;
     tokio::time::sleep(Duration::from_secs(3)).await;
@@ -61,9 +63,7 @@ async fn yeeter() {
 }
 
 async fn yeet_listener(id: u8) {
-    let subber = StdBoundedTopicSocket::<YeetTopic, _, _>::new(
-        STACK.base(), 64,
-    );
+    let subber = StdBoundedTopicSocket::<YeetTopic, _, _>::new(STACK.base(), 64);
     let subber = pin!(subber);
     let mut hdl = subber.subscribe();
 

--- a/demos/ergot-client/src/main.rs
+++ b/demos/ergot-client/src/main.rs
@@ -4,6 +4,7 @@ use ergot::{
     socket::endpoint::StdBoundedEndpointSocket,
     well_known::ErgotPingEndpoint,
 };
+use log::info;
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use tokio::net::TcpStream;
 
@@ -14,6 +15,7 @@ static STACK: NetStack<CriticalSectionRawMutex, StdTcpClientIm> = NetStack::new(
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
+    env_logger::init();
     let socket = TcpStream::connect("127.0.0.1:2025").await.unwrap();
 
     tokio::task::spawn(pingserver());
@@ -34,7 +36,7 @@ async fn pingserver() {
     loop {
         server_hdl
             .serve(async |req| {
-                println!("Serving ping {req}");
+                info!("Serving ping {req}");
                 req
             })
             .await

--- a/demos/ergot-router/Cargo.lock
+++ b/demos/ergot-router/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "const-fnv1a-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +199,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "ergot"
 version = "0.1.0"
 dependencies = [
@@ -167,6 +246,7 @@ dependencies = [
  "cobs 0.3.0",
  "cordyceps",
  "critical-section",
+ "log",
  "maitake-sync",
  "mutex",
  "postcard",
@@ -183,7 +263,9 @@ dependencies = [
  "const-fnv1a-hash",
  "cordyceps",
  "critical-section",
+ "env_logger",
  "ergot",
+ "log",
  "maitake-sync",
  "mutex",
  "pin-project",
@@ -254,6 +336,36 @@ checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -344,7 +456,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -395,6 +507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +549,15 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -628,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -700,7 +827,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -780,6 +907,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -922,6 +1055,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/demos/ergot-router/Cargo.toml
+++ b/demos/ergot-router/Cargo.toml
@@ -19,6 +19,8 @@ serde = { version = "1.0", features = ["derive"] }
 postcard-rpc = "0.11.9"
 postcard-schema = { version = "0.2.1", features = ["derive"] }
 cobs = { version = "0.3.0", features = ["use_std"] }
+log = "0.4.27"
+env_logger = "0.11.8"
 
 
 [dependencies.ergot]

--- a/demos/ergot-router/src/main.rs
+++ b/demos/ergot-router/src/main.rs
@@ -1,5 +1,8 @@
 use ergot::{
-    interface_manager::std_tcp_router::{register_interface, StdTcpIm}, socket::topic::StdBoundedTopicSocket, well_known::ErgotPingEndpoint, Address, NetStack
+    Address, NetStack,
+    interface_manager::std_tcp_router::{StdTcpIm, register_interface},
+    socket::topic::StdBoundedTopicSocket,
+    well_known::ErgotPingEndpoint,
 };
 use log::{info, warn};
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
@@ -51,15 +54,14 @@ async fn ping_all() {
         for net in nets {
             let pg = ctr;
             ctr = ctr.wrapping_add(1);
-            let rr = STACK
-                .req_resp::<ErgotPingEndpoint>(
-                    Address {
-                        network_id: net,
-                        node_id: 2,
-                        port_id: 0,
-                    },
-                    &pg,
-                );
+            let rr = STACK.req_resp::<ErgotPingEndpoint>(
+                Address {
+                    network_id: net,
+                    node_id: 2,
+                    port_id: 0,
+                },
+                &pg,
+            );
             let fut = timeout(Duration::from_millis(100), rr);
             let res = fut.await;
             info!("ping {net}.2 w/ {pg}: {res:?}");
@@ -68,9 +70,7 @@ async fn ping_all() {
 }
 
 async fn yeet_listener(id: u8) {
-    let subber = StdBoundedTopicSocket::<YeetTopic, _, _>::new(
-        STACK.base(), 64,
-    );
+    let subber = StdBoundedTopicSocket::<YeetTopic, _, _>::new(STACK.base(), 64);
     let subber = pin!(subber);
     let mut hdl = subber.subscribe();
 

--- a/demos/ergot-router/src/main.rs
+++ b/demos/ergot-router/src/main.rs
@@ -1,6 +1,7 @@
 use ergot::{
     interface_manager::std_tcp_router::{register_interface, StdTcpIm}, well_known::ErgotPingEndpoint, Address, NetStack
 };
+use log::{info, warn};
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use tokio::{
     net::TcpListener,
@@ -14,6 +15,7 @@ static STACK: NetStack<CriticalSectionRawMutex, StdTcpIm> = NetStack::new();
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
+    env_logger::init();
     let listener = TcpListener::bind("127.0.0.1:2025").await?;
 
     tokio::task::spawn(ping_all());
@@ -22,12 +24,12 @@ async fn main() -> io::Result<()> {
     // `serve(listener).await`, or just `serve(&STACK, "127.0.0.1:2025").await`?
     loop {
         let (socket, addr) = listener.accept().await?;
-        println!("Connect {addr:?}");
+        info!("Connect {addr:?}");
         let hdl = register_interface(STACK.base(), socket).unwrap();
 
         tokio::task::spawn(async move {
             let res = hdl.run().await;
-            println!("END: {res:?}");
+            warn!("END: {res:?}");
         });
     }
 }
@@ -38,7 +40,7 @@ async fn ping_all() {
     loop {
         ival.tick().await;
         let nets = STACK.with_interface_manager(|im| im.get_nets());
-        println!("Nets to ping: {nets:?}");
+        info!("Nets to ping: {nets:?}");
         for net in nets {
             let pg = ctr;
             ctr = ctr.wrapping_add(1);
@@ -53,7 +55,7 @@ async fn ping_all() {
                 );
             let fut = timeout(Duration::from_millis(100), rr);
             let res = fut.await;
-            println!("ping {net}.2 w/ {pg}: {res:?}");
+            info!("ping {net}.2 w/ {pg}: {res:?}");
         }
     }
 }


### PR DESCRIPTION
This adds support for broadcast messages at the `ergot-base` level, and using them as Topics at the `ergot` level.

Port ID == 255 is assigned as broadcast messages. We also allow attaching broadcast sockets, where multiple aliasing sockets may exist at once.

Broadcast messages are sent to all matching local sockets, and forwarded out to all interfaces. When sending broadcast messages, the destination is always set to the specific destination, which helps prevent trivial routing loops.

Closes #11
Closes #3