### PR TITLE
feat(ergot): Add "serve blocking" handler for endpoint servers

### DIFF
--- a/demos/ergot-client/src/main.rs
+++ b/demos/ergot-client/src/main.rs
@@ -42,7 +42,7 @@ async fn pingserver() {
     let mut server_hdl = server.attach();
     loop {
         server_hdl
-            .serve(async |req| {
+            .serve_blocking(|req: &u32| {
                 info!("Serving ping {req}");
                 *req
             })

--- a/demos/nrf52840-eusb/src/main.rs
+++ b/demos/nrf52840-eusb/src/main.rs
@@ -173,7 +173,7 @@ async fn pingserver() {
     let mut server_hdl = server.attach();
     loop {
         server_hdl
-            .serve(async |req| {
+            .serve_blocking(|req: &u32| {
                 info!("Serving ping {=u32}", req);
                 *req
             })


### PR DESCRIPTION
If your handler doesn't need async (like the basic ping server in demos currently), you can provide a non-async closure instead.

We still await the request arriving, but we don't await your closure.