### PR TITLE
Fix readmes: broken links, copy/past error, add stream-plotting to tilt-bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ This name was chosen in line with the naming theme of the [mycelium](https://git
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+- Apache License, Version 2.0 ([LICENSE-APACHE](./blob/main/crates/ergot/LICENSE-APACHE) or
   <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- MIT license ([LICENSE-MIT](./blob/main/crates/ergot/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ This name was chosen in line with the naming theme of the [mycelium](https://git
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](./blob/main/crates/ergot/LICENSE-APACHE) or
+- Apache License, Version 2.0 ([LICENSE-APACHE](./crates/ergot/LICENSE-APACHE) or
   <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](./blob/main/crates/ergot/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- MIT license ([LICENSE-MIT](./crates/ergot/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -8,7 +8,7 @@ Currently, there are demos for:
 
 * `std` - meant to run on typical desktop platforms (win/mac/linux)
 * `esp32c6` - Applications for the ESP32-C6 platform, typically using the `ESP32-C6-DevKitC-1`
-* `rp2350` - Applications for the RP2040 platform, typically using a `Pico2` development board, with or without a debugger.
+* `rp2350` - Applications for the RP2350 platform, typically using a `Pico2` development board, with or without a debugger.
 * `rp2040` - Applications for the RP2040 platform, typically using a `Pico` development board, with or without a debugger.
 * `nrf52840` - Applications for the `nRF52840` platform, typically using an `nRF52840-DK`
 
@@ -34,10 +34,12 @@ The "Tilt App" demo consists of three parts:
 * The [`rp2350-tilt`] firmware project, running on an RP2350
 * The [`tilt-app`] host project, running on a PC
 * The [`shared-icd`] library crate, used by both the firmware and PC projects
+* The [`stream-plotting`] project, running on a PC, uses a simple GUI to live-stream the data from the tilt board
 
 [`rp2350-tilt`]: ./rp2350/rp2350-tilt/README.md
 [`tilt-app`]: ./std/tilt-app/README.md
 [`shared-icd`]: ./shared-icd/README.md
+[`stream-plotting`]: ./std/stream-plotting/README.md
 
 The board has an LSM6DS3TR accelerometer + gyroscope, eight PWM output channels, and
 an RP2350. This demo has the firmware stream the accelerometer and gyroscope data at

--- a/demos/rp2350/rp2350-tilt/README.md
+++ b/demos/rp2350/rp2350-tilt/README.md
@@ -1,10 +1,10 @@
 # RP2350 "Tilt" board
 
-![A 3d render of a circuit board](./../tilt-blink-board.png)
+![A 3d render of a circuit board](../../tilt-blink-board.png)
 
 This firmware is intended for a custom board containing an RP2350,
 accelerometer, and PWM outputs. This firmware showcases streaming a relatively
 high volume of data over USB.
 
-See the [top level demos docs](../README.md) for more information and links to
+See the [top level demos docs](../../README.md) for more information and links to
 the desktop application side of this demo.


### PR DESCRIPTION
Found some broken links and small copy/paste mistakes:

- Fixed broken links
- Change RP2040 to RP2350 where appropriate
- Added stream-plotting demo to the demo readme overview, as it seems to bundle all the tilt app features.