### PR TITLE
Add `book` docs module

### DIFF
--- a/crates/ergot/src/book/_01_what_can_you_do.rs
+++ b/crates/ergot/src/book/_01_what_can_you_do.rs
@@ -1,0 +1,82 @@
+//! # What can you do with ergot?
+//!
+//! Let's start by defining a postcard-rpc style `endpoint`: A server that accept requests of
+//! one type, and responds with a second type. We can define an endpoint called "double", which will
+//! take a `u32`, double it, and return it as a `u64` (to ensure there is no data loss if we pass
+//! a large `u32`).
+//!
+//! ```rust
+//! use postcard_rpc::endpoint;
+//! use mutex::raw_impls::cs::CriticalSectionRawMutex as CSRMutex;
+//! use ergot::NetStack;
+//! use ergot::interface_manager::null::NullInterfaceManager as NullIM;
+//! use ergot::socket::endpoint::OwnedEndpointSocket;
+//! use ergot::Address;
+//! use core::pin::pin;
+//!
+//! // For now, we use the macros from postcard-rpc to define an endpoint
+//! endpoint! {
+//!     // The marker type we create for our endpoint, so we can name it
+//!     DoubleEndpoint,
+//!     // The type of the request, here, a u32
+//!     u32,
+//!     // The type of the response, here, a u64
+//!     u64,
+//!     // The name of our endpoint
+//!     "double"
+//! }
+//!
+//! // We can now create our network stack
+//! static STACK: NetStack<CSRMutex, NullIM> = NetStack::new();
+//!
+//! // An async fn that serves one endpoint request, then returns
+//! async fn serve_once() {
+//!     // Create the socket for our request type, pin it, then attach to the netstack,
+//!     // Making this socket available to receive requests. A port is automatically
+//!     // assigned for this socket.
+//!     let server_skt = OwnedEndpointSocket::<DoubleEndpoint, _, _>::new(&STACK);
+//!     let server_skt = pin!(server_skt);
+//!     let mut hdl = server_skt.attach();
+//!
+//!     // Serve one request, doubling the request and returning it. The async closure
+//!     // is called when a request is successfully received. The response is automatically
+//!     // sent back to the source address of the requestor. Normally, you'd want to do
+//!     // this in a loop, for as long as you want your server to exist, potentially forever!
+//!     hdl.serve(async |p: &u32| {
+//!         let p: u64 = (*p) as u64;
+//!         2 * p
+//!     }).await.unwrap();
+//!
+//!     // When the socket falls out of scope, it is automatically detached from the network
+//!     // stack, and packets to that address will no longer be accepted.
+//! }
+//!
+//! // An async fn that makes one Endpoint request, and waits for the response
+//! async fn client_once() {
+//!     # // Make sure we let the server start first
+//!     # tokio::time::sleep(core::time::Duration::from_millis(50)).await;
+//!     // Send a request via the network stack. We set the destination address as
+//!     // "unknown", which will cause `ergot` to see if there is one (and only one)
+//!     // socket offering this endpoint on the local machine.
+//!     let res = STACK.req_resp::<DoubleEndpoint>(
+//!         Address::unknown(),
+//!         &42u32,
+//!     ).await;
+//!
+//!     // Did it double?
+//!     assert_eq!(res, Ok(84u64));
+//! }
+//!
+//! // Run the test, wait for our client and server to complete
+//! #[tokio::main]
+//! async fn main() {
+//!     let hdl_srv = tokio::task::spawn(serve_once());
+//!     let hdl_cli = tokio::task::spawn(client_once());
+//!     hdl_srv.await.unwrap();
+//!     hdl_cli.await.unwrap();
+//! }
+//! ```
+//!
+//! ## Whew, that was a lot at once!
+//!
+//! It sure was! Let's explain that (later)

