### PR TITLE
Fix some incorrect or double uses of `tick`.

### DIFF
--- a/demos/std/ergot-bridge-pair-udp/src/bin/controller.rs
+++ b/demos/std/ergot-bridge-pair-udp/src/bin/controller.rs
@@ -86,8 +86,6 @@ async fn do_discovery(stack: EdgeStack) {
             info!("Removed: {:?}", rem);
         }
         seen = new_seen;
-
-        ticker.tick().await;
     }
 }
 

--- a/demos/std/ergot-router/src/main.rs
+++ b/demos/std/ergot-router/src/main.rs
@@ -81,8 +81,6 @@ async fn do_discovery(stack: RouterStack) {
             warn!("Removed: {:?}", rem);
         }
         seen = new_seen;
-
-        ticker.tick().await;
     }
 }
 

--- a/demos/std/ergot-seed-router/src/main.rs
+++ b/demos/std/ergot-seed-router/src/main.rs
@@ -67,6 +67,8 @@ async fn do_discovery(stack: RouterStack) {
     let mut seen = HashSet::new();
     let mut ticker = interval(Duration::from_millis(5000));
     loop {
+        ticker.tick().await;
+
         let new_seen = stack
             .discovery()
             .discover(max, Duration::from_millis(2500))
@@ -82,7 +84,5 @@ async fn do_discovery(stack: RouterStack) {
             warn!("Removed: {:?}", rem);
         }
         seen = new_seen;
-
-        ticker.tick().await;
     }
 }


### PR DESCRIPTION
The first call to `Interval::tick` always returns immediately.

Generally, when tick is used in a loop, it should appear just after the start of the loop, if it appears at the end of the loop the code in the loop will run twice immediately.