### PR TITLE
add alloc feature, for now it only enables postcard-schema's alloc

### DIFF
--- a/crates/ergot/Cargo.toml
+++ b/crates/ergot/Cargo.toml
@@ -70,6 +70,9 @@ defmt-v1 = [
 _all-features-hack = [
     "ssmarshal/std",
 ]
+alloc = [
+  "postcard-schema/alloc"
+]
 
 [dependencies]
 const-fnv1a-hash    = "1.1.0"


### PR DESCRIPTION
it is useful if one wants to send like a `String` over ergot, otherwise it would require the use to add postcard-schema and manually enable its alloc feature