### PR TITLE
Use failable methods to avoid a panicking deadlock

### DIFF
--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -107,6 +107,7 @@ impl ProtocolError {
     pub const NSSE_WRONG_PORT_KIND: Self = Self(23);
     pub const NSSE_ANY_PORT_NOT_UNIQUE: Self = Self(24);
     pub const NSSE_ALL_PORT_MISSING_KEY: Self = Self(25);
+    pub const NSSE_WOULD_DEADLOCK: Self = Self(26);
 }
 
 impl Header {


### PR DESCRIPTION
For example, if we were to try to send data while sending data, this will now return an error, instead of likely panicking.

This may have been part of the issue Tommaso saw when adding `log` support for ergot: if we tried to send a log WHILE sending another packet, the mutex would already be locked.