### PR TITLE
Tokio TCP/UDP - Show socket when an error occurs.

### DIFF
--- a/crates/ergot/src/interface_manager/profiles/direct_edge/tokio_tcp.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/tokio_tcp.rs
@@ -158,7 +158,7 @@ async fn tx_worker(mut tx: OwnedWriteHalf, rx: StreamConsumer<StdQueue>, closer:
         let res = tx.write_all(&frame).await;
         frame.release(len);
         if let Err(e) = res {
-            error!("Err: {:?}", e);
+            error!("Tx Error. socket: {:?}, error: {:?}", tx, e);
             break;
         }
     }

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/tokio_udp.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/tokio_udp.rs
@@ -181,8 +181,7 @@ async fn tx_worker(tx: Arc<UdpSocket>, rx: FramedConsumer<StdQueue>, closer: Arc
         let res = tx.send(&frame).await;
         frame.release();
         if let Err(e) = res {
-            error!("Err: {e:?}");
-            break;
+            error!("Tx Error. socket: {:?}, error: {:?}", tx, e);
         }
     }
     // TODO: GC waker?

--- a/crates/ergot/src/interface_manager/profiles/direct_router/tokio_tcp.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_router/tokio_tcp.rs
@@ -83,7 +83,7 @@ impl TxWorker {
             let res = self.tx.write_all(&frame).await;
             frame.release(len);
             if let Err(e) = res {
-                error!("Err: {:?}", e);
+                error!("Tx Error. socket: {:?}, error: {:?}", self.tx, e);
                 break;
             }
         }

--- a/crates/ergot/src/interface_manager/profiles/direct_router/tokio_udp.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_router/tokio_udp.rs
@@ -70,7 +70,7 @@ impl TxWorker {
             let res = self.tx.send(&frame).await;
             frame.release();
             if let Err(e) = res {
-                error!("Err: {e:?}");
+                error!("Tx Error. socket: {:?}, error: {:?}", self.tx, e);
                 break;
             }
         }


### PR DESCRIPTION
* useful context helps track which socket is being referred to, very helpful when multiple sockets are used.