--- a/crates/ergot/src/book/mod.rs
+++ b/crates/ergot/src/book/mod.rs
@@ -1,0 +1,106 @@
+//! # `ergot` - An Introduction
+//!
+//! `ergot` is a network stack written in Rust. It is currently experimental.
+//!
+//! ## What do you mean, "Network Stack"?
+//!
+//! `ergot` is an evolution in the `postcard` family.
+//!
+//! `postcard` is a **binary wire format**, that describes how to convert Rust data
+//! types to and from a binary form that can be sent over a network, or stored to
+//! disk. However: it has no prescription of HOW to communicate between devices, at
+//! a higher level. It is just **data**.
+//!
+//! `postcard-rpc` is a **protocol** using the `postcard` wire format. It prescribes
+//! *behaviors* for when and how to send messages to perform certain operations,
+//! such as request/response "endpoint" pairs, or broadcast-style "topic" messages.
+//! However: it has no prescription of HOW to connect two devices, or how a server
+//! could manage connections with more than one client at a time.
+//!
+//! `ergot` is a **network stack**. It handles concerns such as routing, addressing,
+//! and socket-oriented connections between many devices. It uses `postcard` for
+//! the encoding of user data, and currently offers protocol functionality inspired
+//! by `postcard-rpc`. It allows devices of various sizes to become part of a
+//! network, and for all nodes to communicate with each other.
+//!
+//! As a network stack: It should help you to communicate *across* systems, whether
+//! that is between tasks within the same program, between devices that are directly
+//! connected to each other, or between devices separated by multiple network links.
+//!
+//! ## Why `ergot`, and not `TCP/IP`?
+//!
+//! `ergot` is **NOT** a TCP/IP stack. The decision to build a custom network stack
+//! rather than a new version or layer on top of existing tech was made to support
+//! four main goals:
+//!
+//! ### Communication for devices of ANY size
+//!
+//! First, **the ability to support devices with different levels of capabilities**,
+//! ranging from the smallest Cortex-M0+ devices, all the way up to desktop devices.
+//!
+//! `ergot` achieves this by making many capabilities of the network stack optional
+//! and swappable. Smaller devices can be part of a network, without having to
+//! manage things like routing tables or large network buffers. Instead, they can
+//! rely on larger devices they are connected to, to manage heavier networking
+//! tasks, allowing them to still be communicated with.
+//!
+//! ### Communication across ANY data link
+//!
+//! Second, **the ability to support a wide range of communication links**, within
+//! the same coherent network. For example, a PC could be connected over USB to
+//! a microcontroller, which then is connected to four smaller microcontrollers over
+//! SPI, UART, RS-485, or I2C.
+//!
+//! `ergot` achieves this by allowing for devices to define custom "interfaces": if
+//! you can define how to get a chunk of data from one device to another, you can
+//! probably implement an `ergot` interface.
+//!
+//! ### Type Safe Communication, not chunks/streams of bytes
+//!
+//! Rather than only providing transport of frame (e.g. UDP) or streams (e.g. TCP)
+//! of bytes, `ergot` instead focuses on type safe communication. Sockets have a
+//! type associated with them, always. This means that using `ergot` sockets doesn't
+//! feel like talking over a network, it feels like using channels: data goes in one
+//! side, data comes out the other.
+//!
+//! When sending data locally (e.g. to a socket on the same machine), this allows us
+//! to *completely skip* serialization, placing data in the destination the same as
+//! we would for a channel. When sending data remotely (from or to a remote
+//! machine), senders or receivers don't need to worry about doing the serialization
+//! themselves: all data is encoded as `postcard` data automatically.
+//!
+//! ### Just because I can
+//!
+//! I've been working on communication between devices within the `postcard`
+//! cinematic universe since 2019. This has always been a cycle of exploring how far
+//! can I get with my current tools, finding the limitations of the tools I have,
+//! then building the next level up to address the shortcomings, and repeating that
+//! cycle.
+//!
+//! `ergot` is the next step after `postcard-rpc`: I've reached the limitations of
+//! what can be achieved with JUST a point to point communication protocol, when you
+//! want to connect to more than one device, or want devices to talk with each
+//! other, rather than just a central "host" computer.
+//!
+//! It's possible this all could have been done on top of TCP/IP, writing my own
+//! TCP/IP stack, or extending the wonderful `smoltcp` crate. I didn't *wan't* to do
+//! that. We'll see if it pays off.
+//!
+//! ## What IS it, if not `TCP/IP`?
+//!
+//! Well, it's not THAT far from modern communication stacks based on TCP/IP.
+//!
+//! `ergot` is strongly influenced by [AppleTalk], a networking stack used by
+//! computers in the late 80's and early 90's. It is an interesting place to pull
+//! design choices from: the computers of that time are generally comparable to
+//! today's microcontrollers, and if it worked for them then, why shouldn't the
+//! same design choices work today?
+//!
+//! [AppleTalk]: https://en.wikipedia.org/wiki/AppleTalk
+//!
+//! It likely is possible to describe `ergot` concepts in terms of the [OSI Model],
+//! but I'm not too stressed about it.
+//!
+//! [OSI Model]: https://en.wikipedia.org/wiki/OSI_model
+
+pub mod _01_what_can_you_do;

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -5,6 +5,7 @@ pub use ergot_base;
 pub use ergot_base::Address;
 pub use ergot_base::interface_manager;
 
+pub mod book;
 pub mod net_stack;
 pub mod socket;
 pub mod well_known;


### PR DESCRIPTION
This adds an initial "books" module that I plan to fill out later.

I thought about using `mdbook`, but honestly it's a [huge pain](https://github.com/rust-lang/mdBook/issues/394) currently, so let's just use rustdoc instead.