### PR TITLE
Migrate from bbq2 to bbqueue 0.7.0

### DIFF
--- a/crates/ergot/Cargo.lock
+++ b/crates/ergot/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,18 +16,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -55,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -70,22 +55,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -104,31 +89,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "bbq2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "maitake-sync",
@@ -148,9 +112,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "byteorder"
@@ -160,15 +124,25 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
+name = "cc"
+version = "1.2.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -290,7 +264,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -304,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
@@ -319,9 +293,9 @@ checksum = "2fc328bf943af66b80b98755db9106bf7e7471b0cf47dc8559cd9a6be504cc9c"
 
 [[package]]
 name = "embassy-futures"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
 
 [[package]]
 name = "embassy-net"
@@ -352,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-net-driver-channel"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a567ab50319d866ad5e6c583ed665ba9b07865389644d3d82e45bf1497c934"
+checksum = "b7b2739fbcf6cd206ae08779c7d709087b16577d255f2ea4a45bc4bbbf305b3f"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
@@ -414,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-usb"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb69c7ca7fa90b9ae590e3dea985ef80df06d900a350f9cc9d3f3c8113fc4370"
+checksum = "dc4462e48b19a4f401a11901bdd981aab80c6a826608016a0bdc73cbbab31954"
 dependencies = [
  "defmt 1.0.1",
  "embassy-futures",
@@ -535,9 +509,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
@@ -560,7 +534,7 @@ dependencies = [
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -574,7 +548,7 @@ dependencies = [
  "embedded-io-async 0.6.1",
  "embedded-io-async 0.7.0",
  "env_logger",
- "heapless 0.9.1",
+ "heapless 0.9.2",
  "log",
  "maitake-sync",
  "mutex",
@@ -593,13 +567,19 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "futures"
@@ -657,7 +637,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -692,34 +672,30 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.4"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasip2",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hash32"
@@ -775,13 +751,13 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "defmt 1.0.1",
  "hash32 0.3.1",
- "serde",
+ "serde_core",
  "stable_deref_trait",
 ]
 
@@ -797,32 +773,32 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -833,9 +809,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "linux-raw-sys"
@@ -845,25 +821,24 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loom"
@@ -889,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
  "loom",
@@ -910,38 +885,29 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
-dependencies = [
- "adler2",
-]
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -959,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "mutex"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28c89c319522a8ee27f304b1aeb4faebf652c6b7e04de8b263d715ca68a5c71"
+checksum = "f23bf5944734b7a5d1bd0a9b594213dd04de471fd3d3a1bfce672913dd72d606"
 dependencies = [
  "critical-section",
  "mutex-traits",
@@ -969,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "mutex-traits"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd54cb762feb1788c74f5d3387983864d2365ca1819043d2addb76db80169102"
+checksum = "3929f2b5633d29cf7b6624992e5f3c1e9334f1193423e12d17be4faf678cde3f"
 
 [[package]]
 name = "mycelium-bitfield"
@@ -1011,7 +977,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1019,12 +985,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1047,15 +1012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,15 +1019,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project"
@@ -1090,7 +1040,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1107,9 +1057,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1141,7 +1091,7 @@ checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1150,7 +1100,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475666d89f42231a0a57da32d5f6ca7f9b5cd4c335ea1fe8f3278215b7a21ff"
 dependencies = [
- "heapless 0.9.1",
+ "heapless 0.9.2",
  "postcard-derive",
  "serde",
 ]
@@ -1183,23 +1133,23 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -1232,62 +1182,41 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustc_version"
@@ -1304,7 +1233,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1313,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scoped-tls"
@@ -1331,28 +1260,38 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1361,7 +1300,7 @@ version = "4.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acaf3f973e8616d7ceac415f53fc60e190b2a686fbcf8d27d0256c741c5007b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cfg-if",
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -1383,6 +1322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,9 +1335,9 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smoltcp"
@@ -1410,12 +1355,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1439,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_cell"
@@ -1465,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1476,59 +1421,57 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1547,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1558,20 +1501,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1590,14 +1533,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1608,18 +1551,18 @@ dependencies = [
 
 [[package]]
 name = "unescaper"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01d12e3a56a4432a8b436f293c25f4808bdf9e9f9f98f9260bba1f1bc5a1f26"
+checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "usb-device"
@@ -1694,15 +1637,15 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
@@ -1730,73 +1673,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1806,15 +1694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1832,7 +1711,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1868,19 +1756,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1897,9 +1785,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1915,9 +1803,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1933,9 +1821,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -1945,9 +1833,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1963,9 +1851,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1981,9 +1869,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1999,9 +1887,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2017,32 +1905,32 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]

--- a/crates/ergot/Cargo.toml
+++ b/crates/ergot/Cargo.toml
@@ -27,7 +27,7 @@ disable-cache-padding = [
     "maitake-sync/no-cache-pad",
 ]
 std = [
-    "bbq2/std",
+    "bbqueue/std",
     "cobs-acc/std",
     "cobs/std",
     "critical-section/std",
@@ -93,11 +93,11 @@ log                 = "0.4.27"
 postcard            = "1.1.3"
 pin-project         = "1.1.10"
 
-bbq2            = { version = "0.4.2",  default-features = false,   features = ["maitake-sync-0_2"] }
+bbqueue         = { version = "0.7.0",  default-features = false,   features = ["maitake-sync-0_3"] }
 cobs            = { version = "0.3.0",  default-features = false }
 cordyceps       = { version = "0.3.4",  default-features = false }
 embassy-time    = { version = "0.5.0", optional = true }
-maitake-sync    = { version = "0.2.2",  default-features = false }
+maitake-sync    = { version = "0.3.0",  default-features = false }
 mutex           = { version = "1.0.0",  features = ["impl-critical-section"] }
 serde           = { version = "1.0",    default-features = false,   features = ["derive"] }
 

--- a/crates/ergot/src/interface_manager/interface_impls/embassy_net_udp.rs
+++ b/crates/ergot/src/interface_manager/interface_impls/embassy_net_udp.rs
@@ -1,9 +1,9 @@
 use core::marker::PhantomData;
 
-use bbq2::queue::BBQueue;
-use bbq2::traits::bbqhdl::BbqHandle;
-use bbq2::traits::notifier::maitake::MaiNotSpsc;
-use bbq2::traits::storage::Inline;
+use bbqueue::BBQueue;
+use bbqueue::traits::bbqhdl::BbqHandle;
+use bbqueue::traits::notifier::maitake::MaiNotSpsc;
+use bbqueue::traits::storage::Inline;
 
 use crate::interface_manager::Interface;
 use crate::interface_manager::utils::framed_stream;

--- a/crates/ergot/src/interface_manager/interface_impls/embassy_usb.rs
+++ b/crates/ergot/src/interface_manager/interface_impls/embassy_usb.rs
@@ -12,8 +12,8 @@
 
 use core::{marker::PhantomData, sync::atomic::AtomicU8};
 
-use bbq2::{
-    queue::BBQueue,
+use bbqueue::{
+    BBQueue,
     traits::{bbqhdl::BbqHandle, notifier::maitake::MaiNotSpsc, storage::Inline},
 };
 use static_cell::ConstStaticCell;
@@ -109,9 +109,9 @@ pub mod eusb_0_5 {
     use core::sync::atomic::Ordering;
 
     use crate::logging::{debug, info, warn};
-    use bbq2::{
+    use bbqueue::{
+        BBQueue,
         prod_cons::framed::FramedConsumer,
-        queue::BBQueue,
         traits::{coordination::Coord, notifier::maitake::MaiNotSpsc, storage::Inline},
     };
     use embassy_futures::select::{Either, select};

--- a/crates/ergot/src/interface_manager/interface_impls/embedded_io.rs
+++ b/crates/ergot/src/interface_manager/interface_impls/embedded_io.rs
@@ -1,7 +1,7 @@
 use crate::logging::info;
-use bbq2::{
+use bbqueue::{
+    BBQueue,
     prod_cons::stream::StreamConsumer,
-    queue::BBQueue,
     traits::{
         bbqhdl::BbqHandle, coordination::Coord, notifier::maitake::MaiNotSpsc, storage::Inline,
     },

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/embassy_net_udp_0_7.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/embassy_net_udp_0_7.rs
@@ -5,11 +5,11 @@ use crate::interface_manager::{InterfaceState, Profile};
 use crate::logging::{error, trace};
 use crate::net_stack::NetStackHandle;
 use crate::wire_frames::MAX_HDR_ENCODED_SIZE;
-use bbq2::prod_cons::framed::FramedConsumer;
-use bbq2::queue::BBQueue;
-use bbq2::traits::coordination::Coord;
-use bbq2::traits::notifier::maitake::MaiNotSpsc;
-use bbq2::traits::storage::Inline;
+use bbqueue::BBQueue;
+use bbqueue::prod_cons::framed::FramedConsumer;
+use bbqueue::traits::coordination::Coord;
+use bbqueue::traits::notifier::maitake::MaiNotSpsc;
+use bbqueue::traits::storage::Inline;
 use embassy_futures::select::{Either, select};
 use embassy_net_0_7::udp::{RecvError, SendError, UdpMetadata, UdpSocket};
 

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/eusb_0_5.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/eusb_0_5.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     net_stack::NetStackHandle,
 };
-use bbq2::traits::bbqhdl::BbqHandle;
+use bbqueue::traits::bbqhdl::BbqHandle;
 use embassy_usb_0_5::driver::{Driver, Endpoint, EndpointError, EndpointOut};
 
 pub type EmbassyUsbManager<Q> = DirectEdge<EmbassyInterface<Q>>;

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/tokio_tcp.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/tokio_tcp.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use crate::logging::{error, info, trace, warn};
-use bbq2::{prod_cons::stream::StreamConsumer, traits::bbqhdl::BbqHandle};
+use bbqueue::{prod_cons::stream::StreamConsumer, traits::bbqhdl::BbqHandle};
 use maitake_sync::WaitQueue;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/tokio_udp.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/tokio_udp.rs
@@ -17,8 +17,8 @@ use crate::{
 
 use crate::interface_manager::profiles::direct_edge::{CENTRAL_NODE_ID, EDGE_NODE_ID};
 use crate::logging::{error, info, trace, warn};
-use bbq2::prod_cons::framed::FramedConsumer;
-use bbq2::traits::bbqhdl::BbqHandle;
+use bbqueue::prod_cons::framed::FramedConsumer;
+use bbqueue::traits::bbqhdl::BbqHandle;
 use maitake_sync::WaitQueue;
 use tokio::{net::UdpSocket, select};
 

--- a/crates/ergot/src/interface_manager/profiles/direct_router/nusb_0_1.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_router/nusb_0_1.rs
@@ -3,7 +3,7 @@
 //! This implementation can be used to connect to a number of direct edge USB devices.
 
 use crate::logging::{debug, error, info, trace, warn};
-use bbq2::{prod_cons::framed::FramedConsumer, traits::bbqhdl::BbqHandle};
+use bbqueue::{prod_cons::framed::FramedConsumer, traits::bbqhdl::BbqHandle};
 use maitake_sync::WaitQueue;
 use nusb::transfer::{Queue, RequestBuffer, TransferError};
 use std::sync::Arc;

--- a/crates/ergot/src/interface_manager/profiles/direct_router/tokio_serial_5.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_router/tokio_serial_5.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     net_stack::NetStackHandle,
 };
-use bbq2::{prod_cons::stream::StreamConsumer, traits::bbqhdl::BbqHandle};
+use bbqueue::{prod_cons::stream::StreamConsumer, traits::bbqhdl::BbqHandle};
 use cobs::max_encoding_overhead;
 use maitake_sync::WaitQueue;
 use std::sync::Arc;

--- a/crates/ergot/src/interface_manager/profiles/direct_router/tokio_tcp.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_router/tokio_tcp.rs
@@ -3,7 +3,7 @@
 //! This implementation can be used to connect to a number of direct edge TCP devices.
 
 use crate::logging::{debug, error, info, warn};
-use bbq2::{prod_cons::stream::StreamConsumer, traits::bbqhdl::BbqHandle};
+use bbqueue::{prod_cons::stream::StreamConsumer, traits::bbqhdl::BbqHandle};
 use cobs::max_encoding_overhead;
 use maitake_sync::WaitQueue;
 use std::sync::Arc;

--- a/crates/ergot/src/interface_manager/profiles/direct_router/tokio_udp.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_router/tokio_udp.rs
@@ -3,7 +3,7 @@
 //! This implementation can be used to connect to a number of direct edge UDP devices.
 
 use crate::logging::{debug, error, info, trace, warn};
-use bbq2::{prod_cons::framed::FramedConsumer, traits::bbqhdl::BbqHandle};
+use bbqueue::{prod_cons::framed::FramedConsumer, traits::bbqhdl::BbqHandle};
 use maitake_sync::WaitQueue;
 use std::sync::Arc;
 use tokio::{net::UdpSocket, select};

--- a/crates/ergot/src/interface_manager/utils/cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/cobs_stream.rs
@@ -3,7 +3,7 @@
 //! The "Cobs Stream" is one flavor of interface sinks. It is intended for serial-like
 //! interfaces that require framing in software.
 
-use bbq2::{prod_cons::stream::StreamProducer, traits::bbqhdl::BbqHandle};
+use bbqueue::{prod_cons::stream::StreamProducer, traits::bbqhdl::BbqHandle};
 use postcard::{
     Serializer,
     ser_flavors::{self, Flavor},

--- a/crates/ergot/src/interface_manager/utils/framed_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/framed_stream.rs
@@ -3,7 +3,7 @@
 //! The "Framed Stream" is one flavor of interface sinks. It is intended for packet-like
 //! interfaces that do NOT require framing in software.
 
-use bbq2::{prod_cons::framed::FramedProducer, traits::bbqhdl::BbqHandle};
+use bbqueue::{prod_cons::framed::FramedProducer, traits::bbqhdl::BbqHandle};
 use postcard::{
     Serializer,
     ser_flavors::{self, Flavor, Slice},

--- a/crates/ergot/src/interface_manager/utils/std.rs
+++ b/crates/ergot/src/interface_manager/utils/std.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use bbq2::{
-    queue::BBQueue,
+use bbqueue::{
+    BBQueue,
     traits::{coordination::cas::AtomicCoord, notifier::maitake::MaiNotSpsc, storage::BoxedSlice},
 };
 

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -214,7 +214,7 @@ pub const DEFAULT_TTL: u8 = 16;
 
 /// Exports of used crate versions
 pub mod exports {
-    pub use bbq2;
+    pub use bbqueue;
     pub use mutex;
 }
 

--- a/crates/ergot/src/socket/borrow.rs
+++ b/crates/ergot/src/socket/borrow.rs
@@ -1,10 +1,10 @@
 //! "Borrow" sockets
 //!
-//! Borrow sockets use a `bbq2` queue to store the serialized form of messages.
+//! Borrow sockets use a `bbqueue` queue to store the serialized form of messages.
 //!
 //! This allows for sending and receiving borrowed types like `&str` or `&[u8]`,
 //! or messages that contain borrowed types. This is achieved by serializing
-//! messages into the bbq2 ring buffer when inserting into the socket, and
+//! messages into the bbqueue ring buffer when inserting into the socket, and
 //! deserializing when removing from the socket.
 //!
 //! Although you can use borrowed sockets for types that are fully owned, e.g.
@@ -22,7 +22,7 @@ use core::{
     task::{Context, Poll, Waker},
 };
 
-use bbq2::{
+use bbqueue::{
     prod_cons::framed::{FramedConsumer, FramedGrantR},
     traits::bbqhdl::BbqHandle,
 };

--- a/crates/ergot/src/socket/topic.rs
+++ b/crates/ergot/src/socket/topic.rs
@@ -305,7 +305,7 @@ pub mod stack_bor {
     use crate::traits::Topic;
     use crate::{
         FrameKind, Key,
-        exports::bbq2::traits::bbqhdl::BbqHandle,
+        exports::bbqueue::traits::bbqhdl::BbqHandle,
         net_stack::NetStackHandle,
         socket::{
             Attributes,

--- a/crates/ergot/src/toolkits/mod.rs
+++ b/crates/ergot/src/toolkits/mod.rs
@@ -27,9 +27,9 @@ pub mod null {
 #[cfg(feature = "embedded-io-async-v0_6")]
 pub mod embedded_io_async_v0_6 {
     use crate::{
-        exports::bbq2::{
+        exports::bbqueue::{
+            BBQueue,
             prod_cons::stream::StreamProducer,
-            queue::BBQueue,
             traits::{bbqhdl::BbqHandle, notifier::maitake::MaiNotSpsc, storage::Inline},
         },
         interface_manager::{
@@ -62,9 +62,9 @@ pub mod embedded_io_async_v0_6 {
 #[cfg(feature = "embedded-io-async-v0_7")]
 pub mod embedded_io_async_v0_7 {
     use crate::{
-        exports::bbq2::{
+        exports::bbqueue::{
+            BBQueue,
             prod_cons::stream::StreamProducer,
-            queue::BBQueue,
             traits::{bbqhdl::BbqHandle, notifier::maitake::MaiNotSpsc, storage::Inline},
         },
         interface_manager::{
@@ -97,9 +97,9 @@ pub mod embedded_io_async_v0_7 {
 #[cfg(feature = "embassy-usb-v0_5")]
 pub mod embassy_usb_v0_5 {
     use crate::{
-        exports::bbq2::{
+        exports::bbqueue::{
+            BBQueue,
             prod_cons::framed::FramedProducer,
-            queue::BBQueue,
             traits::{bbqhdl::BbqHandle, notifier::maitake::MaiNotSpsc, storage::Inline},
         },
         interface_manager::{
@@ -140,11 +140,11 @@ pub mod embassy_net_v0_7 {
     use crate::interface_manager::interface_impls::embassy_net_udp::EmbassyNetInterface;
     use crate::interface_manager::profiles::direct_edge::DirectEdge;
     use crate::interface_manager::utils::framed_stream::Sink;
-    use bbq2::prod_cons::framed::FramedProducer;
-    use bbq2::queue::BBQueue;
-    use bbq2::traits::bbqhdl::BbqHandle;
-    use bbq2::traits::notifier::maitake::MaiNotSpsc;
-    use bbq2::traits::storage::Inline;
+    use bbqueue::BBQueue;
+    use bbqueue::prod_cons::framed::FramedProducer;
+    use bbqueue::traits::bbqhdl::BbqHandle;
+    use bbqueue::traits::notifier::maitake::MaiNotSpsc;
+    use bbqueue::traits::storage::Inline;
     use maitake_sync::blocking::{ConstInit, ScopedRawMutex};
 
     pub type Queue<const N: usize, C> = BBQueue<Inline<N>, C, MaiNotSpsc>;

--- a/crates/ergot/tests/smoke.rs
+++ b/crates/ergot/tests/smoke.rs
@@ -1,7 +1,7 @@
 use std::{pin::pin, time::Duration};
 
-use bbq2::{
-    queue::BBQueue,
+use bbqueue::{
+    BBQueue,
     traits::{coordination::cas::AtomicCoord, notifier::maitake::MaiNotSpsc, storage::Inline},
 };
 use ergot::{

--- a/demos/esp32c3/Cargo.lock
+++ b/demos/esp32c3/Cargo.lock
@@ -42,10 +42,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "critical-section",
@@ -524,7 +524,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -752,7 +752,7 @@ dependencies = [
 name = "esp32c3-serial"
 version = "0.1.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "critical-section",
  "defmt 1.0.1",
  "embassy-executor",
@@ -766,6 +766,7 @@ dependencies = [
  "esp-hal-smartled",
  "mutex",
  "panic-rtt-target",
+ "portable-atomic",
  "rtt-target",
  "smart-leds",
  "static_cell",
@@ -1080,11 +1081,12 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
+ "critical-section",
  "loom",
  "mutex-traits",
  "mycelium-bitfield",

--- a/demos/esp32c3/Cargo.toml
+++ b/demos/esp32c3/Cargo.toml
@@ -5,7 +5,9 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-ergot   = { path = "../../crates/ergot", features = ["embedded-io-async-v0_6"] }
+bbqueue         = { version = "0.7.0", default-features = false, features = ["critical-section", "maitake-sync-0_3"] }
+ergot           = { path = "../../crates/ergot", features = ["embedded-io-async-v0_6"] }
+portable-atomic = { version = "1.6.0", default-features = false }
 
 [profile.dev]
 # Rust debug is too slow.

--- a/demos/esp32c3/esp32c3-serial/Cargo.toml
+++ b/demos/esp32c3/esp32c3-serial/Cargo.toml
@@ -4,7 +4,9 @@ edition = "2024"
 version = "0.1.0"
 
 [dependencies]
-ergot                   = { workspace = true }
+bbqueue             = { workspace = true }
+ergot               = { workspace = true }
+portable-atomic     = { workspace = true }
 
 critical-section    = "1.2"
 defmt               = "1"
@@ -23,4 +25,3 @@ rtt-target              = { version = "0.6.1",      features = ["defmt"] }
 static_cell             = { version = "2.1.1" }
 
 esp-hal-smartled        = { git = "https://github.com/esp-rs/esp-hal-community", rev = "20badf1b03727153074fd647b5a3c2a26310ad3e" }
-bbq2 = {version = "0.4.2", features = ["critical-section"]}

--- a/demos/esp32c3/esp32c3-serial/src/main.rs
+++ b/demos/esp32c3/esp32c3-serial/src/main.rs
@@ -4,7 +4,7 @@
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Ticker};
 use ergot::{
-    exports::bbq2::traits::coordination::cs::CsCoord,
+    exports::bbqueue::traits::coordination::cs::CsCoord,
     fmt,
     toolkits::embedded_io_async_v0_6::{self as kit, tx_worker},
 };

--- a/demos/esp32c6/Cargo.lock
+++ b/demos/esp32c6/Cargo.lock
@@ -42,10 +42,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "maitake-sync",
@@ -523,7 +523,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
  "loom",

--- a/demos/esp32c6/esp32c6-serial/src/main.rs
+++ b/demos/esp32c6/esp32c6-serial/src/main.rs
@@ -4,7 +4,7 @@
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Ticker};
 use ergot::{
-    exports::bbq2::traits::coordination::cas::AtomicCoord,
+    exports::bbqueue::traits::coordination::cas::AtomicCoord,
     logging::log_v0_4::LogSink,
     toolkits::embedded_io_async_v0_6::{self as kit, tx_worker},
 };

--- a/demos/microbit/Cargo.lock
+++ b/demos/microbit/Cargo.lock
@@ -54,10 +54,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "critical-section",
@@ -628,7 +628,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -832,11 +832,12 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
+ "critical-section",
  "loom",
  "mutex-traits",
  "mycelium-bitfield",
@@ -870,7 +871,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 name = "microbit-null"
 version = "0.1.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cortex-m",
  "cortex-m-rt",
  "defmt 1.0.1",

--- a/demos/microbit/Cargo.toml
+++ b/demos/microbit/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.dependencies]
 ergot   = { path = "../../crates/ergot", features = ["embassy-usb-v0_5", "defmt-v1"] }
 
-bbq2                = { version = "0.4.1", default-features = false, features = ["critical-section", "maitake-sync-0_2"] }
+bbqueue             = { version = "0.7.0", default-features = false, features = ["critical-section", "maitake-sync-0_3"] }
 cortex-m            = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 embassy-executor    = { version = "0.9.1", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-nrf         = { version = "0.8.0", features = ["defmt", "nrf52833", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }

--- a/demos/microbit/microbit-null/Cargo.toml
+++ b/demos/microbit/microbit-null/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 ergot               = { workspace = true }
 
-bbq2                = { workspace = true }
+bbqueue             = { workspace = true }
 cortex-m            = { workspace = true }
 embassy-executor    = { workspace = true }
 embassy-nrf         = { workspace = true }

--- a/demos/nrf52840/Cargo.lock
+++ b/demos/nrf52840/Cargo.lock
@@ -54,10 +54,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "critical-section",
@@ -627,7 +627,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -825,11 +825,12 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
+ "critical-section",
  "loom",
  "mutex-traits",
  "mycelium-bitfield",
@@ -910,7 +911,7 @@ dependencies = [
 name = "nrf52840-eusb"
 version = "0.1.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cortex-m",
  "cortex-m-rt",
  "defmt 1.0.1",

--- a/demos/nrf52840/Cargo.toml
+++ b/demos/nrf52840/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [workspace.dependencies]
 ergot   = { path = "../../crates/ergot", features = ["embassy-usb-v0_5", "defmt-v1"] }
 
-bbq2                = { version = "0.4.1", default-features = false, features = ["critical-section", "maitake-sync-0_2"] }
+bbqueue             = { version = "0.7.0", default-features = false, features = ["critical-section", "maitake-sync-0_3"] }
 cortex-m            = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 embassy-executor    = { version = "0.9.1", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-nrf         = { version = "0.8.0", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }

--- a/demos/nrf52840/nrf52840-eusb/Cargo.toml
+++ b/demos/nrf52840/nrf52840-eusb/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 ergot               = { workspace = true }
 
-bbq2                = { workspace = true }
+bbqueue             = { workspace = true }
 cortex-m            = { workspace = true }
 embassy-executor    = { workspace = true }
 embassy-nrf         = { workspace = true }

--- a/demos/nrf52840/nrf52840-eusb/src/main.rs
+++ b/demos/nrf52840/nrf52840-eusb/src/main.rs
@@ -18,7 +18,7 @@ use embassy_time::{Duration, Timer, WithTimeout};
 use embassy_usb::{driver::Driver, Config, UsbDevice};
 use ergot::{
     endpoint,
-    exports::bbq2::{prod_cons::framed::FramedConsumer, traits::coordination::cas::AtomicCoord},
+    exports::bbqueue::{prod_cons::framed::FramedConsumer, traits::coordination::cas::AtomicCoord},
     toolkits::embassy_usb_v0_5 as kit,
     topic, Address,
 };

--- a/demos/rp2040/Cargo.lock
+++ b/demos/rp2040/Cargo.lock
@@ -69,10 +69,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "critical-section",
@@ -754,7 +754,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -1034,11 +1034,12 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
+ "critical-section",
  "loom",
  "mutex-traits",
  "mycelium-bitfield",
@@ -1486,7 +1487,7 @@ dependencies = [
 name = "rp2040-eusb"
 version = "0.1.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cortex-m",
  "cortex-m-rt",
  "defmt 1.0.1",
@@ -1526,7 +1527,7 @@ dependencies = [
 name = "rp2040-serial-pair"
 version = "0.1.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cortex-m",
  "cortex-m-rt",
  "defmt 1.0.1",

--- a/demos/rp2040/Cargo.toml
+++ b/demos/rp2040/Cargo.toml
@@ -7,13 +7,13 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-bbq2                = { version = "0.4.1", default-features = false, features = ["critical-section", "maitake-sync-0_2"] }
+bbqueue             = { version = "0.7.0", default-features = false, features = ["critical-section", "maitake-sync-0_3"] }
 cortex-m            = { version = "0.7.6", features = ["inline-asm"] }
 embassy-executor    = { version = "0.9.1", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-rp          = { version = "0.8.0", features = ["rp2040", "defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
 embassy-time        = { version = "0.5.0", features = ["defmt", "defmt-timestamp-uptime"] }
 ergot               = { path = "../../crates/ergot", features = ["embassy-usb-v0_5", "defmt-v1"] }
-maitake-sync        = { version = "0.2.2", default-features = false }
+maitake-sync        = { version = "0.3.0", default-features = false }
 panic-probe         = { version = "0.3",   features = ["print-defmt"] }
 portable-atomic     = { version = "1.6.0", features = ["critical-section"] }
 serde               = { version = "1.0", default-features = false, features = ["derive"] }

--- a/demos/rp2040/rp2040-eusb/Cargo.toml
+++ b/demos/rp2040/rp2040-eusb/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bbq2                = { workspace = true }
+bbqueue             = { workspace = true }
 cortex-m            = { workspace = true }
 cortex-m-rt         = { workspace = true }
 defmt               = { workspace = true }

--- a/demos/rp2040/rp2040-eusb/src/main.rs
+++ b/demos/rp2040/rp2040-eusb/src/main.rs
@@ -17,7 +17,7 @@ use embassy_time::{Duration, Ticker, Timer};
 use embassy_usb::{driver::Driver, Config, UsbDevice};
 use ergot::{
     endpoint,
-    exports::bbq2::{prod_cons::framed::FramedConsumer, traits::coordination::cs::CsCoord},
+    exports::bbqueue::{prod_cons::framed::FramedConsumer, traits::coordination::cs::CsCoord},
     toolkits::embassy_usb_v0_5 as kit,
     topic, Address,
 };

--- a/demos/rp2040/rp2040-serial-pair/Cargo.toml
+++ b/demos/rp2040/rp2040-serial-pair/Cargo.toml
@@ -17,6 +17,6 @@ defmt               = { workspace = true }
 defmt-rtt           = { workspace = true }
 mutex               = { workspace = true }
 serde               = { workspace = true }
-bbq2                = { workspace = true }
+bbqueue             = { workspace = true }
 embassy-futures     = { workspace = true }
 static_cell         = { workspace = true }

--- a/demos/rp2040/rp2040-serial-pair/src/bin/controller.rs
+++ b/demos/rp2040/rp2040-serial-pair/src/bin/controller.rs
@@ -5,8 +5,8 @@
 
 use core::pin::pin;
 
-use bbq2::{
-    queue::BBQueue,
+use bbqueue::{
+    BBQueue,
     traits::{coordination::cs::CsCoord, notifier::maitake::MaiNotSpsc, storage::Inline},
 };
 use defmt::info;

--- a/demos/rp2040/rp2040-serial-pair/src/bin/target.rs
+++ b/demos/rp2040/rp2040-serial-pair/src/bin/target.rs
@@ -5,8 +5,8 @@
 
 use core::pin::pin;
 
-use bbq2::{
-    queue::BBQueue,
+use bbqueue::{
+    BBQueue,
     traits::{coordination::cs::CsCoord, notifier::maitake::MaiNotSpsc, storage::Inline},
 };
 use defmt::info;

--- a/demos/rp2040/rp2040-serial-pair/src/lib.rs
+++ b/demos/rp2040/rp2040-serial-pair/src/lib.rs
@@ -3,9 +3,9 @@
 
 use core::marker::PhantomData;
 
-use bbq2::{
+use bbqueue::{
     prod_cons::framed::{FramedConsumer, FramedProducer},
-    queue::BBQueue,
+    BBQueue,
     traits::{
         bbqhdl::BbqHandle,
         notifier::{maitake::MaiNotSpsc, AsyncNotifier},

--- a/demos/rp2350/Cargo.lock
+++ b/demos/rp2350/Cargo.lock
@@ -69,10 +69,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "critical-section",
@@ -765,7 +765,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -1045,11 +1045,12 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
+ "critical-section",
  "loom",
  "mutex-traits",
  "mycelium-bitfield",
@@ -1497,7 +1498,7 @@ dependencies = [
 name = "rp2350-eusb"
 version = "0.1.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cortex-m",
  "cortex-m-rt",
  "defmt 1.0.1",
@@ -1537,7 +1538,7 @@ dependencies = [
 name = "rp2350-tilt"
 version = "0.1.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cortex-m",
  "cortex-m-rt",
  "defmt 1.0.1",

--- a/demos/rp2350/Cargo.toml
+++ b/demos/rp2350/Cargo.toml
@@ -7,13 +7,13 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-bbq2                = { version = "0.4.1", default-features = false, features = ["critical-section", "maitake-sync-0_2"] }
+bbqueue             = { version = "0.7.0", default-features = false, features = ["critical-section", "maitake-sync-0_3"] }
 cortex-m            = { version = "0.7.6", features = ["inline-asm"] }
 embassy-executor    = { version = "0.9.1", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-rp          = { version = "0.8.0", features = ["rp235xa", "defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
 embassy-time        = { version = "0.5.0", features = ["defmt", "defmt-timestamp-uptime"] }
 ergot               = { path = "../../crates/ergot", features = ["embassy-usb-v0_5", "defmt-v1"] }
-maitake-sync        = { version = "0.2.2", default-features = false }
+maitake-sync        = { version = "0.3.0", default-features = false }
 panic-probe         = { version = "0.3",   features = ["print-defmt"] }
 portable-atomic     = { version = "1.6.0", features = ["critical-section"] }
 serde               = { version = "1.0", default-features = false, features = ["derive"] }

--- a/demos/rp2350/rp2350-eusb/Cargo.toml
+++ b/demos/rp2350/rp2350-eusb/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bbq2                = { workspace = true }
+bbqueue             = { workspace = true }
 cortex-m            = { workspace = true }
 cortex-m-rt         = { workspace = true }
 defmt               = { workspace = true }

--- a/demos/rp2350/rp2350-eusb/src/main.rs
+++ b/demos/rp2350/rp2350-eusb/src/main.rs
@@ -17,7 +17,7 @@ use embassy_time::{Duration, Ticker, Timer};
 use embassy_usb::{driver::Driver, Config, UsbDevice};
 use ergot::{
     endpoint,
-    exports::bbq2::{prod_cons::framed::FramedConsumer, traits::coordination::cs::CsCoord},
+    exports::bbqueue::{prod_cons::framed::FramedConsumer, traits::coordination::cs::CsCoord},
     toolkits::embassy_usb_v0_5 as kit,
     topic, Address,
 };

--- a/demos/rp2350/rp2350-tilt/Cargo.toml
+++ b/demos/rp2350/rp2350-tilt/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bbq2.workspace = true
+bbqueue.workspace = true
 cortex-m-rt.workspace = true
 cortex-m.workspace = true
 defmt-rtt.workspace = true

--- a/demos/rp2350/rp2350-tilt/src/main.rs
+++ b/demos/rp2350/rp2350-tilt/src/main.rs
@@ -20,7 +20,7 @@ use embassy_usb::{driver::Driver, Config, UsbDevice};
 use embedded_hal::spi::SpiDevice;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use ergot::{
-    exports::bbq2::{prod_cons::framed::FramedConsumer, traits::coordination::cs::CsCoord},
+    exports::bbqueue::{prod_cons::framed::FramedConsumer, traits::coordination::cs::CsCoord},
     fmt,
     interface_manager::InterfaceState,
     interface_manager::Profile,

--- a/demos/shared-icd/Cargo.lock
+++ b/demos/shared-icd/Cargo.lock
@@ -27,10 +27,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "maitake-sync",
@@ -120,7 +120,7 @@ checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
  "loom",

--- a/demos/std/Cargo.lock
+++ b/demos/std/Cargo.lock
@@ -496,10 +496,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "maitake-sync",
@@ -1214,7 +1214,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -2179,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
  "loom",

--- a/demos/stm32f303vc/Cargo.lock
+++ b/demos/stm32f303vc/Cargo.lock
@@ -66,10 +66,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "maitake-sync",
@@ -688,7 +688,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
  "loom",

--- a/demos/stm32h723zg/Cargo.lock
+++ b/demos/stm32h723zg/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,10 +72,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "critical-section",
@@ -81,6 +93,12 @@ name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
+name = "bitfield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
@@ -184,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal",
- "bitfield",
+ "bitfield 0.13.2",
  "critical-section",
  "embedded-hal 0.2.7",
  "volatile-register",
@@ -394,7 +412,7 @@ dependencies = [
  "embassy-net-driver",
  "embassy-sync",
  "embassy-time",
- "embedded-io-async",
+ "embedded-io-async 0.6.1",
  "embedded-nal-async",
  "heapless 0.8.0",
  "managed",
@@ -408,6 +426,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524eb3c489760508f71360112bca70f6e53173e6fe48fc5f0efd0f5ab217751d"
 dependencies = [
  "defmt 0.3.100",
+]
+
+[[package]]
+name = "embassy-net-driver-channel"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b2739fbcf6cd206ae08779c7d709087b16577d255f2ea4a45bc4bbbf305b3f"
+dependencies = [
+ "embassy-futures",
+ "embassy-net-driver",
+ "embassy-sync",
 ]
 
 [[package]]
@@ -441,8 +470,8 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-nb",
- "embedded-io",
- "embedded-io-async",
+ "embedded-io 0.6.1",
+ "embedded-io-async 0.6.1",
  "embedded-storage",
  "embedded-storage-async",
  "futures-util",
@@ -468,7 +497,7 @@ dependencies = [
  "cfg-if",
  "critical-section",
  "defmt 1.0.1",
- "embedded-io-async",
+ "embedded-io-async 0.6.1",
  "futures-core",
  "futures-sink",
  "heapless 0.8.0",
@@ -511,13 +540,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-usb"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc4462e48b19a4f401a11901bdd981aab80c6a826608016a0bdc73cbbab31954"
+dependencies = [
+ "defmt 1.0.1",
+ "embassy-futures",
+ "embassy-net-driver-channel",
+ "embassy-sync",
+ "embassy-usb-driver",
+ "embedded-io-async 0.6.1",
+ "heapless 0.8.0",
+ "ssmarshal",
+ "usbd-hid",
+]
+
+[[package]]
 name = "embassy-usb-driver"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17119855ccc2d1f7470a39756b12068454ae27a3eabb037d940b5c03d9c77b7a"
 dependencies = [
  "defmt 1.0.1",
- "embedded-io-async",
+ "embedded-io-async 0.6.1",
 ]
 
 [[package]]
@@ -598,13 +644,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
 name = "embedded-io-async"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "defmt 0.3.100",
- "embedded-io",
+ "embedded-io 0.6.1",
+]
+
+[[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "defmt 1.0.1",
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -622,7 +687,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76959917cd2b86f40a98c28dd5624eddd1fa69d746241c8257eac428d83cb211"
 dependencies = [
- "embedded-io-async",
+ "embedded-io-async 0.6.1",
  "embedded-nal",
 ]
 
@@ -642,10 +707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "ergot"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -654,6 +725,10 @@ dependencies = [
  "defmt 1.0.1",
  "embassy-futures",
  "embassy-net",
+ "embassy-time",
+ "embassy-usb",
+ "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "heapless 0.9.1",
  "log",
  "maitake-sync",
@@ -732,6 +807,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -831,11 +915,12 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
+ "critical-section",
  "loom",
  "mutex-traits",
  "mycelium-bitfield",
@@ -934,7 +1019,7 @@ dependencies = [
 name = "nucleoh723zg-net-udp-pair"
 version = "0.1.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cortex-m",
  "cortex-m-rt",
  "defmt 1.0.1",
@@ -1294,6 +1379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssmarshal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e6ad23b128192ed337dfa4f1b8099ced0c2bf30d61e551b65fda5916dbb850"
+dependencies = [
+ "encode_unicode",
+ "serde",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,6 +1573,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "usb-device"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
+dependencies = [
+ "heapless 0.8.0",
+ "portable-atomic",
+]
+
+[[package]]
+name = "usbd-hid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f291ab53d428685cc780f08a2eb9d5d6ff58622db2b36e239a4f715f1e184c"
+dependencies = [
+ "serde",
+ "ssmarshal",
+ "usb-device",
+ "usbd-hid-macros",
+]
+
+[[package]]
+name = "usbd-hid-descriptors"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee54712c5d778d2fb2da43b1ce5a7b5060886ef7b09891baeb4bf36910a3ed"
+dependencies = [
+ "bitfield 0.14.0",
+]
+
+[[package]]
+name = "usbd-hid-macros"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb573c76e7884035ac5e1ab4a81234c187a82b6100140af0ab45757650ccda38"
+dependencies = [
+ "byteorder",
+ "hashbrown",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+ "usbd-hid-descriptors",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1630,12 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -1635,4 +1783,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]

--- a/demos/stm32h723zg/Cargo.toml
+++ b/demos/stm32h723zg/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-ergot = { path = "../../crates/ergot", features = ["embassy-net-v0_7"] }
+ergot = { path = "../../crates/ergot", features = ["embassy-net-v0_7", "defmt-v1"] }
 
 cortex-m-rt    = "0.7.0"
 defmt          = "1.0.1"
@@ -16,7 +16,7 @@ mutex          = "1.0.2"
 static_cell    = "2.1.1"
 embedded-alloc = "0.6.0"
 
-bbq2              = { version = "0.4.1", default-features = false, features = ["critical-section", "maitake-sync-0_2"] }
+bbqueue           = { version = "0.7.0", default-features = false, features = ["critical-section", "maitake-sync-0_3"] }
 
 cortex-m          = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 embassy-executor  = { version = "0.9.1",  features = ["defmt", "arch-cortex-m", "executor-thread", "executor-interrupt"] }

--- a/demos/stm32h723zg/nucleoh723zg-net-udp-pair/Cargo.toml
+++ b/demos/stm32h723zg/nucleoh723zg-net-udp-pair/Cargo.toml
@@ -21,6 +21,6 @@ panic-probe.workspace = true
 postcard-schema.workspace = true
 serde.workspace = true
 static_cell.workspace = true
-bbq2.workspace = true
+bbqueue.workspace = true
 log = "0.4.27"
 embedded-alloc.workspace = true

--- a/demos/stm32h723zg/nucleoh723zg-net-udp-pair/src/bin/controller.rs
+++ b/demos/stm32h723zg/nucleoh723zg-net-udp-pair/src/bin/controller.rs
@@ -22,7 +22,7 @@ use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, eth, peripherals, rcc, rng};
 use embassy_time::{Duration, Ticker, Timer, WithTimeout};
 use embedded_alloc::LlffHeap as Heap;
-use ergot::exports::bbq2::traits::coordination::cas::AtomicCoord;
+use ergot::exports::bbqueue::traits::coordination::cas::AtomicCoord;
 use ergot::interface_manager::profiles::direct_edge::embassy_net_udp_0_7::{RxTxWorker, UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX, UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX};
 use ergot::logging::log_v0_4::LogSink;
 use ergot::toolkits::embassy_net_v0_7 as kit;

--- a/demos/stm32h723zg/nucleoh723zg-net-udp-pair/src/bin/target.rs
+++ b/demos/stm32h723zg/nucleoh723zg-net-udp-pair/src/bin/target.rs
@@ -22,7 +22,7 @@ use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, eth, peripherals, rcc, rng};
 use embassy_time::{Duration, Ticker, Timer, WithTimeout};
 use embedded_alloc::LlffHeap as Heap;
-use ergot::exports::bbq2::traits::coordination::cas::AtomicCoord;
+use ergot::exports::bbqueue::traits::coordination::cas::AtomicCoord;
 use ergot::interface_manager::profiles::direct_edge::embassy_net_udp_0_7::{RxTxWorker, UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX, UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX};
 use ergot::logging::log_v0_4::LogSink;
 use ergot::toolkits::embassy_net_v0_7 as kit;

--- a/demos/stm32h743zi/Cargo.lock
+++ b/demos/stm32h743zi/Cargo.lock
@@ -72,10 +72,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "bbq2"
-version = "0.4.2"
+name = "bbqueue"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3e5fd78b60ce3a60e21e9a92b1d5e741328264de8e609193e2bf7616747bd"
+checksum = "68917624e17aad88607cb5a5936f6da9b607c48c711e4e9ed101e7189aed28c2"
 dependencies = [
  "const-init",
  "critical-section",
@@ -716,7 +716,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 name = "ergot"
 version = "0.12.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cobs 0.3.0",
  "cobs-acc",
  "const-fnv1a-hash",
@@ -915,11 +915,12 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748f86d9befd480b602c3bebc9ef30dbf2f3dfc8acc4a73d07b90f0117e6de3f"
+checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
+ "critical-section",
  "loom",
  "mutex-traits",
  "mycelium-bitfield",
@@ -1018,7 +1019,7 @@ dependencies = [
 name = "nucleoh743zi-net-udp-pair"
 version = "0.1.0"
 dependencies = [
- "bbq2",
+ "bbqueue",
  "cortex-m",
  "cortex-m-rt",
  "defmt 1.0.1",

--- a/demos/stm32h743zi/Cargo.toml
+++ b/demos/stm32h743zi/Cargo.toml
@@ -16,7 +16,7 @@ mutex          = "1.0.2"
 static_cell    = "2.1.1"
 embedded-alloc = "0.6.0"
 
-bbq2              = { version = "0.4.1", default-features = false, features = ["critical-section", "maitake-sync-0_2"] }
+bbqueue           = { version = "0.7.0", default-features = false, features = ["critical-section", "maitake-sync-0_3"] }
 
 cortex-m          = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 embassy-executor  = { version = "0.9.1",  features = ["defmt", "arch-cortex-m", "executor-thread", "executor-interrupt"] }

--- a/demos/stm32h743zi/nucleoh743zi-net-udp-pair/Cargo.toml
+++ b/demos/stm32h743zi/nucleoh743zi-net-udp-pair/Cargo.toml
@@ -21,6 +21,6 @@ panic-probe.workspace = true
 postcard-schema.workspace = true
 serde.workspace = true
 static_cell.workspace = true
-bbq2.workspace = true
+bbqueue.workspace = true
 log = "0.4.27"
 embedded-alloc.workspace = true

--- a/demos/stm32h743zi/nucleoh743zi-net-udp-pair/src/bin/controller.rs
+++ b/demos/stm32h743zi/nucleoh743zi-net-udp-pair/src/bin/controller.rs
@@ -22,7 +22,7 @@ use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, eth, peripherals, rcc, rng};
 use embassy_time::{Duration, Ticker, Timer, WithTimeout};
 use embedded_alloc::LlffHeap as Heap;
-use ergot::exports::bbq2::traits::coordination::cas::AtomicCoord;
+use ergot::exports::bbqueue::traits::coordination::cas::AtomicCoord;
 use ergot::interface_manager::profiles::direct_edge::embassy_net_udp_0_7::{RxTxWorker, UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX, UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX};
 use ergot::logging::log_v0_4::LogSink;
 use ergot::toolkits::embassy_net_v0_7 as kit;

--- a/demos/stm32h743zi/nucleoh743zi-net-udp-pair/src/bin/target.rs
+++ b/demos/stm32h743zi/nucleoh743zi-net-udp-pair/src/bin/target.rs
@@ -22,7 +22,7 @@ use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, eth, peripherals, rcc, rng};
 use embassy_time::{Duration, Ticker, Timer, WithTimeout};
 use embedded_alloc::LlffHeap as Heap;
-use ergot::exports::bbq2::traits::coordination::cas::AtomicCoord;
+use ergot::exports::bbqueue::traits::coordination::cas::AtomicCoord;
 use ergot::interface_manager::profiles::direct_edge::embassy_net_udp_0_7::{RxTxWorker, UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX, UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX};
 use ergot::logging::log_v0_4::LogSink;
 use ergot::toolkits::embassy_net_v0_7 as kit;


### PR DESCRIPTION
bbqueue 0.7.0 incorporates the bbq2 code and depends on maitake-sync 0.3.0, which fixes the portable-atomic/critical-section conflict with esp-hal on ESP32-C3 (see hawkw/mycelium#559).

Changes:
- Replace bbq2 dependency with bbqueue 0.7.0 in all Cargo.toml files
- Update maitake-sync from 0.2.2 to 0.3.0
- Update all import paths from bbq2 to bbqueue
- Update re-exports from exports::bbq2 to exports::bbqueue
- Fix stm32h723zg demo missing defmt-v1 feature