### PR TITLE
Use matrix strategy to build demos-std for all OS

### DIFF
--- a/.github/workflows/build-demos-std.yml
+++ b/.github/workflows/build-demos-std.yml
@@ -10,7 +10,13 @@ on:
 jobs:
   demos-std:
     name: "Build all std demos"
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: windows-2022
+          - os: ubuntu-latest
+          - os: macos-14
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       #


### PR DESCRIPTION
According to the demos folder readme:

```
std - meant to run on typical desktop platforms (win/mac/linux)
```

but CI currently doesn't currently test whether you could actually build for those platforms, and as such, it doesn't (on windows).

I've tested this workflow in a private fork, so it *should* work.
<img width="785" height="525" alt="image" src="https://github.com/user-attachments/assets/47175299-7210-454f-a46c-9a49745ca382" />
