### PR TITLE
Remove `hdr_raw` usage

### DIFF
--- a/crates/ergot/src/conformance/net_stack.rs
+++ b/crates/ergot/src/conformance/net_stack.rs
@@ -187,7 +187,6 @@ pub mod mocks {
         fn send_raw(
             &mut self,
             _hdr: &Header,
-            _hdr_raw: &[u8],
             _data: &[u8],
             _source: Self::InterfaceIdent,
         ) -> Result<(), InterfaceSendError> {

--- a/crates/ergot/src/conformance/net_stack.rs
+++ b/crates/ergot/src/conformance/net_stack.rs
@@ -103,7 +103,7 @@ pub mod mocks {
     use mutex::raw_impls::cs::CriticalSectionRawMutex;
 
     use crate::{
-        Header, ProtocolError,
+        Header, HeaderSeq, ProtocolError,
         interface_manager::{InterfaceSendError, InterfaceState, Profile, SetStateError},
         net_stack::ArcNetStack,
     };
@@ -186,7 +186,7 @@ pub mod mocks {
 
         fn send_raw(
             &mut self,
-            _hdr: &Header,
+            _hdr: &HeaderSeq,
             _data: &[u8],
             _source: Self::InterfaceIdent,
         ) -> Result<(), InterfaceSendError> {

--- a/crates/ergot/src/conformance/net_stack.rs
+++ b/crates/ergot/src/conformance/net_stack.rs
@@ -126,8 +126,7 @@ pub mod mocks {
     }
 
     pub struct ExpectedSendRaw {
-        pub hdr: Header,
-        pub hdr_raw: Vec<u8>,
+        pub hdr: HeaderSeq,
         pub body: Vec<u8>,
         pub retval: Result<(), InterfaceSendError>,
     }

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -187,7 +187,7 @@ pub trait InterfaceSink {
         apdx: Option<&AnyAllAppendix>,
         body: &T,
     ) -> Result<(), ()>;
-    fn send_raw(&mut self, hdr: &CommonHeader, hdr_raw: &[u8], body: &[u8]) -> Result<(), ()>;
+    fn send_raw(&mut self, hdr_raw: &[u8], body: &[u8]) -> Result<(), ()>;
     fn send_err(&mut self, hdr: &CommonHeader, err: ProtocolError) -> Result<(), ()>;
 }
 
@@ -202,8 +202,8 @@ pub enum InterfaceSendError {
     /// Profile found a destination interface, but that interface
     /// was full in space/slots
     InterfaceFull,
-    /// TODO: Remove
-    PlaceholderOhNo,
+    /// An unhandled internal error occurred, this is a bug.
+    InternalError,
     /// Destination was an "any" port, but a key was not provided
     AnyPortMissingKey,
     /// TTL has reached the terminal value
@@ -250,7 +250,7 @@ impl InterfaceSendError {
             InterfaceSendError::DestinationLocal => ProtocolError::ISE_DESTINATION_LOCAL,
             InterfaceSendError::NoRouteToDest => ProtocolError::ISE_NO_ROUTE_TO_DEST,
             InterfaceSendError::InterfaceFull => ProtocolError::ISE_INTERFACE_FULL,
-            InterfaceSendError::PlaceholderOhNo => ProtocolError::ISE_PLACEHOLDER_OH_NO,
+            InterfaceSendError::InternalError => ProtocolError::ISE_INTERNAL_ERROR,
             InterfaceSendError::AnyPortMissingKey => ProtocolError::ISE_ANY_PORT_MISSING_KEY,
             InterfaceSendError::TtlExpired => ProtocolError::ISE_TTL_EXPIRED,
             InterfaceSendError::RoutingLoop => ProtocolError::ISE_ROUTING_LOOP,

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -124,7 +124,6 @@ pub trait Profile {
     fn send_raw(
         &mut self,
         hdr: &Header,
-        hdr_raw: &[u8],
         data: &[u8],
         source: Self::InterfaceIdent,
     ) -> Result<(), InterfaceSendError>;

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -34,7 +34,7 @@
 //!
 //! [`NetStack`]: crate::NetStack
 
-use crate::{AnyAllAppendix, Header, ProtocolError, wire_frames::CommonHeader};
+use crate::{AnyAllAppendix, Header, HeaderSeq, ProtocolError, wire_frames::CommonHeader};
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
@@ -123,7 +123,7 @@ pub trait Profile {
     /// This method should only be used for messages that do NOT originate locally
     fn send_raw(
         &mut self,
-        hdr: &Header,
+        hdr: &HeaderSeq,
         data: &[u8],
         source: Self::InterfaceIdent,
     ) -> Result<(), InterfaceSendError>;

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -34,7 +34,7 @@
 //!
 //! [`NetStack`]: crate::NetStack
 
-use crate::{AnyAllAppendix, Header, HeaderSeq, ProtocolError, wire_frames::CommonHeader};
+use crate::{Header, HeaderSeq, ProtocolError};
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
@@ -181,14 +181,9 @@ pub trait Interface {
 /// TX worker.
 #[allow(clippy::result_unit_err)]
 pub trait InterfaceSink {
-    fn send_ty<T: Serialize>(
-        &mut self,
-        hdr: &CommonHeader,
-        apdx: Option<&AnyAllAppendix>,
-        body: &T,
-    ) -> Result<(), ()>;
+    fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, body: &T) -> Result<(), ()>;
     fn send_raw(&mut self, hdr_raw: &[u8], body: &[u8]) -> Result<(), ()>;
-    fn send_err(&mut self, hdr: &CommonHeader, err: ProtocolError) -> Result<(), ()>;
+    fn send_err(&mut self, hdr: &HeaderSeq, err: ProtocolError) -> Result<(), ()>;
 }
 
 #[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -182,7 +182,7 @@ pub trait Interface {
 #[allow(clippy::result_unit_err)]
 pub trait InterfaceSink {
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, body: &T) -> Result<(), ()>;
-    fn send_raw(&mut self, hdr_raw: &[u8], body: &[u8]) -> Result<(), ()>;
+    fn send_raw(&mut self, hdr: &HeaderSeq, body: &[u8]) -> Result<(), ()>;
     fn send_err(&mut self, hdr: &HeaderSeq, err: ProtocolError) -> Result<(), ()>;
 }
 

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
@@ -279,7 +279,7 @@ pub fn process_frame<N>(
     // If the dest is 0, should we rewrite the dest as self.net_id? This
     // is the opposite as above, but I dunno how that will work with responses
     let res = match frame.body {
-        Ok(body) => nsh.stack().send_raw(&frame.hdr, frame.hdr_raw, body, ident),
+        Ok(body) => nsh.stack().send_raw(&frame.hdr, body, ident),
         Err(e) => {
             // send_err requires a Header instead of a HeaderSeq, so we convert it
             let nshdr: Header = frame.hdr.clone().into();

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
@@ -283,11 +283,13 @@ pub fn process_frame<N>(
     //
     // If the dest is 0, should we rewrite the dest as self.net_id? This
     // is the opposite as above, but I dunno how that will work with responses
-    let hdr = frame.hdr.clone();
-    let nshdr: Header = hdr.clone().into();
     let res = match frame.body {
-        Ok(body) => nsh.stack().send_raw(&hdr, frame.hdr_raw, body, ident),
-        Err(e) => nsh.stack().send_err(&nshdr, e, Some(ident)),
+        Ok(body) => nsh.stack().send_raw(&frame.hdr, frame.hdr_raw, body, ident),
+        Err(e) => {
+            // send_err requires a Header instead of a HeaderSeq, so we convert it
+            let nshdr: Header = frame.hdr.clone().into();
+            nsh.stack().send_err(&nshdr, e, Some(ident))
+        }
     };
 
     match res {

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
@@ -26,7 +26,7 @@ pub mod eusb_0_5;
 pub mod tokio_tcp;
 
 use crate::{
-    Header, ProtocolError,
+    Header, HeaderSeq, ProtocolError,
     interface_manager::{
         Interface, InterfaceSendError, InterfaceSink, InterfaceState, Profile, SetStateError,
     },
@@ -186,7 +186,7 @@ impl<I: Interface> Profile for DirectEdge<I> {
 
     fn send_raw(
         &mut self,
-        _hdr: &Header,
+        _hdr: &HeaderSeq,
         _data: &[u8],
         _source: Self::InterfaceIdent,
     ) -> Result<(), InterfaceSendError> {
@@ -284,10 +284,10 @@ pub fn process_frame<N>(
     // If the dest is 0, should we rewrite the dest as self.net_id? This
     // is the opposite as above, but I dunno how that will work with responses
     let hdr = frame.hdr.clone();
-    let hdr: Header = hdr.into();
+    let nshdr: Header = hdr.clone().into();
     let res = match frame.body {
         Ok(body) => nsh.stack().send_raw(&hdr, frame.hdr_raw, body, ident),
-        Err(e) => nsh.stack().send_err(&hdr, e, Some(ident)),
+        Err(e) => nsh.stack().send_err(&nshdr, e, Some(ident)),
     };
 
     match res {

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
@@ -187,7 +187,6 @@ impl<I: Interface> Profile for DirectEdge<I> {
     fn send_raw(
         &mut self,
         _hdr: &Header,
-        _hdr_raw: &[u8],
         _data: &[u8],
         _source: Self::InterfaceIdent,
     ) -> Result<(), InterfaceSendError> {

--- a/crates/ergot/src/interface_manager/profiles/direct_router/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_router/mod.rs
@@ -143,7 +143,6 @@ impl<I: Interface> Profile for DirectRouter<I> {
     fn send_raw(
         &mut self,
         hdr: &crate::Header,
-        hdr_raw: &[u8],
         data: &[u8],
         source: Self::InterfaceIdent,
     ) -> Result<(), InterfaceSendError> {
@@ -153,6 +152,7 @@ impl<I: Interface> Profile for DirectRouter<I> {
             return Err(InterfaceSendError::NoRouteToDest);
         }
 
+        let hdr_raw = todo!("serialize the header");
         if hdr.dst.port_id == 255 {
             if hdr.any_all.is_none() {
                 return Err(InterfaceSendError::AnyPortMissingKey);

--- a/crates/ergot/src/interface_manager/profiles/null.rs
+++ b/crates/ergot/src/interface_manager/profiles/null.rs
@@ -7,7 +7,7 @@
 use serde::Serialize;
 
 use crate::{
-    Header,
+    Header, HeaderSeq,
     interface_manager::{ConstInit, InterfaceSendError, InterfaceState, Profile, SetStateError},
 };
 
@@ -33,7 +33,7 @@ impl Profile for Null {
 
     fn send_raw(
         &mut self,
-        hdr: &Header,
+        hdr: &HeaderSeq,
         _data: &[u8],
         _source: Self::InterfaceIdent,
     ) -> Result<(), InterfaceSendError> {

--- a/crates/ergot/src/interface_manager/profiles/null.rs
+++ b/crates/ergot/src/interface_manager/profiles/null.rs
@@ -34,7 +34,6 @@ impl Profile for Null {
     fn send_raw(
         &mut self,
         hdr: &Header,
-        _hdr_raw: &[u8],
         _data: &[u8],
         _source: Self::InterfaceIdent,
     ) -> Result<(), InterfaceSendError> {

--- a/crates/ergot/src/interface_manager/utils/cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/cobs_stream.rs
@@ -66,6 +66,12 @@ where
     }
 
     fn send_raw(&mut self, hdr: &HeaderSeq, body: &[u8]) -> Result<(), ()> {
+        let is_err = hdr.kind == FrameKind::PROTOCOL_ERROR;
+
+        if is_err {
+            // todo: use a different interface for this
+            return Err(());
+        }
         let max_len = cobs::max_encoding_length(MAX_HDR_ENCODED_SIZE + body.len());
         let mut wgr = self.prod.grant_exact(max_len).map_err(drop)?;
 

--- a/crates/ergot/src/interface_manager/utils/cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/cobs_stream.rs
@@ -67,14 +67,7 @@ where
         Ok(())
     }
 
-    fn send_raw(&mut self, hdr: &CommonHeader, hdr_raw: &[u8], body: &[u8]) -> Result<(), ()> {
-        let is_err = hdr.kind == FrameKind::PROTOCOL_ERROR;
-
-        if is_err {
-            // todo: use a different interface for this
-            return Err(());
-        }
-
+    fn send_raw(&mut self, hdr_raw: &[u8], body: &[u8]) -> Result<(), ()> {
         let max_len = cobs::max_encoding_length(hdr_raw.len() + body.len());
         let mut wgr = self.prod.grant_exact(max_len).map_err(drop)?;
 

--- a/crates/ergot/src/interface_manager/utils/cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/cobs_stream.rs
@@ -7,11 +7,7 @@ use bbq2::{prod_cons::stream::StreamProducer, traits::bbqhdl::BbqHandle};
 use postcard::ser_flavors::{self, Flavor};
 use serde::Serialize;
 
-use crate::{
-    AnyAllAppendix, FrameKind, ProtocolError,
-    interface_manager::InterfaceSink,
-    wire_frames::{self, CommonHeader},
-};
+use crate::{FrameKind, HeaderSeq, ProtocolError, interface_manager::InterfaceSink, wire_frames};
 
 pub struct Sink<Q>
 where
@@ -43,12 +39,7 @@ impl<Q> InterfaceSink for Sink<Q>
 where
     Q: BbqHandle,
 {
-    fn send_ty<T: Serialize>(
-        &mut self,
-        hdr: &CommonHeader,
-        apdx: Option<&AnyAllAppendix>,
-        body: &T,
-    ) -> Result<(), ()> {
+    fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, body: &T) -> Result<(), ()> {
         let is_err = hdr.kind == FrameKind::PROTOCOL_ERROR;
 
         if is_err {
@@ -60,7 +51,7 @@ where
         let mut wgr = self.prod.grant_exact(max_len).map_err(drop)?;
 
         let ser = ser_flavors::Cobs::try_new(ser_flavors::Slice::new(&mut wgr)).map_err(drop)?;
-        let used = wire_frames::encode_frame_ty(ser, hdr, apdx, body).map_err(drop)?;
+        let used = wire_frames::encode_frame_ty(ser, hdr, body).map_err(drop)?;
         let len = used.len();
         wgr.commit(len);
 
@@ -82,7 +73,7 @@ where
         Ok(())
     }
 
-    fn send_err(&mut self, hdr: &CommonHeader, err: ProtocolError) -> Result<(), ()> {
+    fn send_err(&mut self, hdr: &HeaderSeq, err: ProtocolError) -> Result<(), ()> {
         let is_err = hdr.kind == FrameKind::PROTOCOL_ERROR;
 
         // note: here it SHOULD be an err!

--- a/crates/ergot/src/interface_manager/utils/framed_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/framed_stream.rs
@@ -64,13 +64,7 @@ where
         Ok(())
     }
 
-    fn send_raw(&mut self, hdr: &CommonHeader, hdr_raw: &[u8], body: &[u8]) -> Result<(), ()> {
-        let is_err = hdr.kind == FrameKind::PROTOCOL_ERROR;
-
-        if is_err {
-            // todo: use a different interface for this
-            return Err(());
-        }
+    fn send_raw(&mut self, hdr_raw: &[u8], body: &[u8]) -> Result<(), ()> {
         let len = hdr_raw.len() + body.len();
         let Ok(len) = u16::try_from(len) else {
             return Err(());

--- a/crates/ergot/src/interface_manager/utils/framed_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/framed_stream.rs
@@ -63,6 +63,12 @@ where
     }
 
     fn send_raw(&mut self, hdr: &HeaderSeq, body: &[u8]) -> Result<(), ()> {
+        let is_err = hdr.kind == FrameKind::PROTOCOL_ERROR;
+
+        if is_err {
+            // todo: use a different interface for this
+            return Err(());
+        }
         let max_len = MAX_HDR_ENCODED_SIZE + body.len();
         let Ok(max_len) = u16::try_from(max_len) else {
             return Err(());

--- a/crates/ergot/src/interface_manager/utils/framed_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/framed_stream.rs
@@ -77,7 +77,7 @@ where
         let mut ser = Serializer {
             output: Slice::new(&mut wgr),
         };
-        encode_frame_hdr(&mut ser, &hdr).map_err(drop)?;
+        encode_frame_hdr(&mut ser, hdr).map_err(drop)?;
         ser.output.try_extend(body).map_err(drop)?;
         let used = ser.output.finalize().map_err(drop)?.len();
         wgr.commit(u16::try_from(used).map_err(drop)?);

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -185,6 +185,17 @@ impl Header {
     }
 }
 
+impl HeaderSeq {
+    #[inline]
+    pub fn decrement_ttl(&mut self) -> Result<(), InterfaceSendError> {
+        self.ttl = self.ttl.checked_sub(1).ok_or_else(|| {
+            warn!("Header TTL expired: {self:?}");
+            InterfaceSendError::TtlExpired
+        })?;
+        Ok(())
+    }
+}
+
 impl From<HeaderSeq> for Header {
     fn from(val: HeaderSeq) -> Self {
         Self {

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -129,7 +129,7 @@ impl ProtocolError {
     pub const ISE_DESTINATION_LOCAL: Self = Self(11);
     pub const ISE_NO_ROUTE_TO_DEST: Self = Self(12);
     pub const ISE_INTERFACE_FULL: Self = Self(13);
-    pub const ISE_PLACEHOLDER_OH_NO: Self = Self(14);
+    pub const ISE_INTERNAL_ERROR: Self = Self(14);
     pub const ISE_ANY_PORT_MISSING_KEY: Self = Self(15);
     pub const ISE_TTL_EXPIRED: Self = Self(16);
     pub const ISE_ROUTING_LOOP: Self = Self(17);

--- a/crates/ergot/src/net_stack/inner.rs
+++ b/crates/ergot/src/net_stack/inner.rs
@@ -191,6 +191,9 @@ where
     }
 
     /// Handle sending of a raw (serialized) message
+    ///
+    /// Note: `hdr_raw` must EXACTLY match the contents of `hdr`, or incorrect routing
+    /// may occur.
     pub(super) fn send_raw(
         &mut self,
         hdr: &HeaderSeq,

--- a/crates/ergot/src/net_stack/inner.rs
+++ b/crates/ergot/src/net_stack/inner.rs
@@ -216,14 +216,14 @@ where
                 sockets,
                 hdr,
                 |skt| Self::send_raw_to_socket(skt, body, hdr, hdr_raw, seq_no).is_ok(),
-                || manager.send_raw(hdr, hdr_raw, body, source).is_ok(),
+                || manager.send_raw(hdr, body, source).is_ok(),
             )
         } else {
             Self::unicast(
                 sockets,
                 hdr,
                 |skt| Self::send_raw_to_socket(skt, body, hdr, hdr_raw, seq_no),
-                || manager.send_raw(hdr, hdr_raw, body, source),
+                || manager.send_raw(hdr, body, source),
             )
         }
     }

--- a/crates/ergot/src/net_stack/inner.rs
+++ b/crates/ergot/src/net_stack/inner.rs
@@ -191,13 +191,9 @@ where
     }
 
     /// Handle sending of a raw (serialized) message
-    ///
-    /// Note: `hdr_raw` must EXACTLY match the contents of `hdr`, or incorrect routing
-    /// may occur.
     pub(super) fn send_raw(
         &mut self,
         hdr: &HeaderSeq,
-        hdr_raw: &[u8],
         body: &[u8],
         source: P::InterfaceIdent,
     ) -> Result<(), NetStackSendError> {
@@ -220,14 +216,14 @@ where
             Self::broadcast(
                 sockets,
                 &nshdr,
-                |skt| Self::send_raw_to_socket(skt, body, &nshdr, hdr_raw, seq_no).is_ok(),
+                |skt| Self::send_raw_to_socket(skt, body, &nshdr, seq_no).is_ok(),
                 || manager.send_raw(hdr, body, source).is_ok(),
             )
         } else {
             Self::unicast(
                 sockets,
                 &nshdr,
-                |skt| Self::send_raw_to_socket(skt, body, &nshdr, hdr_raw, seq_no),
+                |skt| Self::send_raw_to_socket(skt, body, &nshdr, seq_no),
                 || manager.send_raw(hdr, body, source),
             )
         }
@@ -564,7 +560,6 @@ where
         this: NonNull<SocketHeader>,
         body: &[u8],
         hdr: &Header,
-        hdr_raw: &[u8],
         seq_no: &mut u16,
     ) -> Result<(), NetStackSendError> {
         let vtable: &'static SocketVTable = {
@@ -580,7 +575,7 @@ where
             seq
         });
 
-        (f)(this, body, hdr, hdr_raw).map_err(NetStackSendError::SocketSend)
+        (f)(this, body, hdr).map_err(NetStackSendError::SocketSend)
     }
 }
 

--- a/crates/ergot/src/net_stack/mod.rs
+++ b/crates/ergot/src/net_stack/mod.rs
@@ -27,7 +27,7 @@ use serde::Serialize;
 use topics::Topics;
 
 use crate::{
-    Header, ProtocolError,
+    Header, HeaderSeq, ProtocolError,
     fmtlog::{ErgotFmtTx, Level},
     interface_manager::{self, InterfaceSendError, Profile},
     socket::{SocketHeader, SocketSendError},
@@ -209,7 +209,7 @@ where
     /// [`NetStack`].
     pub fn send_raw(
         &self,
-        hdr: &Header,
+        hdr: &HeaderSeq,
         hdr_raw: &[u8],
         body: &[u8],
         source: P::InterfaceIdent,

--- a/crates/ergot/src/net_stack/mod.rs
+++ b/crates/ergot/src/net_stack/mod.rs
@@ -210,12 +210,11 @@ where
     pub fn send_raw(
         &self,
         hdr: &HeaderSeq,
-        hdr_raw: &[u8],
         body: &[u8],
         source: P::InterfaceIdent,
     ) -> Result<(), NetStackSendError> {
         self.inner
-            .try_with_lock(|inner| inner.send_raw(hdr, hdr_raw, body, source))
+            .try_with_lock(|inner| inner.send_raw(hdr, body, source))
             .ok_or(NetStackSendError::WouldDeadlock)?
     }
 

--- a/crates/ergot/src/socket/borrow.rs
+++ b/crates/ergot/src/socket/borrow.rs
@@ -27,7 +27,10 @@ use bbq2::{
     traits::bbqhdl::BbqHandle,
 };
 use cordyceps::list::Links;
-use postcard::ser_flavors;
+use postcard::{
+    Serializer,
+    ser_flavors::{self, Flavor, Slice},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -37,7 +40,7 @@ use crate::{
     socket::{
         Attributes, BorSerFn, HeaderMessage, Response, SocketHeader, SocketSendError, SocketVTable,
     },
-    wire_frames::{self, BorrowedFrame, de_frame},
+    wire_frames::{self, BorrowedFrame, MAX_HDR_ENCODED_SIZE, de_frame, encode_frame_hdr},
 };
 
 #[repr(C)]
@@ -258,27 +261,37 @@ where
         Ok(())
     }
 
-    fn recv_raw(
-        this: NonNull<()>,
-        that: &[u8],
-        _hdr: HeaderSeq,
-        hdr_raw: &[u8],
-    ) -> Result<(), SocketSendError> {
+    fn recv_raw(this: NonNull<()>, that: &[u8], hdr: HeaderSeq) -> Result<(), SocketSendError> {
         let this: NonNull<Self> = this.cast();
         let this: &Self = unsafe { this.as_ref() };
         let qbox: &mut QueueBox<Q> = unsafe { &mut *this.inner.get() };
         let qref = qbox.q.bbq_ref();
         let prod = qref.framed_producer();
 
-        let Ok(needed) = u16::try_from(that.len() + hdr_raw.len()) else {
+        // Re-encode the header
+        let mut buf = [0u8; MAX_HDR_ENCODED_SIZE];
+        let mut ser = Serializer {
+            output: Slice::new(&mut buf),
+        };
+        let Ok(()) = encode_frame_hdr(&mut ser, &hdr) else {
+            // If this fails, it likely means MAX_HDR_ENCODED_SIZE is being incorrectly calculaed
+            log::error!("Encoding of HeaderSeq should never fail. This is a bug.");
+            return Err(SocketSendError::WhatTheHell);
+        };
+        let Ok(hdr_used) = ser.output.finalize() else {
+            // Slice flavor finalization should never fail
+            unreachable!("Slice finalization should never error");
+        };
+
+        let Ok(needed) = u16::try_from(that.len() + hdr_used.len()) else {
             return Err(SocketSendError::NoSpace);
         };
 
         let Ok(mut wgr) = prod.grant(needed) else {
             return Err(SocketSendError::NoSpace);
         };
-        let (hdr, body) = wgr.split_at_mut(hdr_raw.len());
-        hdr.copy_from_slice(hdr_raw);
+        let (hdr, body) = wgr.split_at_mut(hdr_used.len());
+        hdr.copy_from_slice(hdr_used);
         body.copy_from_slice(that);
         wgr.commit(needed);
 
@@ -362,11 +375,7 @@ where
                 let sli: &[u8] = resp.deref();
 
                 if let Some(frame) = de_frame(sli) {
-                    let BorrowedFrame {
-                        hdr,
-                        body,
-                        hdr_raw: _,
-                    } = frame;
+                    let BorrowedFrame { hdr, body } = frame;
                     match body {
                         Ok(body) => {
                             let sli: &[u8] = body;

--- a/crates/ergot/src/socket/borrow.rs
+++ b/crates/ergot/src/socket/borrow.rs
@@ -37,7 +37,7 @@ use crate::{
     socket::{
         Attributes, BorSerFn, HeaderMessage, Response, SocketHeader, SocketSendError, SocketVTable,
     },
-    wire_frames::{self, BorrowedFrame, CommonHeader, de_frame},
+    wire_frames::{self, BorrowedFrame, de_frame},
 };
 
 #[repr(C)]
@@ -187,15 +187,7 @@ where
 
         let ser = ser_flavors::Slice::new(&mut wgr);
 
-        let chdr = CommonHeader {
-            src: hdr.src,
-            dst: hdr.dst,
-            seq_no: hdr.seq_no,
-            kind: hdr.kind,
-            ttl: hdr.ttl,
-        };
-
-        if let Ok(used) = wire_frames::encode_frame_err(ser, &chdr, err) {
+        if let Ok(used) = wire_frames::encode_frame_err(ser, &hdr, err) {
             let len = used.len() as u16;
             wgr.commit(len);
             if let Some(wake) = qbox.waker.take() {
@@ -225,15 +217,7 @@ where
         };
         let ser = ser_flavors::Slice::new(&mut wgr);
 
-        let chdr = CommonHeader {
-            src: hdr.src,
-            dst: hdr.dst,
-            seq_no: hdr.seq_no,
-            kind: hdr.kind,
-            ttl: hdr.ttl,
-        };
-
-        let Ok(used) = wire_frames::encode_frame_ty(ser, &chdr, hdr.any_all.as_ref(), that) else {
+        let Ok(used) = wire_frames::encode_frame_ty(ser, &hdr, that) else {
             return Err(SocketSendError::NoSpace);
         };
 

--- a/crates/ergot/src/socket/mod.rs
+++ b/crates/ergot/src/socket/mod.rs
@@ -155,8 +155,6 @@ pub type RecvRaw = fn(
     &[u8],
     // the header
     HeaderSeq,
-    // the raw header
-    &[u8],
 ) -> Result<(), SocketSendError>;
 
 pub type RecvError = fn(

--- a/crates/ergot/src/socket/mod.rs
+++ b/crates/ergot/src/socket/mod.rs
@@ -58,11 +58,7 @@ use core::{
     ptr::{self, NonNull},
 };
 
-use crate::{
-    FrameKind, HeaderSeq, Key, ProtocolError,
-    nash::NameHash,
-    wire_frames::{self, CommonHeader},
-};
+use crate::{FrameKind, HeaderSeq, Key, ProtocolError, nash::NameHash, wire_frames};
 use cordyceps::{Linked, list::Links};
 use postcard::ser_flavors;
 use serde::Serialize;
@@ -181,15 +177,7 @@ pub(crate) fn borser<T: Serialize>(
     let that: &T = unsafe { that.as_ref() };
     let ser = ser_flavors::Slice::new(out);
 
-    let chdr = CommonHeader {
-        src: hdr.src,
-        dst: hdr.dst,
-        seq_no: hdr.seq_no,
-        kind: hdr.kind,
-        ttl: hdr.ttl,
-    };
-
-    let Ok(used) = wire_frames::encode_frame_ty(ser, &chdr, hdr.any_all.as_ref(), that) else {
+    let Ok(used) = wire_frames::encode_frame_ty(ser, &hdr, that) else {
         log::trace!("BOOP");
         return Err(SocketSendError::NoSpace);
     };

--- a/crates/ergot/src/socket/raw_owned.rs
+++ b/crates/ergot/src/socket/raw_owned.rs
@@ -296,12 +296,7 @@ where
         }
     }
 
-    fn recv_raw(
-        this: NonNull<()>,
-        that: &[u8],
-        hdr: HeaderSeq,
-        _hdr_raw: &[u8],
-    ) -> Result<(), SocketSendError> {
+    fn recv_raw(this: NonNull<()>, that: &[u8], hdr: HeaderSeq) -> Result<(), SocketSendError> {
         let this: NonNull<Self> = this.cast();
         let this: &Self = unsafe { this.as_ref() };
         let mutitem: &mut StoreBox<S, Response<T>> = unsafe { &mut *this.inner.get() };

--- a/crates/ergot/src/wire_frames.rs
+++ b/crates/ergot/src/wire_frames.rs
@@ -15,6 +15,18 @@ pub struct CommonHeader {
     // WARNING: Update MAX_HDR_ENCODED_SIZE if you add/remove anything here!
 }
 
+impl From<&HeaderSeq> for CommonHeader {
+    fn from(value: &HeaderSeq) -> Self {
+        Self {
+            src: value.src,
+            dst: value.dst,
+            seq_no: value.seq_no,
+            kind: value.kind,
+            ttl: value.ttl,
+        }
+    }
+}
+
 pub enum PartialDecodeTail<'a> {
     // WARNING: Update MAX_HDR_ENCODED_SIZE if you add/remove anything here!
     Specific(&'a [u8]),

--- a/crates/ergot/src/wire_frames.rs
+++ b/crates/ergot/src/wire_frames.rs
@@ -219,13 +219,11 @@ pub fn de_frame(remain: &[u8]) -> Option<BorrowedFrame<'_>> {
             ttl,
         },
         body,
-        hdr_raw: res.hdr_raw,
     })
 }
 
 pub struct BorrowedFrame<'a> {
     pub hdr: HeaderSeq,
-    pub hdr_raw: &'a [u8],
     pub body: Result<&'a [u8], ProtocolError>,
 }
 

--- a/crates/ergot/src/wire_frames.rs
+++ b/crates/ergot/src/wire_frames.rs
@@ -6,20 +6,24 @@ use crate::{Address, AnyAllAppendix, FrameKind, HeaderSeq, Key, ProtocolError, n
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CommonHeader {
+    // WARNING: Update MAX_HDR_ENCODED_SIZE if you add/remove anything here!
     pub src: Address,
     pub dst: Address,
     pub seq_no: u16,
     pub kind: FrameKind,
     pub ttl: u8,
+    // WARNING: Update MAX_HDR_ENCODED_SIZE if you add/remove anything here!
 }
 
 pub enum PartialDecodeTail<'a> {
+    // WARNING: Update MAX_HDR_ENCODED_SIZE if you add/remove anything here!
     Specific(&'a [u8]),
     AnyAll {
         apdx: AnyAllAppendix,
         body: &'a [u8],
     },
     Err(ProtocolError),
+    // WARNING: Update MAX_HDR_ENCODED_SIZE if you add/remove anything here!
 }
 
 pub struct PartialDecode<'a> {
@@ -97,6 +101,44 @@ impl From<postcard::Error> for EncodeFrameError {
         Self::SerializationError(value)
     }
 }
+/// The largest encoded size of a header, usable for creating a max-sized buffer
+///
+/// ```text
+/// CommonHeader=================================
+/// src: Address,            u32, varint: 5 bytes
+/// dst: Address,            u32, varint: 5 bytes
+/// seq_no: u16,             u16, varint: 3 bytes
+/// kind: FrameKind,         u8, !varint: 1 byte
+/// ttl: u8,                 u8, !varint: 1 byte
+/// AnyAllAppendix===============================
+/// key: Key,                [u8; 8]:     8 bytes
+/// nash: Option<NameHash>,  u32, varint: 5 bytes
+/// ==================================== 28 bytes
+/// ```
+//
+// TODO: A more automatic way of handling this. This is currently tested with a
+// unit test below.
+pub const MAX_HDR_ENCODED_SIZE: usize = 28;
+
+/// Encode the frame header to the given serializer
+pub fn encode_frame_hdr<F>(
+    ser: &mut Serializer<F>,
+    hdr: &CommonHeader,
+    apdx: Option<&AnyAllAppendix>,
+) -> Result<(), EncodeFrameError>
+where
+    F: ser_flavors::Flavor,
+{
+    hdr.serialize(&mut *ser)?;
+
+    if let Some(app) = apdx {
+        ser.output.try_extend(&app.key.0)?;
+        let val: u32 = app.nash.as_ref().map(NameHash::to_u32).unwrap_or(0);
+        val.serialize(ser)?;
+    }
+
+    Ok(())
+}
 
 // must not be error
 // doesn't check if dest is actually any/all
@@ -111,13 +153,7 @@ where
     T: Serialize,
 {
     let mut serializer = Serializer { output: flav };
-    hdr.serialize(&mut serializer)?;
-
-    if let Some(app) = apdx {
-        serializer.output.try_extend(&app.key.0)?;
-        let val: u32 = app.nash.as_ref().map(NameHash::to_u32).unwrap_or(0);
-        val.serialize(&mut serializer)?;
-    }
+    encode_frame_hdr(&mut serializer, hdr, apdx)?;
 
     body.serialize(&mut serializer)?;
     Ok(serializer.output.finalize()?)
@@ -182,4 +218,34 @@ pub struct BorrowedFrame<'a> {
     pub hdr: HeaderSeq,
     pub hdr_raw: &'a [u8],
     pub body: Result<&'a [u8], ProtocolError>,
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use postcard::{ser_flavors::Flavor, Serializer};
+
+    use crate::{nash::NameHash, wire_frames::MAX_HDR_ENCODED_SIZE, Address, AnyAllAppendix, FrameKind, Key};
+
+    use super::{encode_frame_hdr, CommonHeader};
+
+    #[test]
+    fn max_hdr_ser_size() {
+        let hdr = CommonHeader {
+            // Addresses: maximum integer values
+            src: Address { network_id: u16::MAX, node_id: u8::MAX, port_id: u8::MAX },
+            dst: Address { network_id: u16::MAX, node_id: u8::MAX, port_id: u8::MAX },
+            seq_no: u16::MAX,
+            kind: FrameKind(u8::MAX),
+            ttl: u8::MAX,
+        };
+        let apdx = AnyAllAppendix {
+            key: Key([0xFFu8; 8]),
+            nash: NameHash::from_u32(u32::MAX),
+        };
+        let flav = postcard::ser_flavors::StdVec::new();
+        let mut ser = Serializer { output: flav };
+        encode_frame_hdr(&mut ser, &hdr, Some(&apdx)).unwrap();
+        let res = ser.output.finalize().unwrap();
+        assert_eq!(res.len(), MAX_HDR_ENCODED_SIZE);
+    }
 }

--- a/crates/ergot/src/wire_frames.rs
+++ b/crates/ergot/src/wire_frames.rs
@@ -222,18 +222,28 @@ pub struct BorrowedFrame<'a> {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use postcard::{ser_flavors::Flavor, Serializer};
+    use postcard::{Serializer, ser_flavors::Flavor};
 
-    use crate::{nash::NameHash, wire_frames::MAX_HDR_ENCODED_SIZE, Address, AnyAllAppendix, FrameKind, Key};
+    use crate::{
+        Address, AnyAllAppendix, FrameKind, Key, nash::NameHash, wire_frames::MAX_HDR_ENCODED_SIZE,
+    };
 
-    use super::{encode_frame_hdr, CommonHeader};
+    use super::{CommonHeader, encode_frame_hdr};
 
     #[test]
     fn max_hdr_ser_size() {
         let hdr = CommonHeader {
             // Addresses: maximum integer values
-            src: Address { network_id: u16::MAX, node_id: u8::MAX, port_id: u8::MAX },
-            dst: Address { network_id: u16::MAX, node_id: u8::MAX, port_id: u8::MAX },
+            src: Address {
+                network_id: u16::MAX,
+                node_id: u8::MAX,
+                port_id: u8::MAX,
+            },
+            dst: Address {
+                network_id: u16::MAX,
+                node_id: u8::MAX,
+                port_id: u8::MAX,
+            },
             seq_no: u16::MAX,
             kind: FrameKind(u8::MAX),
             ttl: u8::MAX,

--- a/crates/ergot/tests/smoke.rs
+++ b/crates/ergot/tests/smoke.rs
@@ -9,7 +9,7 @@ use ergot::{
     ProtocolError,
     interface_manager::profiles::null::Null,
     socket::{Attributes, owned::single::Socket},
-    wire_frames::{CommonHeader, encode_frame_ty},
+    wire_frames::encode_frame_ty,
 };
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use postcard::ser_flavors;
@@ -102,17 +102,17 @@ async fn hello() {
             let mut buf = [0u8; 128];
             let hdr = encode_frame_ty::<_, ()>(
                 ser_flavors::Slice::new(&mut buf),
-                &CommonHeader {
+                &HeaderSeq {
                     src,
                     dst,
                     seq_no: 123,
                     kind: FrameKind::ENDPOINT_REQ,
                     ttl: DEFAULT_TTL,
+                    any_all: Some(AnyAllAppendix {
+                        key: Key(*b"TEST1234"),
+                        nash: None,
+                    }),
                 },
-                Some(&AnyAllAppendix {
-                    key: Key(*b"TEST1234"),
-                    nash: None,
-                }),
                 &(),
             )
             .unwrap();

--- a/crates/ergot/tests/smoke.rs
+++ b/crates/ergot/tests/smoke.rs
@@ -5,7 +5,8 @@ use bbq2::{
     traits::{coordination::cas::AtomicCoord, notifier::maitake::MaiNotSpsc, storage::Inline},
 };
 use ergot::{
-    Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, Key, NetStack, ProtocolError,
+    Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, HeaderSeq, Key, NetStack,
+    ProtocolError,
     interface_manager::profiles::null::Null,
     socket::{Attributes, owned::single::Socket},
     wire_frames::{CommonHeader, encode_frame_ty},
@@ -117,14 +118,14 @@ async fn hello() {
             .unwrap();
             STACK
                 .send_raw(
-                    &Header {
+                    &HeaderSeq {
                         src,
                         dst,
                         any_all: Some(AnyAllAppendix {
                             key: Key(*b"TEST1234"),
                             nash: None,
                         }),
-                        seq_no: Some(123),
+                        seq_no: 123,
                         kind: FrameKind::ENDPOINT_REQ,
                         ttl: DEFAULT_TTL,
                     },

--- a/crates/ergot/tests/smoke2.rs
+++ b/crates/ergot/tests/smoke2.rs
@@ -3,7 +3,7 @@
 use std::{pin::pin, time::Duration};
 
 use ergot::{
-    Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, Key, NetStack, endpoint,
+    Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, HeaderSeq, Key, NetStack, endpoint,
     interface_manager::profiles::null::Null,
     traits::Endpoint,
     wire_frames::{CommonHeader, encode_frame_ty},
@@ -115,14 +115,14 @@ async fn hello() {
             .unwrap();
             STACK
                 .send_raw(
-                    &Header {
+                    &HeaderSeq {
                         src,
                         dst,
                         any_all: Some(AnyAllAppendix {
                             key: Key(ExampleEndpoint::REQ_KEY.to_bytes()),
                             nash: None,
                         }),
-                        seq_no: Some(123),
+                        seq_no: 123,
                         kind: FrameKind::ENDPOINT_REQ,
                         ttl: DEFAULT_TTL,
                     },

--- a/crates/ergot/tests/smoke2.rs
+++ b/crates/ergot/tests/smoke2.rs
@@ -4,9 +4,7 @@ use std::{pin::pin, time::Duration};
 
 use ergot::{
     Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, HeaderSeq, Key, NetStack, endpoint,
-    interface_manager::profiles::null::Null,
-    traits::Endpoint,
-    wire_frames::{CommonHeader, encode_frame_ty},
+    interface_manager::profiles::null::Null, traits::Endpoint, wire_frames::encode_frame_ty,
 };
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use postcard::ser_flavors;
@@ -99,17 +97,17 @@ async fn hello() {
             let mut buf = [0u8; 128];
             let hdr = encode_frame_ty::<_, ()>(
                 ser_flavors::Slice::new(&mut buf),
-                &CommonHeader {
+                &HeaderSeq {
                     src,
                     dst,
                     seq_no: 123,
                     kind: FrameKind::ENDPOINT_REQ,
                     ttl: DEFAULT_TTL,
+                    any_all: Some(AnyAllAppendix {
+                        key: Key(ExampleEndpoint::REQ_KEY.to_bytes()),
+                        nash: None,
+                    }),
                 },
-                Some(&AnyAllAppendix {
-                    key: Key(ExampleEndpoint::REQ_KEY.to_bytes()),
-                    nash: None,
-                }),
                 &(),
             )
             .unwrap();

--- a/crates/ergot/tests/smoke2.rs
+++ b/crates/ergot/tests/smoke2.rs
@@ -4,10 +4,9 @@ use std::{pin::pin, time::Duration};
 
 use ergot::{
     Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, HeaderSeq, Key, NetStack, endpoint,
-    interface_manager::profiles::null::Null, traits::Endpoint, wire_frames::encode_frame_ty,
+    interface_manager::profiles::null::Null, traits::Endpoint,
 };
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
-use postcard::ser_flavors;
 
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
@@ -94,23 +93,6 @@ async fn hello() {
             // hold more than one message at a time)
             sleep(Duration::from_millis(100)).await;
             let body = postcard::to_vec::<_, 128>(&Example { a: 56, b: 1234 }).unwrap();
-            let mut buf = [0u8; 128];
-            let hdr = encode_frame_ty::<_, ()>(
-                ser_flavors::Slice::new(&mut buf),
-                &HeaderSeq {
-                    src,
-                    dst,
-                    seq_no: 123,
-                    kind: FrameKind::ENDPOINT_REQ,
-                    ttl: DEFAULT_TTL,
-                    any_all: Some(AnyAllAppendix {
-                        key: Key(ExampleEndpoint::REQ_KEY.to_bytes()),
-                        nash: None,
-                    }),
-                },
-                &(),
-            )
-            .unwrap();
             STACK
                 .send_raw(
                     &HeaderSeq {
@@ -124,7 +106,6 @@ async fn hello() {
                         kind: FrameKind::ENDPOINT_REQ,
                         ttl: DEFAULT_TTL,
                     },
-                    hdr,
                     &body,
                     (),
                 )

--- a/demos/rp2040/rp2040-serial-pair/src/lib.rs
+++ b/demos/rp2040/rp2040-serial-pair/src/lib.rs
@@ -286,7 +286,7 @@ where
             let hdr = frame.hdr.clone();
             let nshdr: Header = hdr.clone().into();
             let res = match frame.body {
-                Ok(body) => nsh.stack().send_raw(&hdr, frame.hdr_raw, body, ()),
+                Ok(body) => nsh.stack().send_raw(&hdr, body, ()),
                 Err(e) => nsh.stack().send_err(&nshdr, e, Some(())),
             };
             match res {

--- a/demos/rp2040/rp2040-serial-pair/src/lib.rs
+++ b/demos/rp2040/rp2040-serial-pair/src/lib.rs
@@ -23,7 +23,7 @@ use ergot::{
     },
     net_stack::NetStackHandle,
     wire_frames::de_frame,
-    Header, NetStack, ProtocolError,
+    Header, HeaderSeq, NetStack, ProtocolError,
 };
 use mutex::ScopedRawMutex;
 use serde::Serialize;
@@ -132,7 +132,7 @@ impl<Q: BbqHandle + 'static> Profile for PairedUartProfile<Q> {
 
     fn send_raw(
         &mut self,
-        hdr: &Header,
+        hdr: &HeaderSeq,
         data: &[u8],
         source: Self::InterfaceIdent,
     ) -> Result<(), InterfaceSendError> {
@@ -284,10 +284,10 @@ where
             // If the dest is 0, should we rewrite the dest as self.net_id? This
             // is the opposite as above, but I dunno how that will work with responses
             let hdr = frame.hdr.clone();
-            let hdr: Header = hdr.into();
+            let nshdr: Header = hdr.clone().into();
             let res = match frame.body {
                 Ok(body) => nsh.stack().send_raw(&hdr, frame.hdr_raw, body, ()),
-                Err(e) => nsh.stack().send_err(&hdr, e, Some(())),
+                Err(e) => nsh.stack().send_err(&nshdr, e, Some(())),
             };
             match res {
                 Ok(()) => {}

--- a/demos/rp2040/rp2040-serial-pair/src/lib.rs
+++ b/demos/rp2040/rp2040-serial-pair/src/lib.rs
@@ -133,11 +133,10 @@ impl<Q: BbqHandle + 'static> Profile for PairedUartProfile<Q> {
     fn send_raw(
         &mut self,
         hdr: &Header,
-        hdr_raw: &[u8],
         data: &[u8],
         source: Self::InterfaceIdent,
     ) -> Result<(), InterfaceSendError> {
-        self.inner.send_raw(hdr, hdr_raw, data, source)
+        self.inner.send_raw(hdr, data, source)
     }
 
     fn interface_state(&mut self, ident: Self::InterfaceIdent) -> Option<InterfaceState> {


### PR DESCRIPTION
A retooling of how we use headers in `send_raw` operations. Major changes:

* `NetStack::send_raw` now takes `HeaderSeq` instead of `Header`
* `NetStack::send_raw` no longer takes `hdr_raw`, as well as many other parts of the system
* Reduce usage of `CommonHeader` and `AnyAllAppendix`, instead using `HeaderSeq` more consistently
* Headers are now generally re-serialized down at the InterfaceSink level, so they don't need to be re-encoded more than once.

Originally, the idea behind passing around `hdr_raw` was to avoid cases where profiles/interfaces or borrowed sockets would need to re-serialize the header when forwarding. However, there are places in the code where the header may be modified, particularly for broadcast flooding, or even for updating the TTL count when forwarding, meaning that the serialized and in-memory versions could get out of sync with each other.

To avoid this, we no longer pass around the "raw" header, and just demand it is re-serialized when necessary. This is actually likely not very burdensome at all, as the max header size is 28 bytes, which should be trivial to do.