### PR TITLE
Simplify `docs.rs` documentation and build whole API

### DIFF
--- a/crates/cobs-acc/Cargo.toml
+++ b/crates/cobs-acc/Cargo.toml
@@ -15,7 +15,7 @@ keywords = []
 documentation = "https://docs.rs/cobs-acc/"
 
 [package.metadata.docs.rs]
-features        = ["std"]
+all-features = true
 
 [dependencies]
 cobs = { version = "0.4.0", default-features = false }

--- a/crates/ergot/Cargo.toml
+++ b/crates/ergot/Cargo.toml
@@ -15,7 +15,7 @@ keywords = []
 documentation = "https://docs.rs/ergot/"
 
 [package.metadata.docs.rs]
-features        = ["tokio-std"]
+all-features = true
 
 [features]
 default = [


### PR DESCRIPTION
Currently, a lot of the API surface is missing from the documentation on `docs.rs`.

Please note that I can't verify that this works. From the message of one of the commits:

> Please note that I don't have a way to test this, so I can't guarantee
> it'll work. But the documentation currently builds with all features
> (which is verified in [#178]), and the documentation on `docs.rs`
> metadata seems clear enough: https://docs.rs/about/metadata