### PR TITLE
Introduce NetStackHandle to ergot/ergot-base

### DIFF
--- a/crates/ergot-base/src/lib.rs
+++ b/crates/ergot-base/src/lib.rs
@@ -60,18 +60,20 @@ impl FrameKind {
 
 #[cfg(feature = "postcard-schema-v0_2")]
 impl postcard_schema::Schema for FrameKind {
-    const SCHEMA: &'static postcard_schema::schema::NamedType = &postcard_schema::schema::NamedType {
-        name: "FrameKind",
-        ty: u8::SCHEMA.ty,
-    };
+    const SCHEMA: &'static postcard_schema::schema::NamedType =
+        &postcard_schema::schema::NamedType {
+            name: "FrameKind",
+            ty: u8::SCHEMA.ty,
+        };
 }
 
 #[cfg(feature = "postcard-schema-v0_2")]
 impl postcard_schema::Schema for Key {
-    const SCHEMA: &'static postcard_schema::schema::NamedType = &postcard_schema::schema::NamedType {
-        name: "Key",
-        ty: <[u8; 8]>::SCHEMA.ty,
-    };
+    const SCHEMA: &'static postcard_schema::schema::NamedType =
+        &postcard_schema::schema::NamedType {
+            name: "Key",
+            ty: <[u8; 8]>::SCHEMA.ty,
+        };
 }
 
 impl ProtocolError {

--- a/crates/ergot-base/src/net_stack.rs
+++ b/crates/ergot-base/src/net_stack.rs
@@ -18,7 +18,7 @@
 //! is used both to allow sharing of the inner contents, but also to allow
 //! `Drop` impls to remove themselves from the stack in a blocking manner.
 
-use core::{any::TypeId, ptr::NonNull};
+use core::{any::TypeId, ops::Deref, ptr::NonNull};
 
 use cordyceps::List;
 use log::{debug, trace};
@@ -34,6 +34,16 @@ use crate::{
 /// The Ergot Netstack
 pub struct NetStack<R: ScopedRawMutex, M: InterfaceManager> {
     inner: BlockingMutex<R, NetStackInner<M>>,
+}
+
+pub trait NetStackHandle
+where
+    Self: Sized,
+    Self: Deref<Target = NetStack<Self::Mutex, Self::Interface>>,
+    Self: Clone,
+{
+    type Mutex: ScopedRawMutex + 'static;
+    type Interface: InterfaceManager + 'static;
 }
 
 pub(crate) struct NetStackInner<M: InterfaceManager> {
@@ -58,6 +68,16 @@ pub enum NetStackSendError {
 }
 
 // ---- impl NetStack ----
+
+// TODO: Impl for Arc
+impl<R, M> NetStackHandle for &'static NetStack<R, M>
+where
+    R: ScopedRawMutex,
+    M: InterfaceManager,
+{
+    type Mutex = R;
+    type Interface = M;
+}
 
 impl<R, M> NetStack<R, M>
 where
@@ -140,7 +160,7 @@ where
     /// });
     /// assert_eq!(res, 42);
     /// ```
-    pub fn with_interface_manager<F: FnOnce(&mut M) -> U, U>(&'static self, f: F) -> U {
+    pub fn with_interface_manager<F: FnOnce(&mut M) -> U, U>(&self, f: F) -> U {
         self.inner.with_lock(|inner| f(&mut inner.manager))
     }
 
@@ -150,7 +170,7 @@ where
     /// typically used by interfaces to feed received messages into the
     /// [`NetStack`].
     pub fn send_raw(
-        &'static self,
+        &self,
         hdr: &Header,
         hdr_raw: &[u8],
         body: &[u8],
@@ -161,25 +181,18 @@ where
 
     /// Send a typed message
     pub fn send_ty<T: 'static + Serialize + Clone>(
-        &'static self,
+        &self,
         hdr: &Header,
         t: &T,
     ) -> Result<(), NetStackSendError> {
         self.inner.with_lock(|inner| inner.send_ty(hdr, t))
     }
 
-    pub fn send_err(
-        &'static self,
-        hdr: &Header,
-        err: ProtocolError,
-    ) -> Result<(), NetStackSendError> {
+    pub fn send_err(&self, hdr: &Header, err: ProtocolError) -> Result<(), NetStackSendError> {
         self.inner.with_lock(|inner| inner.send_err(hdr, err))
     }
 
-    pub(crate) unsafe fn try_attach_socket(
-        &'static self,
-        mut node: NonNull<SocketHeader>,
-    ) -> Option<u8> {
+    pub(crate) unsafe fn try_attach_socket(&self, mut node: NonNull<SocketHeader>) -> Option<u8> {
         self.inner.with_lock(|inner| {
             let new_port = inner.alloc_port()?;
             unsafe {
@@ -191,7 +204,7 @@ where
         })
     }
 
-    pub(crate) unsafe fn attach_broadcast_socket(&'static self, mut node: NonNull<SocketHeader>) {
+    pub(crate) unsafe fn attach_broadcast_socket(&self, mut node: NonNull<SocketHeader>) {
         self.inner.with_lock(|inner| {
             unsafe {
                 node.as_mut().port = 255;
@@ -200,7 +213,7 @@ where
         });
     }
 
-    pub(crate) unsafe fn attach_socket(&'static self, node: NonNull<SocketHeader>) -> u8 {
+    pub(crate) unsafe fn attach_socket(&self, node: NonNull<SocketHeader>) -> u8 {
         let res = unsafe { self.try_attach_socket(node) };
         let Some(new_port) = res else {
             panic!("exhausted all addrs");
@@ -208,7 +221,7 @@ where
         new_port
     }
 
-    pub(crate) unsafe fn detach_socket(&'static self, node: NonNull<SocketHeader>) {
+    pub(crate) unsafe fn detach_socket(&self, node: NonNull<SocketHeader>) {
         self.inner.with_lock(|inner| unsafe {
             let port = node.as_ref().port;
             if port != 255 {
@@ -218,7 +231,7 @@ where
         });
     }
 
-    pub(crate) unsafe fn with_lock<U, F: FnOnce() -> U>(&'static self, f: F) -> U {
+    pub(crate) unsafe fn with_lock<U, F: FnOnce() -> U>(&self, f: F) -> U {
         self.inner.with_lock(|_inner| f())
     }
 }
@@ -846,7 +859,7 @@ mod test {
             let (txdone, rxdone) = oneshot::channel();
             let (txwait, rxwait) = oneshot::channel();
             let hdl = std::thread::spawn(move || {
-                let skt = Socket::<u64, _, _>::new(
+                let skt = Socket::<u64, _>::new(
                     &STACK,
                     Key(*b"TEST1234"),
                     Attributes {
@@ -917,7 +930,7 @@ mod test {
 
         // Sockets exhausted (we never see 255)
         let hdl = std::thread::spawn(move || {
-            let skt = Socket::<u64, _, _>::new(
+            let skt = Socket::<u64, _>::new(
                 &STACK,
                 Key(*b"TEST1234"),
                 Attributes {

--- a/crates/ergot-base/src/socket/borrow.rs
+++ b/crates/ergot-base/src/socket/borrow.rs
@@ -27,55 +27,51 @@ use bbq2::{
     traits::bbqhdl::BbqHandle,
 };
 use cordyceps::list::Links;
-use mutex::ScopedRawMutex;
 use postcard::ser_flavors;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    HeaderSeq, Key, NetStack, ProtocolError,
-    interface_manager::InterfaceManager,
+    HeaderSeq, Key, ProtocolError,
     nash::NameHash,
+    net_stack::NetStackHandle,
     wire_frames::{self, BorrowedFrame, CommonHeader, de_frame},
 };
 
 use super::{Attributes, HeaderMessage, Response, SocketHeader, SocketSendError, SocketVTable};
 
 #[repr(C)]
-pub struct Socket<Q, T, R, M>
+pub struct Socket<Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
     // LOAD BEARING: must be first
     hdr: SocketHeader,
-    pub(crate) net: &'static NetStack<R, M>,
+    pub(crate) net: N,
     inner: UnsafeCell<QueueBox<Q>>,
     mtu: u16,
     _pd: PhantomData<fn() -> T>,
 }
 
-pub struct SocketHdl<'a, Q, T, R, M>
+pub struct SocketHdl<'a, Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
-    pub(crate) ptr: NonNull<Socket<Q, T, R, M>>,
-    _lt: PhantomData<Pin<&'a mut Socket<Q, T, R, M>>>,
+    pub(crate) ptr: NonNull<Socket<Q, T, N>>,
+    _lt: PhantomData<Pin<&'a mut Socket<Q, T, N>>>,
     port: u8,
 }
 
-pub struct Recv<'a, 'b, Q, T, R, M>
+pub struct Recv<'a, 'b, Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
-    hdl: &'a mut SocketHdl<'b, Q, T, R, M>,
+    hdl: &'a mut SocketHdl<'b, Q, T, N>,
 }
 
 pub struct ResponseGrant<Q: BbqHandle, T> {
@@ -101,15 +97,14 @@ enum ResponseGrantInner<Q: BbqHandle, T> {
 
 // impl Socket
 
-impl<Q, T, R, M> Socket<Q, T, R, M>
+impl<Q, T, N> Socket<Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
     pub const fn new(
-        net: &'static NetStack<R, M>,
+        net: N,
         key: Key,
         attrs: Attributes,
         sto: Q,
@@ -139,8 +134,8 @@ where
         }
     }
 
-    pub fn attach<'a>(self: Pin<&'a mut Self>) -> SocketHdl<'a, Q, T, R, M> {
-        let stack = self.net;
+    pub fn attach<'a>(self: Pin<&'a mut Self>) -> SocketHdl<'a, Q, T, N> {
+        let stack = self.net.clone();
         let ptr_self: NonNull<Self> = NonNull::from(unsafe { self.get_unchecked_mut() });
         let ptr_erase: NonNull<SocketHeader> = ptr_self.cast();
         let port = unsafe { stack.attach_socket(ptr_erase) };
@@ -151,8 +146,8 @@ where
         }
     }
 
-    pub fn attach_broadcast<'a>(self: Pin<&'a mut Self>) -> SocketHdl<'a, Q, T, R, M> {
-        let stack = self.net;
+    pub fn attach_broadcast<'a>(self: Pin<&'a mut Self>) -> SocketHdl<'a, Q, T, N> {
+        let stack = self.net.clone();
         let ptr_self: NonNull<Self> = NonNull::from(unsafe { self.get_unchecked_mut() });
         let ptr_erase: NonNull<SocketHeader> = ptr_self.cast();
         unsafe { stack.attach_broadcast_socket(ptr_erase) };
@@ -172,8 +167,8 @@ where
         }
     }
 
-    pub fn stack(&self) -> &'static NetStack<R, M> {
-        self.net
+    pub fn stack(&self) -> N {
+        self.net.clone()
     }
 
     fn recv_err(this: NonNull<()>, hdr: HeaderSeq, err: ProtocolError) {
@@ -325,32 +320,30 @@ where
 
 // impl SocketHdl
 
-impl<'a, Q, T, R, M> SocketHdl<'a, Q, T, R, M>
+impl<'a, Q, T, N> SocketHdl<'a, Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
     pub fn port(&self) -> u8 {
         self.port
     }
 
-    pub fn stack(&self) -> &'static NetStack<R, M> {
-        unsafe { *addr_of!((*self.ptr.as_ptr()).net) }
+    pub fn stack(&self) -> N {
+        unsafe { (*addr_of!((*self.ptr.as_ptr()).net)).clone() }
     }
 
-    pub fn recv<'b>(&'b mut self) -> Recv<'b, 'a, Q, T, R, M> {
+    pub fn recv<'b>(&'b mut self) -> Recv<'b, 'a, Q, T, N> {
         Recv { hdl: self }
     }
 }
 
-impl<Q, T, R, M> Drop for Socket<Q, T, R, M>
+impl<Q, T, N> Drop for Socket<Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
     fn drop(&mut self) {
         unsafe {
@@ -360,39 +353,36 @@ where
     }
 }
 
-unsafe impl<Q, T, R, M> Send for SocketHdl<'_, Q, T, R, M>
+unsafe impl<Q, T, N> Send for SocketHdl<'_, Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
 }
 
-unsafe impl<Q, T, R, M> Sync for SocketHdl<'_, Q, T, R, M>
+unsafe impl<Q, T, N> Sync for SocketHdl<'_, Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
 }
 
 // impl Recv
 
-impl<'a, Q, T, R, M> Future for Recv<'a, '_, Q, T, R, M>
+impl<'a, Q, T, N> Future for Recv<'a, '_, Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
     type Output = ResponseGrant<Q, T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let net: &'static NetStack<R, M> = self.hdl.stack();
+        let net: N = self.hdl.stack();
         let f = || -> Option<ResponseGrant<Q, T>> {
-            let this_ref: &Socket<Q, T, R, M> = unsafe { self.hdl.ptr.as_ref() };
+            let this_ref: &Socket<Q, T, N> = unsafe { self.hdl.ptr.as_ref() };
             let qbox: &mut QueueBox<Q> = unsafe { &mut *this_ref.inner.get() };
             let cons: FramedConsumer<Q, u16> = qbox.q.framed_consumer();
 
@@ -466,12 +456,11 @@ where
     }
 }
 
-unsafe impl<Q, T, R, M> Sync for Recv<'_, '_, Q, T, R, M>
+unsafe impl<Q, T, N> Sync for Recv<'_, '_, Q, T, N>
 where
     Q: BbqHandle,
     T: Serialize + Clone,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
 }
 

--- a/crates/ergot-base/src/socket/borrow.rs
+++ b/crates/ergot-base/src/socket/borrow.rs
@@ -48,7 +48,7 @@ where
 {
     // LOAD BEARING: must be first
     hdr: SocketHeader,
-    pub(crate) net: N,
+    pub(crate) net: N::Target,
     inner: UnsafeCell<QueueBox<Q>>,
     mtu: u16,
     _pd: PhantomData<fn() -> T>,
@@ -104,7 +104,7 @@ where
     N: NetStackHandle,
 {
     pub const fn new(
-        net: N,
+        net: N::Target,
         key: Key,
         attrs: Attributes,
         sto: Q,
@@ -167,7 +167,7 @@ where
         }
     }
 
-    pub fn stack(&self) -> N {
+    pub fn stack(&self) -> N::Target {
         self.net.clone()
     }
 
@@ -330,7 +330,7 @@ where
         self.port
     }
 
-    pub fn stack(&self) -> N {
+    pub fn stack(&self) -> N::Target {
         unsafe { (*addr_of!((*self.ptr.as_ptr()).net)).clone() }
     }
 
@@ -380,7 +380,7 @@ where
     type Output = ResponseGrant<Q, T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let net: N = self.hdl.stack();
+        let net: N::Target = self.hdl.stack();
         let f = || -> Option<ResponseGrant<Q, T>> {
             let this_ref: &Socket<Q, T, N> = unsafe { self.hdl.ptr.as_ref() };
             let qbox: &mut QueueBox<Q> = unsafe { &mut *this_ref.inner.get() };

--- a/crates/ergot-base/src/socket/owned.rs
+++ b/crates/ergot-base/src/socket/owned.rs
@@ -63,7 +63,7 @@ macro_rules! wrapper {
                 }
             }
 
-            pub fn stack(&self) -> NS {
+            pub fn stack(&self) -> NS::Target {
                 self.socket.stack()
             }
         }
@@ -77,7 +77,7 @@ macro_rules! wrapper {
                 self.hdl.port()
             }
 
-            pub fn stack(&self) -> NS {
+            pub fn stack(&self) -> NS::Target {
                 self.hdl.stack()
             }
 
@@ -150,7 +150,7 @@ pub mod single {
         NS: NetStackHandle,
     {
         #[inline]
-        pub const fn new(net: NS, key: Key, attrs: Attributes, name: Option<&str>) -> Self {
+        pub const fn new(net: NS::Target, key: Key, attrs: Attributes, name: Option<&str>) -> Self {
             Self {
                 socket: raw_owned::Socket::new(net, key, attrs, None, name),
             }
@@ -217,7 +217,7 @@ pub mod std_bounded {
         NS: NetStackHandle,
     {
         #[inline]
-        pub fn new(net: NS, key: Key, attrs: Attributes, bound: usize, name: Option<&str>) -> Self {
+        pub fn new(net: NS::Target, key: Key, attrs: Attributes, bound: usize, name: Option<&str>) -> Self {
             Self {
                 socket: raw_owned::Socket::new(net, key, attrs, Bounded::with_bound(bound), name),
             }
@@ -283,7 +283,7 @@ pub mod stack_vec {
         NS: NetStackHandle,
     {
         #[inline]
-        pub const fn new(net: NS, key: Key, attrs: Attributes, name: Option<&str>) -> Self {
+        pub const fn new(net: NS::Target, key: Key, attrs: Attributes, name: Option<&str>) -> Self {
             Self {
                 socket: raw_owned::Socket::new(net, key, attrs, Bounded::new(), name),
             }

--- a/crates/ergot-base/src/socket/owned.rs
+++ b/crates/ergot-base/src/socket/owned.rs
@@ -16,41 +16,37 @@
 macro_rules! wrapper {
     ($sto: ty, $($arr: ident)?) => {
         #[repr(transparent)]
-        pub struct Socket<T, R, M, $(const $arr: usize)?>
+        pub struct Socket<T, NS, $(const $arr: usize)?>
         where
             T: Clone + serde::de::DeserializeOwned + 'static,
-            R: mutex::ScopedRawMutex + 'static,
-            M: $crate::interface_manager::InterfaceManager + 'static,
+            NS: $crate::net_stack::NetStackHandle,
         {
-            socket: $crate::socket::raw_owned::Socket<$sto, T, R, M>,
+            socket: $crate::socket::raw_owned::Socket<$sto, T, NS>,
         }
 
-        pub struct SocketHdl<'a, T, R, M, $(const $arr: usize)?>
+        pub struct SocketHdl<'a, T, NS, $(const $arr: usize)?>
         where
             T: Clone + serde::de::DeserializeOwned + 'static,
-            R: mutex::ScopedRawMutex + 'static,
-            M: $crate::interface_manager::InterfaceManager + 'static,
+            NS: $crate::net_stack::NetStackHandle,
         {
-            hdl: $crate::socket::raw_owned::SocketHdl<'a, $sto, T, R, M>,
+            hdl: $crate::socket::raw_owned::SocketHdl<'a, $sto, T, NS>,
         }
 
-        pub struct Recv<'a, 'b, T, R, M, $(const $arr: usize)?>
+        pub struct Recv<'a, 'b, T, NS, $(const $arr: usize)?>
         where
             T: Clone + serde::de::DeserializeOwned + 'static,
-            R: mutex::ScopedRawMutex + 'static,
-            M: $crate::interface_manager::InterfaceManager + 'static,
+            NS: $crate::net_stack::NetStackHandle,
         {
-            recv: $crate::socket::raw_owned::Recv<'a, 'b, $sto, T, R, M>,
+            recv: $crate::socket::raw_owned::Recv<'a, 'b, $sto, T, NS>,
         }
 
-        impl<T, R, M, $(const $arr: usize)?> Socket<T, R, M, $($arr)?>
+        impl<T, NS, $(const $arr: usize)?> Socket<T, NS, $($arr)?>
         where
             T: Clone + serde::de::DeserializeOwned + 'static,
-            R: mutex::ScopedRawMutex + 'static,
-            M: $crate::interface_manager::InterfaceManager + 'static,
+            NS: $crate::net_stack::NetStackHandle,
         {
-            pub fn attach<'a>(self: core::pin::Pin<&'a mut Self>) -> SocketHdl<'a, T, R, M, $($arr)?> {
-                let socket: core::pin::Pin<&'a mut $crate::socket::raw_owned::Socket<$sto, T, R, M>>
+            pub fn attach<'a>(self: core::pin::Pin<&'a mut Self>) -> SocketHdl<'a, T, NS, $($arr)?> {
+                let socket: core::pin::Pin<&'a mut $crate::socket::raw_owned::Socket<$sto, T, NS>>
                     = unsafe { self.map_unchecked_mut(|me| &mut me.socket) };
                 SocketHdl {
                     hdl: socket.attach(),
@@ -59,45 +55,43 @@ macro_rules! wrapper {
 
             pub fn attach_broadcast<'a>(
                 self: core::pin::Pin<&'a mut Self>,
-            ) -> SocketHdl<'a, T, R, M, $($arr)?> {
-                let socket: core::pin::Pin<&'a mut $crate::socket::raw_owned::Socket<$sto, T, R, M>>
+            ) -> SocketHdl<'a, T, NS, $($arr)?> {
+                let socket: core::pin::Pin<&'a mut $crate::socket::raw_owned::Socket<$sto, T, NS>>
                     = unsafe { self.map_unchecked_mut(|me| &mut me.socket) };
                 SocketHdl {
                     hdl: socket.attach_broadcast(),
                 }
             }
 
-            pub fn stack(&self) -> &'static crate::net_stack::NetStack<R, M> {
+            pub fn stack(&self) -> NS {
                 self.socket.stack()
             }
         }
 
-        impl<'a, T, R, M, $(const $arr: usize)?> SocketHdl<'a, T, R, M, $($arr)?>
+        impl<'a, T, NS, $(const $arr: usize)?> SocketHdl<'a, T, NS, $($arr)?>
         where
             T: Clone + serde::de::DeserializeOwned + 'static,
-            R: mutex::ScopedRawMutex + 'static,
-            M: $crate::interface_manager::InterfaceManager + 'static,
+            NS: $crate::net_stack::NetStackHandle,
         {
             pub fn port(&self) -> u8 {
                 self.hdl.port()
             }
 
-            pub fn stack(&self) -> &'static crate::net_stack::NetStack<R, M> {
+            pub fn stack(&self) -> NS {
                 self.hdl.stack()
             }
 
-            pub fn recv<'b>(&'b mut self) -> Recv<'b, 'a, T, R, M, $($arr)?> {
+            pub fn recv<'b>(&'b mut self) -> Recv<'b, 'a, T, NS, $($arr)?> {
                 Recv {
                     recv: self.hdl.recv(),
                 }
             }
         }
 
-        impl<T, R, M, $(const $arr: usize)?> Future for Recv<'_, '_, T, R, M, $($arr)?>
+        impl<T, NS, $(const $arr: usize)?> Future for Recv<'_, '_, T, NS, $($arr)?>
         where
             T: Clone + serde::de::DeserializeOwned + 'static,
-            R: mutex::ScopedRawMutex + 'static,
-            M: $crate::interface_manager::InterfaceManager + 'static,
+            NS: $crate::net_stack::NetStackHandle,
         {
             type Output = $crate::socket::Response<T>;
 
@@ -105,7 +99,7 @@ macro_rules! wrapper {
                 self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
             ) -> core::task::Poll<Self::Output> {
-                let recv: core::pin::Pin<&mut $crate::socket::raw_owned::Recv<'_, '_, $sto, T, R, M>>
+                let recv: core::pin::Pin<&mut $crate::socket::raw_owned::Recv<'_, '_, $sto, T, NS>>
                     = unsafe { self.map_unchecked_mut(|me| &mut me.recv) };
                 recv.poll(cx)
             }
@@ -114,13 +108,11 @@ macro_rules! wrapper {
 }
 
 pub mod single {
-    use mutex::ScopedRawMutex;
     use serde::de::DeserializeOwned;
 
     use crate::{
         Key,
-        interface_manager::InterfaceManager,
-        net_stack::NetStack,
+        net_stack::NetStackHandle,
         socket::{Attributes, raw_owned},
     };
 
@@ -152,19 +144,13 @@ pub mod single {
 
     wrapper!(Option<crate::socket::Response<T>>,);
 
-    impl<T, R, M> Socket<T, R, M>
+    impl<T, NS> Socket<T, NS>
     where
         T: Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
         #[inline]
-        pub const fn new(
-            net: &'static NetStack<R, M>,
-            key: Key,
-            attrs: Attributes,
-            name: Option<&str>,
-        ) -> Self {
+        pub const fn new(net: NS, key: Key, attrs: Attributes, name: Option<&str>) -> Self {
             Self {
                 socket: raw_owned::Socket::new(net, key, attrs, None, name),
             }
@@ -174,13 +160,14 @@ pub mod single {
 
 #[cfg(feature = "std")]
 pub mod std_bounded {
-    use mutex::ScopedRawMutex;
     use serde::de::DeserializeOwned;
     use std::collections::VecDeque;
 
-    use crate::{Key, NetStack, interface_manager::InterfaceManager};
-
-    use crate::socket::{Attributes, raw_owned};
+    use crate::{
+        Key,
+        net_stack::NetStackHandle,
+        socket::{Attributes, raw_owned},
+    };
 
     pub struct Bounded<T> {
         storage: std::collections::VecDeque<T>,
@@ -224,20 +211,13 @@ pub mod std_bounded {
 
     wrapper!(Bounded<crate::socket::Response<T>>,);
 
-    impl<T, R, M> Socket<T, R, M>
+    impl<T, NS> Socket<T, NS>
     where
         T: Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
         #[inline]
-        pub fn new(
-            net: &'static NetStack<R, M>,
-            key: Key,
-            attrs: Attributes,
-            bound: usize,
-            name: Option<&str>,
-        ) -> Self {
+        pub fn new(net: NS, key: Key, attrs: Attributes, bound: usize, name: Option<&str>) -> Self {
             Self {
                 socket: raw_owned::Socket::new(net, key, attrs, Bounded::with_bound(bound), name),
             }
@@ -246,10 +226,10 @@ pub mod std_bounded {
 }
 
 pub mod stack_vec {
-    use mutex::ScopedRawMutex;
     use serde::de::DeserializeOwned;
 
-    use crate::{Key, NetStack, interface_manager::InterfaceManager};
+    use crate::Key;
+    use crate::net_stack::NetStackHandle;
 
     use crate::socket::{Attributes, raw_owned};
 
@@ -297,19 +277,13 @@ pub mod stack_vec {
 
     wrapper!(Bounded<crate::socket::Response<T>, N>, N);
 
-    impl<T, R, M, const N: usize> Socket<T, R, M, N>
+    impl<T, NS, const N: usize> Socket<T, NS, N>
     where
         T: Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
         #[inline]
-        pub const fn new(
-            net: &'static NetStack<R, M>,
-            key: Key,
-            attrs: Attributes,
-            name: Option<&str>,
-        ) -> Self {
+        pub const fn new(net: NS, key: Key, attrs: Attributes, name: Option<&str>) -> Self {
             Self {
                 socket: raw_owned::Socket::new(net, key, attrs, Bounded::new(), name),
             }

--- a/crates/ergot-base/src/socket/owned.rs
+++ b/crates/ergot-base/src/socket/owned.rs
@@ -217,7 +217,13 @@ pub mod std_bounded {
         NS: NetStackHandle,
     {
         #[inline]
-        pub fn new(net: NS::Target, key: Key, attrs: Attributes, bound: usize, name: Option<&str>) -> Self {
+        pub fn new(
+            net: NS::Target,
+            key: Key,
+            attrs: Attributes,
+            bound: usize,
+            name: Option<&str>,
+        ) -> Self {
             Self {
                 socket: raw_owned::Socket::new(net, key, attrs, Bounded::with_bound(bound), name),
             }

--- a/crates/ergot-base/src/socket/raw_owned.rs
+++ b/crates/ergot-base/src/socket/raw_owned.rs
@@ -9,7 +9,13 @@
 //! storage.
 
 use core::{
-    any::TypeId, cell::UnsafeCell, marker::PhantomData, ops::Deref, pin::Pin, ptr::{addr_of, NonNull}, task::{Context, Poll, Waker}
+    any::TypeId,
+    cell::UnsafeCell,
+    marker::PhantomData,
+    ops::Deref,
+    pin::Pin,
+    ptr::{NonNull, addr_of},
+    task::{Context, Poll, Waker},
 };
 
 use cordyceps::list::Links;
@@ -79,7 +85,13 @@ where
     T: Clone + DeserializeOwned + 'static,
     N: NetStackHandle,
 {
-    pub const fn new(net: N::Target, key: Key, attrs: Attributes, sto: S, name: Option<&str>) -> Self {
+    pub const fn new(
+        net: N::Target,
+        key: Key,
+        attrs: Attributes,
+        sto: S,
+        name: Option<&str>,
+    ) -> Self {
         Self {
             hdr: SocketHeader {
                 links: Links::new(),

--- a/crates/ergot-base/src/socket/raw_owned.rs
+++ b/crates/ergot-base/src/socket/raw_owned.rs
@@ -12,7 +12,6 @@ use core::{
     any::TypeId,
     cell::UnsafeCell,
     marker::PhantomData,
-    ops::Deref,
     pin::Pin,
     ptr::{NonNull, addr_of},
     task::{Context, Poll, Waker},
@@ -114,7 +113,7 @@ where
         let stack = self.net.clone();
         let ptr_self: NonNull<Self> = NonNull::from(unsafe { self.get_unchecked_mut() });
         let ptr_erase: NonNull<SocketHeader> = ptr_self.cast();
-        let port = unsafe { stack.deref().attach_socket(ptr_erase) };
+        let port = unsafe { stack.attach_socket(ptr_erase) };
         SocketHdl {
             ptr: ptr_self,
             _lt: PhantomData,
@@ -126,7 +125,7 @@ where
         let stack = self.net.clone();
         let ptr_self: NonNull<Self> = NonNull::from(unsafe { self.get_unchecked_mut() });
         let ptr_erase: NonNull<SocketHeader> = ptr_self.cast();
-        unsafe { stack.deref().attach_broadcast_socket(ptr_erase) };
+        unsafe { stack.attach_broadcast_socket(ptr_erase) };
         SocketHdl {
             ptr: ptr_self,
             _lt: PhantomData,

--- a/crates/ergot-base/src/socket/raw_owned.rs
+++ b/crates/ergot-base/src/socket/raw_owned.rs
@@ -18,12 +18,9 @@ use core::{
 };
 
 use cordyceps::list::Links;
-use mutex::ScopedRawMutex;
 use serde::de::DeserializeOwned;
 
-use crate::{
-    HeaderSeq, Key, NetStack, ProtocolError, interface_manager::InterfaceManager, nash::NameHash,
-};
+use crate::{HeaderSeq, Key, ProtocolError, nash::NameHash, net_stack::NetStackHandle};
 
 use super::{Attributes, HeaderMessage, Response, SocketHeader, SocketSendError, SocketVTable};
 
@@ -39,39 +36,36 @@ pub trait Storage<T: 'static>: 'static {
 
 // Socket
 #[repr(C)]
-pub struct Socket<S, T, R, M>
+pub struct Socket<S, T, N>
 where
     S: Storage<Response<T>>,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
     // LOAD BEARING: must be first
     hdr: SocketHeader,
-    pub(crate) net: &'static NetStack<R, M>,
+    pub(crate) net: N,
     inner: UnsafeCell<StoreBox<S, Response<T>>>,
 }
 
-pub struct SocketHdl<'a, S, T, R, M>
+pub struct SocketHdl<'a, S, T, N>
 where
     S: Storage<Response<T>>,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
-    pub(crate) ptr: NonNull<Socket<S, T, R, M>>,
-    _lt: PhantomData<Pin<&'a mut Socket<S, T, R, M>>>,
+    pub(crate) ptr: NonNull<Socket<S, T, N>>,
+    _lt: PhantomData<Pin<&'a mut Socket<S, T, N>>>,
     port: u8,
 }
 
-pub struct Recv<'a, 'b, S, T, R, M>
+pub struct Recv<'a, 'b, S, T, N>
 where
     S: Storage<Response<T>>,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
-    hdl: &'a mut SocketHdl<'b, S, T, R, M>,
+    hdl: &'a mut SocketHdl<'b, S, T, N>,
 }
 
 struct StoreBox<S: Storage<T>, T: 'static> {
@@ -84,20 +78,13 @@ struct StoreBox<S: Storage<T>, T: 'static> {
 
 // impl Socket
 
-impl<S, T, R, M> Socket<S, T, R, M>
+impl<S, T, N> Socket<S, T, N>
 where
     S: Storage<Response<T>>,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
-    pub const fn new(
-        net: &'static NetStack<R, M>,
-        key: Key,
-        attrs: Attributes,
-        sto: S,
-        name: Option<&str>,
-    ) -> Self {
+    pub const fn new(net: N, key: Key, attrs: Attributes, sto: S, name: Option<&str>) -> Self {
         Self {
             hdr: SocketHeader {
                 links: Links::new(),
@@ -116,11 +103,11 @@ where
         }
     }
 
-    pub fn attach<'a>(self: Pin<&'a mut Self>) -> SocketHdl<'a, S, T, R, M> {
-        let stack = self.net;
+    pub fn attach<'a>(self: Pin<&'a mut Self>) -> SocketHdl<'a, S, T, N> {
+        let stack = self.net.clone();
         let ptr_self: NonNull<Self> = NonNull::from(unsafe { self.get_unchecked_mut() });
         let ptr_erase: NonNull<SocketHeader> = ptr_self.cast();
-        let port = unsafe { stack.attach_socket(ptr_erase) };
+        let port = unsafe { stack.deref().attach_socket(ptr_erase) };
         SocketHdl {
             ptr: ptr_self,
             _lt: PhantomData,
@@ -128,11 +115,11 @@ where
         }
     }
 
-    pub fn attach_broadcast<'a>(self: Pin<&'a mut Self>) -> SocketHdl<'a, S, T, R, M> {
-        let stack = self.net;
+    pub fn attach_broadcast<'a>(self: Pin<&'a mut Self>) -> SocketHdl<'a, S, T, N> {
+        let stack = self.net.clone();
         let ptr_self: NonNull<Self> = NonNull::from(unsafe { self.get_unchecked_mut() });
         let ptr_erase: NonNull<SocketHeader> = ptr_self.cast();
-        unsafe { stack.attach_broadcast_socket(ptr_erase) };
+        unsafe { stack.deref().attach_broadcast_socket(ptr_erase) };
         SocketHdl {
             ptr: ptr_self,
             _lt: PhantomData,
@@ -152,8 +139,8 @@ where
         }
     }
 
-    pub fn stack(&self) -> &'static NetStack<R, M> {
-        self.net
+    pub fn stack(&self) -> N {
+        self.net.clone()
     }
 
     fn recv_err(this: NonNull<()>, hdr: HeaderSeq, err: ProtocolError) {
@@ -230,32 +217,30 @@ where
 
 // impl SocketHdl
 
-impl<'a, S, T, R, M> SocketHdl<'a, S, T, R, M>
+impl<'a, S, T, N> SocketHdl<'a, S, T, N>
 where
     S: Storage<Response<T>>,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
     pub fn port(&self) -> u8 {
         self.port
     }
 
-    pub fn stack(&self) -> &'static NetStack<R, M> {
-        unsafe { *addr_of!((*self.ptr.as_ptr()).net) }
+    pub fn stack(&self) -> N {
+        unsafe { (*addr_of!((*self.ptr.as_ptr()).net)).clone() }
     }
 
-    pub fn recv<'b>(&'b mut self) -> Recv<'b, 'a, S, T, R, M> {
+    pub fn recv<'b>(&'b mut self) -> Recv<'b, 'a, S, T, N> {
         Recv { hdl: self }
     }
 }
 
-impl<S, T, R, M> Drop for Socket<S, T, R, M>
+impl<S, T, N> Drop for Socket<S, T, N>
 where
     S: Storage<Response<T>>,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
     fn drop(&mut self) {
         unsafe {
@@ -265,41 +250,38 @@ where
     }
 }
 
-unsafe impl<S, T, R, M> Send for SocketHdl<'_, S, T, R, M>
+unsafe impl<S, T, N> Send for SocketHdl<'_, S, T, N>
 where
     S: Storage<Response<T>>,
     T: Send,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
 }
 
-unsafe impl<S, T, R, M> Sync for SocketHdl<'_, S, T, R, M>
+unsafe impl<S, T, N> Sync for SocketHdl<'_, S, T, N>
 where
     S: Storage<Response<T>>,
     T: Send,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
 }
 
 // impl Recv
 
-impl<S, T, R, M> Future for Recv<'_, '_, S, T, R, M>
+impl<S, T, N> Future for Recv<'_, '_, S, T, N>
 where
     S: Storage<Response<T>>,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
     type Output = Response<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let net: &'static NetStack<R, M> = self.hdl.stack();
+        let net: N = self.hdl.stack();
         let f = || {
-            let this_ref: &Socket<S, T, R, M> = unsafe { self.hdl.ptr.as_ref() };
+            let this_ref: &Socket<S, T, N> = unsafe { self.hdl.ptr.as_ref() };
             let box_ref: &mut StoreBox<S, Response<T>> = unsafe { &mut *this_ref.inner.get() };
 
             if let Some(resp) = box_ref.sto.try_pop() {
@@ -326,13 +308,12 @@ where
     }
 }
 
-unsafe impl<S, T, R, M> Sync for Recv<'_, '_, S, T, R, M>
+unsafe impl<S, T, N> Sync for Recv<'_, '_, S, T, N>
 where
     S: Storage<Response<T>>,
     T: Send,
     T: Clone + DeserializeOwned + 'static,
-    R: ScopedRawMutex + 'static,
-    M: InterfaceManager + 'static,
+    N: NetStackHandle,
 {
 }
 

--- a/crates/ergot-base/tests/smoke.rs
+++ b/crates/ergot-base/tests/smoke.rs
@@ -44,7 +44,7 @@ async fn hello() {
     };
 
     {
-        let socket = Socket::<Example, _>::new(
+        let socket = Socket::<Example, &_>::new(
             &STACK,
             Key(*b"TEST1234"),
             Attributes {
@@ -220,7 +220,7 @@ async fn hello_err() {
         port_id: 123,
     };
 
-    let socket = Socket::<Example, _>::new(
+    let socket = Socket::<Example, &_>::new(
         &STACK,
         Key(*b"TEST1234"),
         Attributes {
@@ -296,7 +296,7 @@ async fn hello_borrowed() {
 
     static QBUF: BBQueue<Inline<1024>, AtomicCoord, MaiNotSpsc> = BBQueue::new();
 
-    let socket = brw::Socket::<&_, &str, _>::new(
+    let socket = brw::Socket::<&_, &str, &_>::new(
         &STACK,
         Key(*b"TEST1234"),
         Attributes {

--- a/crates/ergot-base/tests/smoke.rs
+++ b/crates/ergot-base/tests/smoke.rs
@@ -44,7 +44,7 @@ async fn hello() {
     };
 
     {
-        let socket = Socket::<Example, _, _>::new(
+        let socket = Socket::<Example, _>::new(
             &STACK,
             Key(*b"TEST1234"),
             Attributes {
@@ -220,7 +220,7 @@ async fn hello_err() {
         port_id: 123,
     };
 
-    let socket = Socket::<Example, _, _>::new(
+    let socket = Socket::<Example, _>::new(
         &STACK,
         Key(*b"TEST1234"),
         Attributes {
@@ -296,7 +296,7 @@ async fn hello_borrowed() {
 
     static QBUF: BBQueue<Inline<1024>, AtomicCoord, MaiNotSpsc> = BBQueue::new();
 
-    let socket = brw::Socket::<&BBQueue<_, _, _>, &str, _, _>::new(
+    let socket = brw::Socket::<&_, &str, _>::new(
         &STACK,
         Key(*b"TEST1234"),
         Attributes {

--- a/crates/ergot/src/book/_01_what_can_you_do.rs
+++ b/crates/ergot/src/book/_01_what_can_you_do.rs
@@ -34,7 +34,7 @@
 //!     // Create the socket for our request type, pin it, then attach to the netstack,
 //!     // Making this socket available to receive requests. A port is automatically
 //!     // assigned for this socket.
-//!     let server_skt = Server::<DoubleEndpoint, _, _>::new(&STACK, 16, None);
+//!     let server_skt = STACK.std_bounded_endpoint_server::<DoubleEndpoint>(16, None);
 //!     let server_skt = pin!(server_skt);
 //!     let mut hdl = server_skt.attach();
 //!

--- a/crates/ergot/src/net_stack.rs
+++ b/crates/ergot/src/net_stack.rs
@@ -194,7 +194,7 @@ where
     ///     // (not shown: starting an `Example` service...)
     ///     # let jhdl = tokio::task::spawn(async {
     ///     #     println!("Serve!");
-    ///     #     let srv = Server::<Example, _, _>::new(&STACK, 16, None);
+    ///     #     let srv = STACK.std_bounded_endpoint_server::<Example>(16, None);
     ///     #     let srv = core::pin::pin!(srv);
     ///     #     let mut hdl = srv.attach();
     ///     #     hdl.serve(async |p| *p as i32).await.unwrap();

--- a/crates/ergot/src/net_stack.rs
+++ b/crates/ergot/src/net_stack.rs
@@ -352,7 +352,7 @@ where
     ) -> crate::socket::topic::stack_vec::Receiver<T, &'_ Self, N>
     where
         T: Topic,
-        T::Message: Serialize + DeserializeOwned + Clone
+        T::Message: Serialize + DeserializeOwned + Clone,
     {
         crate::socket::topic::stack_vec::Receiver::new(self, name)
     }
@@ -365,7 +365,7 @@ where
     ) -> crate::socket::topic::std_bounded::Receiver<T, &'_ Self>
     where
         T: Topic,
-        T::Message: Serialize + DeserializeOwned + Clone
+        T::Message: Serialize + DeserializeOwned + Clone,
     {
         crate::socket::topic::std_bounded::Receiver::new(self, bound, name)
     }

--- a/crates/ergot/src/socket/endpoint.rs
+++ b/crates/ergot/src/socket/endpoint.rs
@@ -1,9 +1,8 @@
 //! Endpoint Client and Server Sockets
 //!
 //! TODO: Explanation of storage choices and examples using `single`.
-use crate::{interface_manager::InterfaceManager, traits::Endpoint};
+use crate::traits::Endpoint;
 use core::pin::{Pin, pin};
-use mutex::ScopedRawMutex;
 use pin_project::pin_project;
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -13,50 +12,46 @@ macro_rules! endpoint_server {
     ($sto: ty, $($arr: ident)?) => {
         /// An endpoint Server Socket, that accepts incoming `E::Request`s.
         #[pin_project::pin_project]
-        pub struct Server<E, R, M, $(const $arr: usize)?>
+        pub struct Server<E, NS, $(const $arr: usize)?>
         where
             E: Endpoint,
             E::Request: Serialize + Clone + DeserializeOwned + 'static,
-            R: ScopedRawMutex + 'static,
-            M: InterfaceManager + 'static,
+            NS: ergot_base::net_stack::NetStackHandle,
         {
             #[pin]
-            sock: $crate::socket::endpoint::raw::Server<$sto, E, R, M>,
+            sock: $crate::socket::endpoint::raw::Server<$sto, E, NS>,
         }
 
         /// An endpoint Server handle
-        pub struct ServerHandle<'a, E, R, M, $(const $arr: usize)?>
+        pub struct ServerHandle<'a, E, NS, $(const $arr: usize)?>
         where
             E: Endpoint,
             E::Request: Serialize + Clone + DeserializeOwned + 'static,
-            R: ScopedRawMutex + 'static,
-            M: InterfaceManager + 'static,
+            NS: ergot_base::net_stack::NetStackHandle,
         {
-            hdl: super::raw::ServerHandle<'a, $sto, E, R, M>,
+            hdl: super::raw::ServerHandle<'a, $sto, E, NS>,
         }
 
 
-        impl<E, R, M, $(const $arr: usize)?> Server<E, R, M, $($arr)?>
+        impl<E, NS, $(const $arr: usize)?> Server<E, NS, $($arr)?>
         where
             E: Endpoint,
             E::Request: Serialize + Clone + DeserializeOwned + 'static,
-            R: ScopedRawMutex + 'static,
-            M: InterfaceManager + 'static,
+            NS: ergot_base::net_stack::NetStackHandle,
         {
             /// Attach the Server to a Netstack and receive a Handle
-            pub fn attach<'a>(self: Pin<&'a mut Self>) -> ServerHandle<'a, E, R, M, $($arr)?> {
+            pub fn attach<'a>(self: Pin<&'a mut Self>) -> ServerHandle<'a, E, NS, $($arr)?> {
                 let this = self.project();
-                let hdl: super::raw::ServerHandle<'_, _, _, R, M> = this.sock.attach();
+                let hdl: super::raw::ServerHandle<'_, _, _, NS> = this.sock.attach();
                 ServerHandle { hdl }
             }
         }
 
-        impl<E, R, M, $(const $arr: usize)?> ServerHandle<'_, E, R, M, $($arr)?>
+        impl<E, NS, $(const $arr: usize)?> ServerHandle<'_, E, NS, $($arr)?>
         where
             E: Endpoint,
             E::Request: Serialize + Clone + DeserializeOwned + 'static,
-            R: ScopedRawMutex + 'static,
-            M: InterfaceManager + 'static,
+            NS: ergot_base::net_stack::NetStackHandle,
         {
             /// The port number of this server handle
             pub fn port(&self) -> u8 {
@@ -98,49 +93,45 @@ macro_rules! endpoint_client {
     ($sto: ty, $($arr: ident)?) => {
         /// An endpoint Client socket, typically used for receiving a response
         #[pin_project]
-        pub struct Client<E, R, M, $(const $arr: usize)?>
+        pub struct Client<E, NS, $(const $arr: usize)?>
         where
             E: Endpoint,
             E::Response: Serialize + Clone + DeserializeOwned + 'static,
-            R: ScopedRawMutex + 'static,
-            M: InterfaceManager + 'static,
+            NS: ergot_base::net_stack::NetStackHandle,
         {
             #[pin]
-            sock: super::raw::Client<$sto, E, R, M>,
+            sock: super::raw::Client<$sto, E, NS>,
         }
 
         /// An endpoint Client Handle
-        pub struct ClientHandle<'a, E, R, M, $(const $arr: usize)?>
+        pub struct ClientHandle<'a, E, NS, $(const $arr: usize)?>
         where
             E: Endpoint,
             E::Response: Serialize + Clone + DeserializeOwned + 'static,
-            R: ScopedRawMutex + 'static,
-            M: InterfaceManager + 'static,
+            NS: ergot_base::net_stack::NetStackHandle,
         {
-            hdl: super::raw::ClientHandle<'a, $sto, E, R, M>,
+            hdl: super::raw::ClientHandle<'a, $sto, E, NS>,
         }
 
-        impl<E, R, M, $(const $arr: usize)?> Client<E, R, M, $($arr)?>
+        impl<E, NS, $(const $arr: usize)?> Client<E, NS, $($arr)?>
         where
             E: Endpoint,
             E::Response: Serialize + Clone + DeserializeOwned + 'static,
-            R: ScopedRawMutex + 'static,
-            M: InterfaceManager + 'static,
+            NS: ergot_base::net_stack::NetStackHandle,
         {
             /// Attach the Client socket to the net stack, and receive a Handle
-            pub fn attach<'a>(self: Pin<&'a mut Self>) -> ClientHandle<'a, E, R, M, $($arr)?> {
+            pub fn attach<'a>(self: Pin<&'a mut Self>) -> ClientHandle<'a, E, NS, $($arr)?> {
                 let this = self.project();
-                let hdl: super::raw::ClientHandle<'_, _, _, R, M> = this.sock.attach();
+                let hdl: super::raw::ClientHandle<'_, _, _, NS> = this.sock.attach();
                 ClientHandle { hdl }
             }
         }
 
-        impl<E, R, M, $(const $arr: usize)?> ClientHandle<'_, E, R, M, $($arr)?>
+        impl<E, NS, $(const $arr: usize)?> ClientHandle<'_, E, NS, $($arr)?>
         where
             E: Endpoint,
             E::Response: Serialize + Clone + DeserializeOwned + 'static,
-            R: ScopedRawMutex + 'static,
-            M: InterfaceManager + 'static,
+            NS: ergot_base::net_stack::NetStackHandle,
         {
             /// The port of this Client socket
             pub fn port(&self) -> u8 {
@@ -160,6 +151,7 @@ pub mod raw {
     use super::*;
     use ergot_base::{
         FrameKind,
+        net_stack::NetStackHandle,
         socket::{
             Attributes,
             raw_owned::{self, Storage},
@@ -167,65 +159,60 @@ pub mod raw {
     };
 
     #[pin_project]
-    pub struct Server<S, E, R, M>
+    pub struct Server<S, E, NS>
     where
         S: Storage<Response<E::Request>>,
         E: Endpoint,
         E::Request: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
         #[pin]
-        sock: raw_owned::Socket<S, E::Request, R, M>,
+        sock: raw_owned::Socket<S, E::Request, NS>,
     }
 
     #[pin_project]
-    pub struct Client<S, E, R, M>
+    pub struct Client<S, E, NS>
     where
         S: Storage<Response<E::Response>>,
         E: Endpoint,
         E::Response: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
         #[pin]
-        sock: raw_owned::Socket<S, E::Response, R, M>,
+        sock: raw_owned::Socket<S, E::Response, NS>,
     }
 
-    pub struct ServerHandle<'a, S, E, R, M>
+    pub struct ServerHandle<'a, S, E, NS>
     where
         S: Storage<Response<E::Request>>,
         E: Endpoint,
         E::Request: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        hdl: raw_owned::SocketHdl<'a, S, E::Request, R, M>,
+        hdl: raw_owned::SocketHdl<'a, S, E::Request, NS>,
     }
 
-    pub struct ClientHandle<'a, S, E, R, M>
+    pub struct ClientHandle<'a, S, E, NS>
     where
         S: Storage<Response<E::Response>>,
         E: Endpoint,
         E::Response: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        hdl: raw_owned::SocketHdl<'a, S, E::Response, R, M>,
+        hdl: raw_owned::SocketHdl<'a, S, E::Response, NS>,
     }
 
-    impl<S, E, R, M> Server<S, E, R, M>
+    impl<S, E, NS> Server<S, E, NS>
     where
         S: Storage<Response<E::Request>>,
         E: Endpoint,
         E::Request: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        pub const fn new(net: &'static crate::NetStack<R, M>, sto: S, name: Option<&str>) -> Self {
+        pub fn new(net: NS, sto: S, name: Option<&str>) -> Self {
             Self {
                 sock: raw_owned::Socket::new(
-                    &net.inner,
+                    net.stack(),
                     base::Key(E::REQ_KEY.to_bytes()),
                     Attributes {
                         kind: FrameKind::ENDPOINT_REQ,
@@ -237,20 +224,19 @@ pub mod raw {
             }
         }
 
-        pub fn attach<'a>(self: Pin<&'a mut Self>) -> ServerHandle<'a, S, E, R, M> {
+        pub fn attach<'a>(self: Pin<&'a mut Self>) -> ServerHandle<'a, S, E, NS> {
             let this = self.project();
-            let hdl: raw_owned::SocketHdl<'_, S, E::Request, R, M> = this.sock.attach();
+            let hdl: raw_owned::SocketHdl<'_, S, E::Request, NS> = this.sock.attach();
             ServerHandle { hdl }
         }
     }
 
-    impl<S, E, R, M> ServerHandle<'_, S, E, R, M>
+    impl<S, E, NS> ServerHandle<'_, S, E, NS>
     where
         S: Storage<Response<E::Request>>,
         E: Endpoint,
         E::Request: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
         pub fn port(&self) -> u8 {
             self.hdl.port()
@@ -323,18 +309,17 @@ pub mod raw {
         }
     }
 
-    impl<S, E, R, M> Client<S, E, R, M>
+    impl<S, E, NS> Client<S, E, NS>
     where
         S: Storage<Response<E::Response>>,
         E: Endpoint,
         E::Response: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        pub const fn new(net: &'static crate::NetStack<R, M>, sto: S, name: Option<&str>) -> Self {
+        pub fn new(net: NS, sto: S, name: Option<&str>) -> Self {
             Self {
                 sock: raw_owned::Socket::new(
-                    &net.inner,
+                    net.stack(),
                     base::Key(E::RESP_KEY.to_bytes()),
                     Attributes {
                         kind: FrameKind::ENDPOINT_RESP,
@@ -346,20 +331,19 @@ pub mod raw {
             }
         }
 
-        pub fn attach<'a>(self: Pin<&'a mut Self>) -> ClientHandle<'a, S, E, R, M> {
+        pub fn attach<'a>(self: Pin<&'a mut Self>) -> ClientHandle<'a, S, E, NS> {
             let this = self.project();
-            let hdl: raw_owned::SocketHdl<'_, S, E::Response, R, M> = this.sock.attach();
+            let hdl: raw_owned::SocketHdl<'_, S, E::Response, NS> = this.sock.attach();
             ClientHandle { hdl }
         }
     }
 
-    impl<S, E, R, M> ClientHandle<'_, S, E, R, M>
+    impl<S, E, NS> ClientHandle<'_, S, E, NS>
     where
         S: Storage<Response<E::Response>>,
         E: Endpoint,
         E::Response: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
         pub fn port(&self) -> u8 {
             self.hdl.port()
@@ -373,18 +357,19 @@ pub mod raw {
 
 /// Endpoint Client/Server sockets using [`Option<T>`] storage
 pub mod single {
+    use ergot_base::net_stack::NetStackHandle;
+
     use super::*;
 
     endpoint_server!(Option<Response<E::Request>>,);
 
-    impl<E, R, M> Server<E, R, M>
+    impl<E, NS> Server<E, NS>
     where
         E: Endpoint,
         E::Request: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        pub const fn new(net: &'static crate::NetStack<R, M>, name: Option<&str>) -> Self {
+        pub fn new(net: NS, name: Option<&str>) -> Self {
             Self {
                 sock: super::raw::Server::new(net, None, name),
             }
@@ -393,14 +378,13 @@ pub mod single {
 
     endpoint_client!(Option<Response<E::Response>>,);
 
-    impl<E, R, M> Client<E, R, M>
+    impl<E, NS> Client<E, NS>
     where
         E: Endpoint,
         E::Response: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        pub const fn new(net: &'static crate::NetStack<R, M>, name: Option<&str>) -> Self {
+        pub fn new(net: NS, name: Option<&str>) -> Self {
             Self {
                 sock: super::raw::Client::new(net, None, name),
             }
@@ -410,20 +394,19 @@ pub mod single {
 
 /// Endpoint Client/Server sockets using [`stack_vec::Bounded`](base::socket::owned::stack_vec::Bounded) storage
 pub mod stack_vec {
-    use ergot_base::socket::owned::stack_vec::Bounded;
+    use ergot_base::{net_stack::NetStackHandle, socket::owned::stack_vec::Bounded};
 
     use super::*;
 
     endpoint_server!(Bounded<Response<E::Request>, N>, N);
 
-    impl<E, R, M, const N: usize> Server<E, R, M, N>
+    impl<E, NS, const N: usize> Server<E, NS, N>
     where
         E: Endpoint,
         E::Request: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        pub const fn new(net: &'static crate::NetStack<R, M>, name: Option<&str>) -> Self {
+        pub fn new(net: NS, name: Option<&str>) -> Self {
             Self {
                 sock: super::raw::Server::new(net, Bounded::new(), name),
             }
@@ -432,14 +415,13 @@ pub mod stack_vec {
 
     endpoint_client!(Bounded<Response<E::Response>, N>, N);
 
-    impl<E, R, M, const N: usize> Client<E, R, M, N>
+    impl<E, NS, const N: usize> Client<E, NS, N>
     where
         E: Endpoint,
         E::Response: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        pub const fn new(net: &'static crate::NetStack<R, M>, name: Option<&str>) -> Self {
+        pub fn new(net: NS, name: Option<&str>) -> Self {
             Self {
                 sock: super::raw::Client::new(net, Bounded::new(), name),
             }
@@ -453,20 +435,19 @@ pub mod stack_vec {
 /// Endpoint Client/Server sockets using [`std_bounded::Bounded`](base::socket::owned::std_bounded::Bounded) storage
 #[cfg(feature = "std")]
 pub mod std_bounded {
-    use ergot_base::socket::owned::std_bounded::Bounded;
+    use ergot_base::{net_stack::NetStackHandle, socket::owned::std_bounded::Bounded};
 
     use super::*;
 
     endpoint_server!(Bounded<Response<E::Request>>,);
 
-    impl<E, R, M> Server<E, R, M>
+    impl<E, NS> Server<E, NS>
     where
         E: Endpoint,
         E::Request: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        pub fn new(net: &'static crate::NetStack<R, M>, bound: usize, name: Option<&str>) -> Self {
+        pub fn new(net: NS, bound: usize, name: Option<&str>) -> Self {
             Self {
                 sock: super::raw::Server::new(net, Bounded::with_bound(bound), name),
             }
@@ -475,14 +456,13 @@ pub mod std_bounded {
 
     endpoint_client!(Bounded<Response<E::Response>>,);
 
-    impl<E, R, M> Client<E, R, M>
+    impl<E, NS> Client<E, NS>
     where
         E: Endpoint,
         E::Response: Serialize + Clone + DeserializeOwned + 'static,
-        R: ScopedRawMutex + 'static,
-        M: InterfaceManager + 'static,
+        NS: NetStackHandle,
     {
-        pub fn new(net: &'static crate::NetStack<R, M>, bound: usize, name: Option<&str>) -> Self {
+        pub fn new(net: NS, bound: usize, name: Option<&str>) -> Self {
             Self {
                 sock: super::raw::Client::new(net, Bounded::with_bound(bound), name),
             }

--- a/crates/ergot/tests/smoke.rs
+++ b/crates/ergot/tests/smoke.rs
@@ -7,7 +7,6 @@ use ergot::{
         wire_frames::{CommonHeader, encode_frame_ty},
     },
     interface_manager::null::NullInterfaceManager,
-    socket::endpoint::single::Server,
     traits::Endpoint,
 };
 use ergot_base::{AnyAllAppendix, DEFAULT_TTL, Key};
@@ -53,7 +52,7 @@ async fn hello() {
     };
 
     {
-        let socket = Server::<ExampleEndpoint, _, _>::new(&STACK, None);
+        let socket = STACK.stack_bounded_endpoint_server::<ExampleEndpoint, 2>(None);
         let mut socket = pin!(socket);
         let mut hdl = socket.as_mut().attach();
 
@@ -217,7 +216,7 @@ async fn req_resp() {
     static STACK: TestNetStack = NetStack::new();
 
     // Start the server...
-    let server = Server::<ExampleEndpoint, _, _>::new(&STACK, None);
+    let server = STACK.stack_bounded_endpoint_server::<ExampleEndpoint, 2>(None);
     let server = pin!(server);
     let mut server_hdl = server.attach();
 
@@ -264,11 +263,10 @@ async fn req_resp() {
 
 #[tokio::test]
 async fn req_resp_stack_vec() {
-    use ergot::socket::endpoint::stack_vec::Server;
     static STACK: TestNetStack = NetStack::new();
 
     // Start the server...
-    let server = Server::<ExampleEndpoint, _, _, 64>::new(&STACK, None);
+    let server = STACK.stack_bounded_endpoint_server::<ExampleEndpoint, 64>(None);
     let server = pin!(server);
     let mut server_hdl = server.attach();
 

--- a/demos/ergot-client/src/main.rs
+++ b/demos/ergot-client/src/main.rs
@@ -1,7 +1,6 @@
 use ergot::{
     NetStack,
     interface_manager::std_tcp_client::{StdTcpClientIm, register_interface},
-    socket::{endpoint::std_bounded::Server, topic::std_bounded::Receiver},
     topic,
     well_known::ErgotPingEndpoint,
 };
@@ -37,7 +36,7 @@ async fn main() -> io::Result<()> {
 }
 
 async fn pingserver() {
-    let server = Server::<ErgotPingEndpoint, _, _>::new(&STACK, 16, None);
+    let server = STACK.std_bounded_endpoint_server::<ErgotPingEndpoint>(16, None);
     let server = pin!(server);
     let mut server_hdl = server.attach();
     loop {
@@ -66,7 +65,7 @@ async fn yeeter() {
 }
 
 async fn yeet_listener(id: u8) {
-    let subber = Receiver::<YeetTopic, _, _>::new(&STACK, 64, None);
+    let subber = STACK.std_bounded_topic_receiver::<YeetTopic>(64, None);
     let subber = pin!(subber);
     let mut hdl = subber.subscribe();
 

--- a/demos/ergot-nusb-router/src/main.rs
+++ b/demos/ergot-nusb-router/src/main.rs
@@ -2,7 +2,6 @@ use ergot::{
     Address, NetStack,
     ergot_base::interface_manager::nusb_0_1_router::{find_new_devices, register_interface},
     interface_manager::nusb_0_1_router::NusbManager,
-    socket::topic::std_bounded::Receiver,
     topic,
     well_known::ErgotPingEndpoint,
 };
@@ -80,7 +79,7 @@ async fn ping_all() {
 }
 
 async fn yeet_listener(id: u8) {
-    let subber = Receiver::<YeetTopic, _, _>::new(&STACK, 64, None);
+    let subber = STACK.std_bounded_topic_receiver::<YeetTopic>(64, None);
     let subber = pin!(subber);
     let mut hdl = subber.subscribe();
 

--- a/demos/ergot-router/src/main.rs
+++ b/demos/ergot-router/src/main.rs
@@ -1,7 +1,6 @@
 use ergot::{
     Address, NetStack,
     interface_manager::std_tcp_router::{StdTcpIm, register_interface},
-    socket::topic::std_bounded::Receiver,
     topic,
     well_known::ErgotPingEndpoint,
 };
@@ -74,7 +73,7 @@ async fn ping_all() {
 }
 
 async fn yeet_listener(id: u8) {
-    let subber = Receiver::<YeetTopic, _, _>::new(&STACK, 64, None);
+    let subber = STACK.std_bounded_topic_receiver::<YeetTopic>(64, None);
     let subber = pin!(subber);
     let mut hdl = subber.subscribe();
 

--- a/demos/nrf52840-eusb/src/main.rs
+++ b/demos/nrf52840-eusb/src/main.rs
@@ -27,7 +27,6 @@ use ergot::{
     interface_manager::eusb_0_4_client::{
         self, EmbassyUsbManager, WireStorage, DEFAULT_TIMEOUT_MS_PER_FRAME, USB_FS_MAX_PACKET_SIZE,
     },
-    socket::{endpoint::stack_vec::Server, topic::stack_vec::Receiver},
     topic,
     well_known::ErgotPingEndpoint,
     Address, NetStack,
@@ -161,7 +160,7 @@ topic!(YeetTopic, u64, "topic/yeet");
 
 #[task]
 async fn pingserver() {
-    let server = Server::<ErgotPingEndpoint, _, _, 4>::new(&STACK, None);
+    let server = STACK.stack_bounded_endpoint_server::<ErgotPingEndpoint, 4>(None);
     let server = pin!(server);
     let mut server_hdl = server.attach();
     loop {
@@ -214,7 +213,7 @@ async fn run_tx(
 
 #[task(pool_size = 2)]
 async fn press_listener(idx: u8) {
-    let recv: Receiver<ButtonPressedTopic, _, _, 4> = Receiver::new(&STACK, None);
+    let recv = STACK.stack_bounded_topic_receiver::<ButtonPressedTopic, 4>(None);
     let recv = pin!(recv);
     let mut recv = recv.subscribe();
 
@@ -226,7 +225,7 @@ async fn press_listener(idx: u8) {
 
 #[task(pool_size = 4)]
 async fn led_server(name: &'static str, mut led: Output<'static>) {
-    let socket: Server<LedEndpoint, _, _, 4> = Server::new(&STACK, Some(name));
+    let socket = STACK.stack_bounded_endpoint_server::<LedEndpoint, 4>(Some(name));
     let socket = pin!(socket);
     let mut hdl = socket.attach();
 

--- a/demos/nrf52840-null/src/main.rs
+++ b/demos/nrf52840-null/src/main.rs
@@ -12,12 +12,7 @@ use embassy_nrf::{
     gpio::{Input, Level, Output, OutputDrive, Pull},
 };
 use embassy_time::{Duration, WithTimeout};
-use ergot::{
-    endpoint,
-    interface_manager::null::NullInterfaceManager,
-    socket::{endpoint::stack_vec::Server, topic::stack_vec::Receiver},
-    topic, Address, NetStack,
-};
+use ergot::{endpoint, interface_manager::null::NullInterfaceManager, topic, Address, NetStack};
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 
 use {defmt_rtt as _, panic_probe as _};
@@ -68,7 +63,7 @@ async fn main(spawner: Spawner) {
 
 #[task(pool_size = 2)]
 async fn press_listener(idx: u8) {
-    let recv: Receiver<ButtonPressedTopic, _, _, 4> = Receiver::new(&STACK, None);
+    let recv = STACK.stack_bounded_topic_receiver::<ButtonPressedTopic, 4>(None);
     let recv = pin!(recv);
     let mut recv = recv.subscribe();
 
@@ -80,7 +75,7 @@ async fn press_listener(idx: u8) {
 
 #[task(pool_size = 4)]
 async fn led_server(name: &'static str, mut led: Output<'static>) {
-    let socket: Server<LedEndpoint, _, _, 4> = Server::new(&STACK, Some(name));
+    let socket = STACK.stack_bounded_endpoint_server::<LedEndpoint, 4>(Some(name));
     let socket = pin!(socket);
     let mut hdl = socket.attach();
 


### PR DESCRIPTION
This PR introduces a `NetStackHandle` trait, inspired by [bbq2's BbqHandle](https://docs.rs/bbq2/latest/bbq2/traits/bbqhdl/index.html).

This allows for:

* one fewer generic in most places (sockets are generic over `NetStackHandle` instead of `ScopedRawMutex` and `InterfaceManager`)
* Insulates sockets if we add a `SocketManager` and `TimeManager` generic to `NetStack`
* Starts to pave the way for `Arc<NetStack>`

