### PR TITLE
Split "std" and "tokio-std" features

### DIFF
--- a/crates/ergot/Cargo.toml
+++ b/crates/ergot/Cargo.toml
@@ -26,7 +26,7 @@ disable-cache-padding = [
     "cordyceps/no-cache-pad",
     "maitake-sync/no-cache-pad",
 ]
-tokio-std = [
+std = [
     "bbq2/std",
     "cobs-acc/std",
     "cobs/std",
@@ -35,8 +35,11 @@ tokio-std = [
     "maitake-sync/std",
     "mutex/std",
     "postcard/use-std",
-    "tokio",
     "postcard-schema/use-std",
+]
+tokio-std = [
+    "tokio",
+    "std",
 ]
 embassy-usb-v0_4 = [
     "defmt-v1",

--- a/crates/ergot/src/fmtlog.rs
+++ b/crates/ergot/src/fmtlog.rs
@@ -46,7 +46,7 @@ pub struct ErgotFmtRx<'a> {
 /// An owned format message for receiving
 ///
 /// Type-punned with [`ErgotFmtRx`] and [`ErgotFmtTx`]
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 #[derive(Serialize, Deserialize, Schema, Clone)]
 pub struct ErgotFmtRxOwned {
     pub level: Level,

--- a/crates/ergot/src/interface_manager/utils/mod.rs
+++ b/crates/ergot/src/interface_manager/utils/mod.rs
@@ -1,7 +1,5 @@
 pub mod cobs_stream;
 pub mod framed_stream;
 
-// TODO: Maybe this should be guarded by a different feature flag ?
-// it has nothing to do with the impl details of the TokioTcpInterface.
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 pub mod std;

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(not(any(test, feature = "tokio-std")), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![allow(clippy::uninlined_format_args)]
 
 pub mod address;

--- a/crates/ergot/src/net_stack/endpoints.rs
+++ b/crates/ergot/src/net_stack/endpoints.rs
@@ -194,7 +194,7 @@ impl<NS: NetStackHandle> Endpoints<NS> {
         crate::socket::endpoint::stack_vec::Server::new(self.inner, name)
     }
 
-    #[cfg(feature = "tokio-std")]
+    #[cfg(feature = "std")]
     pub fn heap_bounded_server<E: Endpoint>(
         self,
         bound: usize,

--- a/crates/ergot/src/net_stack/mod.rs
+++ b/crates/ergot/src/net_stack/mod.rs
@@ -34,12 +34,12 @@ use crate::{
     well_known::ErgotFmtTxTopic,
 };
 
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 pub mod arc;
 mod inner;
 pub mod services;
 
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 pub use arc::ArcNetStack;
 use inner::NetStackInner;
 pub use services::Services;
@@ -136,13 +136,12 @@ where
     R: ScopedRawMutex + ConstInit,
     P: Profile,
 {
-    pub fn new_arc(p: P) -> std::sync::Arc<Self> {
+    pub(crate) fn new_arc(p: P) -> std::sync::Arc<Self> {
         std::sync::Arc::new(Self {
             inner: BlockingMutex::new(NetStackInner::new_with_profile(p)),
         })
     }
 }
-
 impl<R, P> NetStack<R, P>
 where
     R: ScopedRawMutex,

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 use crate::{
     fmtlog::ErgotFmtRxOwned, net_stack::topics::Topics, socket::HeaderMessage,
     well_known::ErgotFmtRxOwnedTopic,
@@ -28,7 +28,7 @@ impl<NS: NetStackHandle> Services<NS> {
         }
     }
 
-    #[cfg(feature = "tokio-std")]
+    #[cfg(feature = "std")]
     pub async fn generic_log_handler<F>(&self, depth: usize, f: F) -> !
     where
         F: Fn(HeaderMessage<ErgotFmtRxOwned>),
@@ -46,7 +46,7 @@ impl<NS: NetStackHandle> Services<NS> {
         }
     }
 
-    #[cfg(feature = "tokio-std")]
+    #[cfg(feature = "std")]
     pub async fn default_stdout_log_handler(&self, depth: usize) -> ! {
         self.generic_log_handler(depth, |msg| {
             println!(

--- a/crates/ergot/src/net_stack/topics.rs
+++ b/crates/ergot/src/net_stack/topics.rs
@@ -36,7 +36,7 @@ impl<NS: NetStackHandle> Topics<NS> {
         crate::socket::topic::stack_vec::Receiver::new(self.inner, name)
     }
 
-    #[cfg(feature = "tokio-std")]
+    #[cfg(feature = "std")]
     pub fn heap_bounded_receiver<T>(
         self,
         bound: usize,
@@ -49,7 +49,7 @@ impl<NS: NetStackHandle> Topics<NS> {
         crate::socket::topic::std_bounded::Receiver::new(self.inner, bound, name)
     }
 
-    #[cfg(feature = "tokio-std")]
+    #[cfg(feature = "std")]
     pub fn heap_bounded_borrowed_receiver<T>(
         self,
         bound: usize,

--- a/crates/ergot/src/socket/endpoint.rs
+++ b/crates/ergot/src/socket/endpoint.rs
@@ -438,7 +438,7 @@ pub mod stack_vec {
 // TODO: Do we need some kind of Socket trait we can use to dedupe things like this?
 
 /// Endpoint Client/Server sockets using [`std_bounded::Bounded`](base::socket::owned::std_bounded::Bounded) storage
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 pub mod std_bounded {
     use crate::{net_stack::NetStackHandle, socket::owned::std_bounded::Bounded};
 

--- a/crates/ergot/src/socket/owned.rs
+++ b/crates/ergot/src/socket/owned.rs
@@ -158,7 +158,7 @@ pub mod single {
     }
 }
 
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 pub mod std_bounded {
     use serde::de::DeserializeOwned;
     use std::collections::VecDeque;

--- a/crates/ergot/src/socket/topic.rs
+++ b/crates/ergot/src/socket/topic.rs
@@ -196,7 +196,7 @@ pub mod stack_vec {
 }
 
 /// Topic sockets using [`std_bounded::Bounded`](base::socket::owned::std_bounded::Bounded) storage
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 pub mod std_bounded {
     use crate::socket::owned::std_bounded::Bounded;
 

--- a/crates/ergot/src/well_known.rs
+++ b/crates/ergot/src/well_known.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 use crate::fmtlog::ErgotFmtRxOwned;
 use crate::fmtlog::{ErgotFmtRx, ErgotFmtTx};
 use crate::{endpoint, topic};
@@ -7,7 +7,7 @@ endpoint!(ErgotPingEndpoint, u32, u32, "ergot/.well-known/ping");
 topic!(ErgotFmtTxTopic, ErgotFmtTx<'a>, "ergot/.well-known/fmt");
 topic!(ErgotFmtRxTopic, ErgotFmtRx<'a>, "ergot/.well-known/fmt");
 
-#[cfg(feature = "tokio-std")]
+#[cfg(feature = "std")]
 topic!(
     ErgotFmtRxOwnedTopic,
     ErgotFmtRxOwned,


### PR DESCRIPTION
This PR splits the "tokio-std" feature into "std", which isn't tokio-dependent, and "tokio-std", which is, and depends on the "std" feature.

There are sockets that are not tokio-specific, which makes the distinction more clear.