### PR TITLE
Add Display impl for Address and Header, use in logging

### DIFF
--- a/crates/ergot/src/address.rs
+++ b/crates/ergot/src/address.rs
@@ -97,6 +97,13 @@ pub struct Address {
     pub port_id: u8,
 }
 
+impl core::fmt::Display for Address {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}.{}:{}", self.network_id, self.node_id, self.port_id)?;
+        Ok(())
+    }
+}
+
 // ---- impl Address ----
 
 impl Address {

--- a/crates/ergot/src/conformance/net_stack.rs
+++ b/crates/ergot/src/conformance/net_stack.rs
@@ -168,7 +168,7 @@ pub mod mocks {
             data: &T,
         ) -> Result<(), InterfaceSendError> {
             let data = postcard::to_stdvec(data).expect("Serializing send failed");
-            log::trace!("Sending hdr:{hdr:?}, data:{data:02X?}");
+            log::trace!("{hdr}: Sending data:{data:02X?}");
             let now = self.expected_sends.pop_front().expect("Unexpected send");
             assert_eq!(&now.hdr, hdr, "Send header mismatch");
             assert_eq!(&now.data, &data, "Send data mismatch");

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
@@ -240,7 +240,7 @@ pub fn process_frame<N>(
         return;
     };
 
-    debug!("Got Frame! {:?}", frame.hdr);
+    debug!("{}: Got Frame!", frame.hdr);
 
     let take_net = net_id.is_none()
         || net_id.is_some_and(|n| frame.hdr.dst.network_id != 0 && n != frame.hdr.dst.network_id);

--- a/crates/ergot/src/interface_manager/profiles/direct_router/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_router/mod.rs
@@ -523,7 +523,7 @@ pub fn process_frame<N>(
     // Successfully received a packet, now we need to
     // do something with it.
     if let Some(mut frame) = de_frame(data) {
-        trace!("got frame: {:?} from {ident:?}", frame.hdr);
+        trace!("{} got frame from {ident:?}", frame.hdr);
         // If the message comes in and has a src net_id of zero,
         // we should rewrite it so it isn't later understood as a
         // local packet.
@@ -549,7 +549,7 @@ pub fn process_frame<N>(
             Ok(()) => {}
             Err(e) => {
                 // TODO: match on error, potentially try to send NAK?
-                warn!("recv->send error: {e:?}");
+                warn!("{} recv->send error: {e:?}", frame.hdr);
             }
         }
     } else {
@@ -607,7 +607,7 @@ mod edge_interface_plus {
                 InterfaceState::Active { net_id, node_id: _ } => *net_id,
             };
 
-            trace!("common_send header: {:?}", ihdr);
+            trace!("{ihdr} common_send");
 
             // TODO: when this WAS a real Profile, we did a lot of these things, but
             // now they should be done by the router. For now, we just have asserts,

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -66,6 +66,34 @@ pub struct HeaderSeq {
     pub ttl: u8,
 }
 
+impl core::fmt::Display for Header {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "({} -> {}; FK:{:03}, SQ: ",
+            self.src, self.dst, self.kind.0,
+        )?;
+        if let Some(seq) = self.seq_no {
+            write!(f, "{seq:04X}")?;
+        } else {
+            f.write_str("----")?;
+        }
+        f.write_str(")")?;
+        Ok(())
+    }
+}
+
+impl core::fmt::Display for HeaderSeq {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "({} -> {}; FK:{:03}, SQ: {:04X})",
+            self.src, self.dst, self.kind.0, self.seq_no,
+        )?;
+        Ok(())
+    }
+}
+
 impl FrameKind {
     pub const RESERVED: Self = Self(0);
     pub const ENDPOINT_REQ: Self = Self(1);

--- a/crates/ergot/src/net_stack/inner.rs
+++ b/crates/ergot/src/net_stack/inner.rs
@@ -68,14 +68,14 @@ where
         SendSockets: FnMut(NonNull<SocketHeader>) -> bool,
         SendProfile: FnOnce() -> bool,
     {
-        trace!("Sending msg broadcast w/ header: {hdr:?}");
+        trace!("{hdr}: Sending msg broadcast");
         let res_lcl = {
             let bcast_iter = Self::find_all_local(sockets, hdr)?;
             let mut any_found = false;
             for dst in bcast_iter {
                 let res = sskt(dst);
                 if res {
-                    debug!("delivered broadcast message locally");
+                    debug!("{hdr}: delivered broadcast message locally");
                 }
                 any_found |= res;
             }
@@ -84,7 +84,7 @@ where
 
         let res_rmt = smgr();
         if res_rmt {
-            debug!("delivered broadcast message remotely");
+            debug!("{hdr}: delivered broadcast message remotely");
         }
 
         if res_lcl || res_rmt {
@@ -108,13 +108,13 @@ where
         SendSockets: FnOnce(NonNull<SocketHeader>) -> Result<(), NetStackSendError>,
         SendProfile: FnOnce() -> Result<(), InterfaceSendError>,
     {
-        trace!("Sending msg unicast w/ header: {hdr:?}");
+        trace!("{hdr}: Sending msg unicast");
         // Can we assume the destination is local?
         let local_bypass = hdr.src.net_node_any() && hdr.dst.net_node_any();
 
         let res = if !local_bypass {
             // Not local: offer to the interface manager to send
-            debug!("Offering msg externally unicast w/ header: {hdr:?}");
+            debug!("{hdr}: Offering msg externally unicast");
             smgr()
         } else {
             // just skip to local sending
@@ -123,23 +123,23 @@ where
 
         match res {
             Ok(()) => {
-                debug!("Externally routed msg unicast");
+                debug!("{hdr}: Externally routed msg unicast");
                 return Ok(());
             }
             // "Destination Local" and "Routing Loop" can both be returned when there is no
             // interface interest, but are non-fatal.
             Err(InterfaceSendError::DestinationLocal) | Err(InterfaceSendError::RoutingLoop) => {
-                debug!("No external interest in msg unicast");
+                debug!("{hdr}: No external interest in msg unicast");
             }
             Err(e) => return Err(NetStackSendError::InterfaceSend(e)),
         }
 
         // It was a destination local error, try to honor that
         let socket = if hdr.dst.port_id == 0 {
-            debug!("Sending ANY unicast msg locally w/ header: {hdr:?}");
+            debug!("{hdr}: Sending ANY unicast msg locally");
             Self::find_any_local(sockets, hdr)
         } else {
-            debug!("Sending ONE unicast msg locally w/ header: {hdr:?}");
+            debug!("{hdr}: Sending ONE unicast msg locally");
             Self::find_one_local(sockets, hdr)
         }?;
 
@@ -160,13 +160,13 @@ where
         SendSockets: FnOnce(NonNull<SocketHeader>) -> Result<(), NetStackSendError>,
         SendProfile: FnOnce() -> Result<(), InterfaceSendError>,
     {
-        trace!("Sending err unicast w/ header: {hdr:?}");
+        trace!("{hdr}: Sending err unicast");
         // Can we assume the destination is local?
         let local_bypass = hdr.src.net_node_any() && hdr.dst.net_node_any();
 
         let res = if !local_bypass {
             // Not local: offer to the interface manager to send
-            debug!("Offering err externally unicast w/ header: {hdr:?}");
+            debug!("{hdr}: Offering err externally unicast");
             smgr()
         } else {
             // just skip to local sending
@@ -175,11 +175,11 @@ where
 
         match res {
             Ok(()) => {
-                debug!("Externally routed err unicast");
+                debug!("{hdr}: Externally routed err unicast");
                 return Ok(());
             }
             Err(InterfaceSendError::DestinationLocal) => {
-                debug!("No external interest in err unicast");
+                debug!("{hdr}: No external interest in err unicast");
             }
             Err(e) => return Err(NetStackSendError::InterfaceSend(e)),
         }
@@ -204,10 +204,10 @@ where
             profile: manager,
             ..
         } = self;
-        trace!("Sending msg raw w/ header: {hdr:?} from {source:?}");
+        trace!("{hdr}: Sending msg raw from {source:?}");
 
         if hdr.kind == FrameKind::PROTOCOL_ERROR {
-            todo!("Don't do that");
+            todo!("{hdr}: Don't do that");
         }
 
         // Is this a broadcast message?
@@ -240,10 +240,10 @@ where
             profile: manager,
             ..
         } = self;
-        trace!("Sending msg ty w/ header: {hdr:?}");
+        trace!("{hdr}: Sending msg ty");
 
         if hdr.kind == FrameKind::PROTOCOL_ERROR {
-            todo!("Don't do that");
+            todo!("{hdr}: Don't do that");
         }
 
         // Is this a broadcast message?
@@ -276,10 +276,10 @@ where
             profile: manager,
             ..
         } = self;
-        trace!("Sending msg bor w/ header: {hdr:?}");
+        trace!("{hdr}: Sending msg bor");
 
         if hdr.kind == FrameKind::PROTOCOL_ERROR {
-            todo!("Don't do that");
+            todo!("{hdr}: Don't do that");
         }
 
         // Is this a broadcast message?
@@ -313,10 +313,10 @@ where
             profile: manager,
             ..
         } = self;
-        trace!("Sending msg err w/ header: {hdr:?}");
+        trace!("{hdr}: Sending msg err");
 
         if hdr.dst.port_id == 255 {
-            todo!("Don't do that");
+            todo!("{hdr}: Don't do that");
         }
 
         Self::unicast_err(

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -90,6 +90,7 @@ impl<NS: NetStackHandle> Services<NS> {
 
         self.generic_log_handler(depth, |msg| match msg.t.level {
             fmtlog::Level::Error => log::error!(
+                target: "remote_log",
                 "({}.{}:{}): {}",
                 msg.hdr.src.network_id,
                 msg.hdr.src.network_id,
@@ -97,6 +98,7 @@ impl<NS: NetStackHandle> Services<NS> {
                 msg.t.inner
             ),
             fmtlog::Level::Warn => log::warn!(
+                target: "remote_log",
                 "({}.{}:{}): {}",
                 msg.hdr.src.network_id,
                 msg.hdr.src.network_id,
@@ -104,6 +106,7 @@ impl<NS: NetStackHandle> Services<NS> {
                 msg.t.inner
             ),
             fmtlog::Level::Info => log::info!(
+                target: "remote_log",
                 "({}.{}:{}): {}",
                 msg.hdr.src.network_id,
                 msg.hdr.src.network_id,
@@ -111,6 +114,7 @@ impl<NS: NetStackHandle> Services<NS> {
                 msg.t.inner
             ),
             fmtlog::Level::Debug => log::debug!(
+                target: "remote_log",
                 "({}.{}:{}): {}",
                 msg.hdr.src.network_id,
                 msg.hdr.src.network_id,
@@ -118,6 +122,7 @@ impl<NS: NetStackHandle> Services<NS> {
                 msg.t.inner
             ),
             fmtlog::Level::Trace => log::trace!(
+                target: "remote_log",
                 "({}.{}:{}): {}",
                 msg.hdr.src.network_id,
                 msg.hdr.src.network_id,
@@ -156,12 +161,12 @@ impl<NS: NetStackHandle> Services<NS> {
         let mut sub = subber.subscribe();
         loop {
             let msg = sub.recv().await;
-            log::info!("Got query!");
+            log::info!("{}: Got query!", msg.hdr);
             let res = nsh.stack().with_sockets(|iter| query_searcher(msg.t, iter));
             let Some(Some(resp)) = res else {
                 continue;
             };
-            log::info!("Sending query response to {:?}", msg.hdr.src);
+            log::info!("{}: Sending query response", msg.hdr);
             _ = topics
                 .clone()
                 .unicast::<ErgotSocketQueryResponseTopic>(msg.hdr.src, &resp);

--- a/demos/std/ergot-bridge-client/src/main.rs
+++ b/demos/std/ergot-bridge-client/src/main.rs
@@ -101,6 +101,6 @@ async fn yeet_listener(stack: EdgeStack, id: u8) {
 
     loop {
         let msg = hdl.recv().await;
-        info!("Listener id:{id} got {msg:?}");
+        info!("{}: Listener id:{id} got {}", msg.hdr, msg.t);
     }
 }

--- a/demos/std/ergot-client/src/main.rs
+++ b/demos/std/ergot-client/src/main.rs
@@ -69,6 +69,6 @@ async fn yeet_listener(stack: EdgeStack, id: u8) {
 
     loop {
         let msg = hdl.recv().await;
-        info!("Listener id:{id} got {msg:?}");
+        info!("{}: Listener id:{id} got {}", msg.hdr, msg.t);
     }
 }

--- a/demos/std/ergot-nusb-router/src/main.rs
+++ b/demos/std/ergot-nusb-router/src/main.rs
@@ -103,6 +103,6 @@ async fn yeet_listener(stack: RouterStack, id: u8) {
 
     loop {
         let msg = hdl.recv().await;
-        info!("Listener id:{id} got {msg:?}");
+        info!("{}: Listener id:{id} got {}", msg.hdr, msg.t);
     }
 }

--- a/demos/std/ergot-router/src/main.rs
+++ b/demos/std/ergot-router/src/main.rs
@@ -91,6 +91,6 @@ async fn yeet_listener(stack: RouterStack, id: u8) {
 
     loop {
         let msg = hdl.recv().await;
-        info!("Listener id:{id} got {msg:?}");
+        info!("{}: Listener id:{id} got {}", msg.hdr, msg.t);
     }
 }


### PR DESCRIPTION
Logs now look like this, which I think is better

```text
[2025-09-07T01:28:33Z TRACE ergot::net_stack::inner] (0.0:0 -> 0.0:4; FK:003, SQ: ----): Sending msg ty
[2025-09-07T01:28:33Z TRACE ergot::net_stack::inner] (0.0:0 -> 0.0:4; FK:003, SQ: ----): Sending msg unicast
[2025-09-07T01:28:33Z DEBUG ergot::net_stack::inner] (0.0:0 -> 0.0:4; FK:003, SQ: ----): No external interest in msg unicast
[2025-09-07T01:28:33Z DEBUG ergot::net_stack::inner] (0.0:0 -> 0.0:4; FK:003, SQ: ----): Sending ONE unicast msg locally
[2025-09-07T01:28:33Z DEBUG ergot::interface_manager::profiles::direct_router::tokio_tcp] sending pkt len:20 on net_id 1
[2025-09-07T01:28:33Z TRACE ergot::interface_manager::profiles::direct_router] (1.2:0 -> 1.1:4; FK:003, SQ: 0011) got frame from 0
[2025-09-07T01:28:33Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:4; FK:003, SQ: 0011): Sending msg raw from 0
[2025-09-07T01:28:33Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:4; FK:003, SQ: 0011): Sending msg unicast
[2025-09-07T01:28:33Z DEBUG ergot::net_stack::inner] (1.2:0 -> 1.1:4; FK:003, SQ: 0011): Offering msg externally unicast
[2025-09-07T01:28:33Z DEBUG ergot::net_stack::inner] (1.2:0 -> 1.1:4; FK:003, SQ: 0011): No external interest in msg unicast
[2025-09-07T01:28:33Z DEBUG ergot::net_stack::inner] (1.2:0 -> 1.1:4; FK:003, SQ: 0011): Sending ONE unicast msg locally
[2025-09-07T01:28:34Z TRACE ergot::interface_manager::profiles::direct_router] (1.2:0 -> 1.1:255; FK:003, SQ: 0012) got frame from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0012): Sending msg raw from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0012): Sending msg broadcast
[2025-09-07T01:28:34Z DEBUG ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0012): delivered broadcast message locally
[2025-09-07T01:28:34Z TRACE ergot::interface_manager::profiles::direct_router] (1.2:0 -> 1.1:255; FK:003, SQ: 0013) got frame from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0013): Sending msg raw from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0013): Sending msg broadcast
[2025-09-07T01:28:34Z WARN  ergot::interface_manager::profiles::direct_router] (1.2:0 -> 1.1:255; FK:003, SQ: 0013) recv->send error: NoRoute
[2025-09-07T01:28:34Z TRACE ergot::interface_manager::profiles::direct_router] (1.2:0 -> 1.1:255; FK:003, SQ: 0014) got frame from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0014): Sending msg raw from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0014): Sending msg broadcast
[2025-09-07T01:28:34Z DEBUG ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0014): delivered broadcast message locally
[2025-09-07T01:28:34Z TRACE ergot::interface_manager::profiles::direct_router] (1.2:0 -> 1.1:255; FK:003, SQ: 0015) got frame from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0015): Sending msg raw from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0015): Sending msg broadcast
[2025-09-07T01:28:34Z DEBUG ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0015): delivered broadcast message locally
[2025-09-07T01:28:34Z TRACE ergot::interface_manager::profiles::direct_router] (1.2:0 -> 1.1:255; FK:003, SQ: 0016) got frame from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0016): Sending msg raw from 0
[2025-09-07T01:28:34Z TRACE ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0016): Sending msg broadcast
[2025-09-07T01:28:34Z DEBUG ergot::net_stack::inner] (1.2:0 -> 1.1:255; FK:003, SQ: 0016): delivered broadcast message locally
```

<img width="1430" height="695" alt="Screenshot 2025-09-07 at 03 32 28" src="https://github.com/user-attachments/assets/e3be085c-deeb-4e2c-8fa3-47986a2f3208" />
