### PR TITLE
all rust targets for nix flake dev shell

### DIFF
--- a/checkall.sh
+++ b/checkall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/crates/ergot/miri.sh
+++ b/crates/ergot/miri.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # We disable isolation because we use tokio sleep
 # We test on linux because currently just pulling in the net stuff for

--- a/fmtall.sh
+++ b/fmtall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 
@@ -13,4 +13,3 @@ cargo fmt --all --manifest-path=./demos/nrf52840/Cargo.toml
 cargo fmt --all --manifest-path=./demos/rp2040/Cargo.toml
 cargo fmt --all --manifest-path=./demos/rp2350/Cargo.toml
 cargo fmt --all --manifest-path=./demos/esp32c6/Cargo.toml
-


### PR DESCRIPTION
also changed the shebang to be properly portable (specifically so i can use the
bash scripts)
