### PR TITLE
Improve documentation and debugging context for `NetStackSendError::WrongPortKind`.

### DIFF
--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -28,7 +28,7 @@ pub use net_stack::{NetStack, NetStackSendError};
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Eq)]
 pub struct FrameKind(pub u8);
 
 #[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]

--- a/crates/ergot/src/net_stack/inner.rs
+++ b/crates/ergot/src/net_stack/inner.rs
@@ -356,7 +356,10 @@ where
                 continue;
             }
             if skt_ref.attrs.kind != hdr.kind {
-                return Err(NetStackSendError::WrongPortKind);
+                return Err(NetStackSendError::WrongPortKind {
+                    expected: skt_ref.attrs.kind,
+                    actual: hdr.kind,
+                });
             }
             break skt;
         };

--- a/crates/ergot/src/net_stack/mod.rs
+++ b/crates/ergot/src/net_stack/mod.rs
@@ -27,7 +27,7 @@ use serde::Serialize;
 use topics::Topics;
 
 use crate::{
-    Header, HeaderSeq, ProtocolError,
+    FrameKind, Header, HeaderSeq, ProtocolError,
     fmtlog::{ErgotFmtTx, Level},
     interface_manager::{self, InterfaceSendError, Profile},
     socket::{SocketHeader, SocketSendError},
@@ -71,7 +71,13 @@ pub enum NetStackSendError {
     InterfaceSend(InterfaceSendError),
     NoRoute,
     AnyPortMissingKey,
-    WrongPortKind,
+    /// The message and the socket don't agree on the port kind
+    /// This can happen if you send a message to the wrong port as a result of using hard-coded
+    /// port numbers or as a result of a device restarting and having different port allocations.
+    WrongPortKind {
+        expected: FrameKind,
+        actual: FrameKind,
+    },
     AnyPortNotUnique,
     AllPortMissingKey,
     WouldDeadlock,
@@ -418,7 +424,7 @@ impl NetStackSendError {
             }
             NetStackSendError::NoRoute => ProtocolError::NSSE_NO_ROUTE,
             NetStackSendError::AnyPortMissingKey => ProtocolError::NSSE_ANY_PORT_MISSING_KEY,
-            NetStackSendError::WrongPortKind => ProtocolError::NSSE_WRONG_PORT_KIND,
+            NetStackSendError::WrongPortKind { .. } => ProtocolError::NSSE_WRONG_PORT_KIND,
             NetStackSendError::AnyPortNotUnique => ProtocolError::NSSE_ANY_PORT_NOT_UNIQUE,
             NetStackSendError::AllPortMissingKey => ProtocolError::NSSE_ALL_PORT_MISSING_KEY,
             NetStackSendError::WouldDeadlock => ProtocolError::NSSE_WOULD_DEADLOCK,


### PR DESCRIPTION
Adds debugging and gives some hints in the documentation.

See code changes.