### PR TITLE
Fix embedded-io-async toolkit to support both v0.6 and v0.7

### DIFF
--- a/crates/ergot/src/interface_manager/interface_impls/embedded_io.rs
+++ b/crates/ergot/src/interface_manager/interface_impls/embedded_io.rs
@@ -7,7 +7,8 @@ use bbq2::{
     },
 };
 use core::marker::PhantomData;
-use embedded_io_async_0_6::Write;
+
+use crate::eio::Write;
 
 use crate::interface_manager::{Interface, utils::cobs_stream};
 

--- a/crates/ergot/src/interface_manager/interface_impls/mod.rs
+++ b/crates/ergot/src/interface_manager/interface_impls/mod.rs
@@ -20,5 +20,5 @@ pub mod embassy_net_udp;
 #[cfg(feature = "nusb-v0_1")]
 pub mod nusb_bulk;
 
-#[cfg(feature = "embedded-io-async-v0_6")]
+#[cfg(any(feature = "embedded-io-async-v0_6", feature = "embedded-io-async-v0_7"))]
 pub mod embedded_io;

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/eio.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/eio.rs
@@ -1,5 +1,6 @@
 use cobs_acc::{CobsAccumulator, FeedResult};
-use embedded_io_async_0_6::Read;
+
+use crate::eio::Read;
 
 use crate::interface_manager::profiles::direct_edge::CENTRAL_NODE_ID;
 use crate::{

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
@@ -14,8 +14,8 @@ use crate::logging::{debug, trace, warn};
 
 use serde::Serialize;
 
-#[cfg(feature = "embedded-io-async-v0_6")]
-pub mod eio_0_6;
+#[cfg(any(feature = "embedded-io-async-v0_6", feature = "embedded-io-async-v0_7"))]
+pub mod eio;
 
 #[cfg(feature = "embassy-usb-v0_5")]
 pub mod eusb_0_5;

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -217,3 +217,12 @@ pub mod exports {
     pub use bbq2;
     pub use mutex;
 }
+
+// Internal re-export of embedded-io-async (supports both v0.6 and v0.7 - API is identical)
+#[cfg(feature = "embedded-io-async-v0_6")]
+pub(crate) use embedded_io_async_0_6 as eio;
+#[cfg(all(
+    feature = "embedded-io-async-v0_7",
+    not(feature = "embedded-io-async-v0_6")
+))]
+pub(crate) use embedded_io_async_0_7 as eio;

--- a/crates/ergot/src/toolkits/mod.rs
+++ b/crates/ergot/src/toolkits/mod.rs
@@ -35,7 +35,7 @@ pub mod embedded_io_async_v0_6 {
         interface_manager::{
             profiles::direct_edge::{
                 DirectEdge,
-                eio_0_6::{self, EmbeddedIoManager},
+                eio::{self, EmbeddedIoManager},
             },
             utils::cobs_stream::Sink,
         },
@@ -48,7 +48,42 @@ pub mod embedded_io_async_v0_6 {
     pub type Queue<const N: usize, C> = BBQueue<Inline<N>, C, MaiNotSpsc>;
     pub type Stack<Q, R> = NetStack<R, EmbeddedIoManager<Q>>;
     pub type BaseStack<Q, R> = crate::NetStack<R, EmbeddedIoManager<Q>>;
-    pub type RxWorker<Q, R, D> = eio_0_6::RxWorker<&'static BaseStack<Q, R>, D>;
+    pub type RxWorker<Q, R, D> = eio::RxWorker<&'static BaseStack<Q, R>, D>;
+
+    pub const fn new_target_stack<Q, R>(producer: StreamProducer<Q>, mtu: u16) -> Stack<Q, R>
+    where
+        Q: BbqHandle + 'static,
+        R: ScopedRawMutex + ConstInit + 'static,
+    {
+        NetStack::new_with_profile(DirectEdge::new_target(Sink::new(producer, mtu)))
+    }
+}
+
+#[cfg(feature = "embedded-io-async-v0_7")]
+pub mod embedded_io_async_v0_7 {
+    use crate::{
+        exports::bbq2::{
+            prod_cons::stream::StreamProducer,
+            queue::BBQueue,
+            traits::{bbqhdl::BbqHandle, notifier::maitake::MaiNotSpsc, storage::Inline},
+        },
+        interface_manager::{
+            profiles::direct_edge::{
+                DirectEdge,
+                eio::{self, EmbeddedIoManager},
+            },
+            utils::cobs_stream::Sink,
+        },
+    };
+    use mutex::{ConstInit, ScopedRawMutex};
+
+    use crate::NetStack;
+    pub use crate::interface_manager::interface_impls::embedded_io::tx_worker;
+
+    pub type Queue<const N: usize, C> = BBQueue<Inline<N>, C, MaiNotSpsc>;
+    pub type Stack<Q, R> = NetStack<R, EmbeddedIoManager<Q>>;
+    pub type BaseStack<Q, R> = crate::NetStack<R, EmbeddedIoManager<Q>>;
+    pub type RxWorker<Q, R, D> = eio::RxWorker<&'static BaseStack<Q, R>, D>;
 
     pub const fn new_target_stack<Q, R>(producer: StreamProducer<Q>, mtu: u16) -> Stack<Q, R>
     where


### PR DESCRIPTION
## Summary

Add `embedded_io_async_v0_7` toolkit module alongside the existing `embedded_io_async_v0_6`. The v0.6 and v0.7 APIs are identical, so the internal implementation is shared via a `pub(crate) eio` alias that resolves to whichever version is enabled (v0.6 takes priority if both are active).

## Changes

- Add `pub(crate) use ... as eio` alias in `lib.rs` that resolves to the correct version based on features
- Rename `eio_0_6.rs` to `eio.rs` (version-agnostic internal module using `crate::eio`)
- Add `embedded_io_async_v0_7` toolkit module in `toolkits/mod.rs`
- Enable `embedded_io` interface impl for both feature flags

## Migration

Users of v0.6 are unaffected. Users who want v0.7 can now use:

```rust
use ergot::toolkits::embedded_io_async_v0_7 as kit;
```

## Testing

Verified the crate compiles with both features:
- `cargo check --features embedded-io-async-v0_6` ✓
- `cargo check --features embedded-io-async-v0_7` ✓