### PR TITLE
Remove invalid unstable configuration

### DIFF
--- a/demos/microbit/.cargo/config.toml
+++ b/demos/microbit/.cargo/config.toml
@@ -6,7 +6,3 @@ target = "thumbv7em-none-eabihf"
 
 [env]
 DEFMT_LOG = "debug"
-
-[unstable]
-build-std = ["core"]
-build-std-features = ["panic_immediate_abort"]

--- a/demos/nrf52840/.cargo/config.toml
+++ b/demos/nrf52840/.cargo/config.toml
@@ -6,7 +6,3 @@ target = "thumbv7em-none-eabihf"
 
 [env]
 DEFMT_LOG = "debug"
-
-[unstable]
-build-std = ["core"]
-build-std-features = ["panic_immediate_abort"]

--- a/demos/rp2040/.cargo/config.toml
+++ b/demos/rp2040/.cargo/config.toml
@@ -11,7 +11,3 @@ target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+
 
 [env]
 DEFMT_LOG = "debug"
-
-[unstable]
-build-std = ["core"]
-build-std-features = ["panic_immediate_abort"]

--- a/demos/rp2350/.cargo/config.toml
+++ b/demos/rp2350/.cargo/config.toml
@@ -11,7 +11,3 @@ target = "thumbv8m.main-none-eabihf"
 
 [env]
 DEFMT_LOG = "error"
-
-[unstable]
-build-std = ["core"]
-build-std-features = ["panic_immediate_abort"]


### PR DESCRIPTION
These are no longer valid in the latest nightly. They fail with the following message:

```
error: panic_immediate_abort is now a real panic strategy! Enable it with `panic = "immediate-abort"` in Cargo.toml, or with the compiler flags `-Zunstable-options -Cpanic=immediate-abort`. In both cases, you still need to build core, e.g. with `-Zbuild-std`
  --> /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:36:1
   |
36 | / compile_error!(
37 | |     "panic_immediate_abort is now a real panic strategy! \
38 | |     Enable it with `panic = \"immediate-abort\"` in Cargo.toml, \
39 | |     or with the compiler flags `-Zunstable-options -Cpanic=immediate-abort`. \
40 | |     In both cases, you still need to build core, e.g. with `-Zbuild-std`"
41 | | );
   | |_^
```

This pull request addresses https://github.com/jamesmunns/ergot/issues/172, without preventing errors like this from popping up again. This could be done at the expense of complicating the CI build significantly. Please merge https://github.com/jamesmunns/ergot/pull/173 instead, if that is desirable.

Close https://github.com/jamesmunns/ergot/issues/172
Close https://github.com/jamesmunns/ergot/pull/173