### PR TITLE
Provide overview of documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Ergot has grown out of the lessons of the [`postcard`] and [`postcard-rpc`] proj
 
 Ergot is still very early in development. Bugs are expected. Help is welcome.
 
+## Documentation
+
+To learn more about ergot, you have multiple options:
+
+- [**Introduction**](https://docs.rs/ergot/latest/ergot/book/index.html): This is the best place to start, if you're new to ergot. It explains how ergot works, and how you use it.
+- [**Demos**](demos/): This repository contains a wide variety of demos that show how to use ergot in various scenarios.
+- [**API Reference**](https://docs.rs/ergot/latest/ergot/): Handy to have around, if you need to know more.
+
+Please note that the link to the API reference above covers the latest release. If you need it for an unreleased version (or just want to have a local copy), run `cargo doc --open` from [crates/ergot/](crates/ergot/).
+
 ## Community
 
 - [Join us on Matrix](https://matrix.to/#/#mnemos-dev:beeper.com)


### PR DESCRIPTION
While the README already links to the API reference, via the badge at the top, I think this is a bit too subtle and easy to miss. Adding a dedicated section makes the documentation overall more discoverable.

Since the README is included into the API reference, at the crate root, this also adds a sorely missing link to the introduction there.

This also means that we're going to link to the API reference, from the API reference, which is awkward. I'm not sure how to fix it though, without decoupling it from the README.