### PR TITLE
Fix issue where the second send fails on linux when using UDP.

### DIFF
--- a/crates/ergot/src/interface_manager/transports/tokio_udp.rs
+++ b/crates/ergot/src/interface_manager/transports/tokio_udp.rs
@@ -4,7 +4,7 @@
 //! UDP datagrams are treated as complete frames (no COBS encoding).
 //!
 //! [`FrameProcessor`]: crate::interface_manager::FrameProcessor
-
+use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -223,8 +223,14 @@ impl UdpTxWorker {
             };
             frame.release();
             if let Err(e) = res {
-                error!("Tx Error: {:?}", e);
-                break;
+                match e.kind() {
+                    // On Linux, /LATER/ calls to `send` /MAY/ cause a `ConnectionRefused` error
+                    // when there is nothing listening and the source/destination are on the same host.
+                    ErrorKind::ConnectionRefused => {},
+                    _ => {
+                        error!("Tx Error. socket: {:?}, error: {:?}", self.socket, e);
+                    }
+                }
             }
         }
         warn!("Closing UDP tx_worker");


### PR DESCRIPTION
* this occurs when using a local address for the destination, it may occur on other scenarios too.

This exampled, from https://github.com/tokio-rs/tokio/issues/4996 demonstrates the root cause:

```
use tokio::net::UdpSocket;

#[tokio::main]
async fn main() {
    let socket =  UdpSocket::bind(("0.0.0.0", 12345)).await.unwrap();
    socket.connect(("127.0.0.1", 1122)).await.unwrap();
    socket.send(b"test 123").await.unwrap();  <-- succeeds
    socket.send(b"test 123").await.unwrap();  <-- fails
}
```

It was entirely non-obvious why that worked on Windows and on the Linux used by the raspberry Pi was using for testing didn't work on a new linux installation (Bazzite, Fedora 43 20260101 `6.17.7-ba22.fc43.x86_64`).