### PR TITLE
Add async backpressure API for networking stack

### DIFF
--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -189,6 +189,132 @@ pub trait InterfaceSink {
     fn send_err(&mut self, hdr: &HeaderSeq, err: ProtocolError) -> Result<(), ()>;
 }
 
+/// Async waiting for interface buffer space.
+///
+/// Implementations wait until the underlying buffer (e.g. bbqueue) has enough
+/// space for a message of the given type. The wait does NOT reserve space —
+/// the caller must retry the send after awaiting.
+#[allow(async_fn_in_trait)]
+pub trait InterfaceWait {
+    /// Wait until there is space for a typed/borrowed message.
+    async fn wait_ty(&self);
+    /// Wait until there is space for an error message.
+    async fn wait_err(&self);
+    /// Wait until there is space for a raw message of the given body length.
+    async fn wait_raw(&self, body_len: usize);
+}
+
+/// Trait for sinks that can produce async wait handles.
+///
+/// Returns `None` if the sink was not configured with a wait queue
+/// (i.e. backpressure is not available).
+pub trait InterfaceSinkWait {
+    /// The wait handle type returned by [`wait_handle`](Self::wait_handle).
+    type Wait: InterfaceWait;
+    /// Get a wait handle for this sink, or `None` if backpressure is not configured.
+    fn wait_handle(&self) -> Option<Self::Wait>;
+}
+
+/// Result of a send attempt that supports backpressure.
+///
+/// - `Sent`: the message was successfully sent.
+/// - `Wait(handle)`: the buffer was full. Await the handle to wait for space,
+///   then retry the send. The handle does NOT reserve space — another sender
+///   could consume it first, so always retry in a loop.
+#[derive(Debug)]
+pub enum SendOutcome<W> {
+    /// Message was sent successfully.
+    Sent,
+    /// Buffer was full — await this handle then retry.
+    Wait(W),
+}
+
+impl SendOutcome<core::convert::Infallible> {
+    /// Convert `SendOutcome<Infallible>` to `()`.
+    ///
+    /// Since `Infallible` can never be constructed, `Wait` is unreachable
+    /// and the compiler eliminates the branch entirely.
+    pub fn unwrap_sent(self) {
+        match self {
+            SendOutcome::Sent => {}
+            SendOutcome::Wait(inf) => match inf {},
+        }
+    }
+}
+
+/// Extension of [`Profile`] that adds async backpressure support.
+///
+/// When a send fails because the outgoing buffer is full, methods return
+/// `SendOutcome::Wait(handle)` instead of `InterfaceSendError::InterfaceFull`.
+/// The caller awaits the handle (outside any mutex) and retries.
+///
+/// # Usage
+///
+/// The `_wait` methods on [`NetStack`](crate::NetStack) handle the retry loop
+/// automatically:
+///
+/// ```ignore
+/// // Without backpressure — returns InterfaceFull error if buffer is full:
+/// stack.topics().broadcast::<MyTopic>(&msg, None)?;
+///
+/// // With backpressure — waits for space, then sends:
+/// stack.topics().broadcast_wait::<MyTopic>(&msg, None).await?;
+/// ```
+///
+/// The wait methods require the profile to implement `ProfileBackpressure`,
+/// which is enabled by passing a bbqueue handle as `wait_q` when constructing
+/// the sink:
+///
+/// ```ignore
+/// let stack = new_target_stack(
+///     tx_queue.stream_producer(),
+///     Some(tx_queue),  // enables backpressure
+///     ERGOT_MTU,
+/// );
+/// ```
+pub trait ProfileBackpressure: Profile {
+    /// The wait handle type, typically wrapping a bbqueue handle.
+    type Wait: InterfaceWait;
+
+    /// Send a typed message, returning a wait handle if the buffer is full.
+    fn send_with_wait<T: Serialize>(
+        &mut self,
+        hdr: &Header,
+        data: &T,
+    ) -> Result<SendOutcome<Self::Wait>, InterfaceSendError>;
+
+    /// Send a borrowed message, returning a wait handle if the buffer is full.
+    fn send_bor_with_wait<T: Serialize>(
+        &mut self,
+        hdr: &Header,
+        data: &T,
+    ) -> Result<SendOutcome<Self::Wait>, InterfaceSendError> {
+        self.send_with_wait(hdr, data)
+    }
+
+    /// Send an error message, returning a wait handle if the buffer is full.
+    fn send_err_with_wait(
+        &mut self,
+        hdr: &Header,
+        err: ProtocolError,
+        source: Option<Self::InterfaceIdent>,
+    ) -> Result<SendOutcome<Self::Wait>, InterfaceSendError> {
+        self.send_err(hdr, err, source)?;
+        Ok(SendOutcome::Sent)
+    }
+
+    /// Send a raw message, returning a wait handle if the buffer is full.
+    fn send_raw_with_wait(
+        &mut self,
+        hdr: &HeaderSeq,
+        data: &[u8],
+        source: Self::InterfaceIdent,
+    ) -> Result<SendOutcome<Self::Wait>, InterfaceSendError> {
+        self.send_raw(hdr, data, source)?;
+        Ok(SendOutcome::Sent)
+    }
+}
+
 #[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]

--- a/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge/mod.rs
@@ -32,7 +32,8 @@ pub mod embassy_net_udp_0_7;
 use crate::{
     Header, HeaderSeq, ProtocolError,
     interface_manager::{
-        Interface, InterfaceSendError, InterfaceSink, InterfaceState, Profile, SetStateError,
+        Interface, InterfaceSendError, InterfaceSink, InterfaceSinkWait, InterfaceState, Profile,
+        ProfileBackpressure, SendOutcome, SetStateError,
     },
     net_stack::NetStackHandle,
     wire_frames::de_frame,
@@ -224,6 +225,54 @@ impl<I: Interface> Profile for DirectEdge<I> {
             }
         }
         Ok(())
+    }
+}
+
+impl<I> ProfileBackpressure for DirectEdge<I>
+where
+    I: Interface,
+    I::Sink: InterfaceSinkWait,
+{
+    type Wait = <I::Sink as InterfaceSinkWait>::Wait;
+
+    fn send_with_wait<T: Serialize>(
+        &mut self,
+        hdr: &Header,
+        data: &T,
+    ) -> Result<SendOutcome<Self::Wait>, InterfaceSendError> {
+        let (intfc, header) = self.common_send(hdr)?;
+
+        let res = intfc.send_ty(&header, data);
+
+        match res {
+            Ok(()) => Ok(SendOutcome::Sent),
+            Err(()) => intfc
+                .wait_handle()
+                .map(SendOutcome::Wait)
+                .ok_or(InterfaceSendError::InterfaceFull),
+        }
+    }
+
+    fn send_err_with_wait(
+        &mut self,
+        hdr: &Header,
+        err: ProtocolError,
+        source: Option<Self::InterfaceIdent>,
+    ) -> Result<SendOutcome<Self::Wait>, InterfaceSendError> {
+        if source.is_some() {
+            return Err(InterfaceSendError::RoutingLoop);
+        }
+        let (intfc, header) = self.common_send(hdr)?;
+
+        let res = intfc.send_err(&header, err);
+
+        match res {
+            Ok(()) => Ok(SendOutcome::Sent),
+            Err(()) => intfc
+                .wait_handle()
+                .map(SendOutcome::Wait)
+                .ok_or(InterfaceSendError::InterfaceFull),
+        }
     }
 }
 

--- a/crates/ergot/src/interface_manager/profiles/direct_router/mod.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_router/mod.rs
@@ -22,9 +22,9 @@ use rand::Rng;
 use crate::{
     Header, ProtocolError,
     interface_manager::{
-        DeregisterError, Interface, InterfaceSendError, InterfaceState, Profile,
-        SeedAssignmentError, SeedNetAssignment, SeedRefreshError, SetStateError,
-        profiles::direct_edge::CENTRAL_NODE_ID,
+        DeregisterError, Interface, InterfaceSendError, InterfaceSinkWait, InterfaceState, Profile,
+        ProfileBackpressure, SeedAssignmentError, SeedNetAssignment, SeedRefreshError, SendOutcome,
+        SetStateError, profiles::direct_edge::CENTRAL_NODE_ID,
     },
     net_stack::NetStackHandle,
     wire_frames::de_frame,
@@ -111,6 +111,7 @@ impl<I: Interface> Profile for DirectRouter<I> {
             }
 
             let mut any_good = false;
+            let mut any_full = false;
             for (_ident, p) in self.direct_links.iter_mut() {
                 // Don't send back to the origin
                 if hdr.dst.network_id == p.net_id {
@@ -119,10 +120,16 @@ impl<I: Interface> Profile for DirectRouter<I> {
                 let mut hdr = hdr.clone();
                 hdr.dst.network_id = p.net_id;
                 hdr.dst.node_id = EDGE_NODE_ID;
-                any_good |= p.edge.send(&hdr, data).is_ok();
+                match p.edge.send(&hdr, data) {
+                    Ok(()) => any_good = true,
+                    Err(InterfaceSendError::InterfaceFull) => any_full = true,
+                    Err(_) => {}
+                }
             }
             if any_good {
                 Ok(())
+            } else if any_full {
+                Err(InterfaceSendError::InterfaceFull)
             } else {
                 Err(InterfaceSendError::NoRouteToDest)
             }
@@ -170,6 +177,7 @@ impl<I: Interface> Profile for DirectRouter<I> {
 
             // use this error until we find a non-origin destination
             let mut default_error = InterfaceSendError::RoutingLoop;
+            let mut any_full = false;
 
             let mut any_good = false;
             for (_ident, p) in self.direct_links.iter_mut() {
@@ -184,9 +192,19 @@ impl<I: Interface> Profile for DirectRouter<I> {
                 // to the address of the next hop.
                 hdr.dst.network_id = p.net_id;
                 hdr.dst.node_id = EDGE_NODE_ID;
-                any_good |= p.edge.send_raw(&hdr, data).is_ok();
+                match p.edge.send_raw(&hdr, data) {
+                    Ok(()) => any_good = true,
+                    Err(InterfaceSendError::InterfaceFull) => any_full = true,
+                    Err(_) => {}
+                }
             }
-            if any_good { Ok(()) } else { Err(default_error) }
+            if any_good {
+                Ok(())
+            } else if any_full {
+                Err(InterfaceSendError::InterfaceFull)
+            } else {
+                Err(default_error)
+            }
         } else {
             let nshdr = hdr.clone().into();
             let intfc = self.find(&nshdr, Some(source))?;
@@ -299,6 +317,147 @@ impl<I: Interface> Profile for DirectRouter<I> {
                     min_refresh_seconds: MIN_SEED_REFRESH,
                     refresh_token: req_refresh_token,
                 })
+            }
+        }
+    }
+}
+
+impl<I> ProfileBackpressure for DirectRouter<I>
+where
+    I: Interface,
+    I::Sink: InterfaceSinkWait,
+{
+    type Wait = <I::Sink as InterfaceSinkWait>::Wait;
+
+    fn send_with_wait<T: serde::Serialize>(
+        &mut self,
+        hdr: &crate::Header,
+        data: &T,
+    ) -> Result<SendOutcome<Self::Wait>, InterfaceSendError> {
+        let mut hdr = hdr.clone();
+        if hdr.decrement_ttl().is_err() {
+            return Err(InterfaceSendError::NoRouteToDest);
+        }
+
+        if hdr.dst.port_id == 255 {
+            if hdr.any_all.is_none() {
+                return Err(InterfaceSendError::AnyPortMissingKey);
+            }
+
+            let mut any_good = false;
+            let mut wait = None;
+            for (_ident, p) in self.direct_links.iter_mut() {
+                if hdr.dst.network_id == p.net_id {
+                    continue;
+                }
+                let mut hdr = hdr.clone();
+                hdr.dst.network_id = p.net_id;
+                hdr.dst.node_id = EDGE_NODE_ID;
+                match p.edge.send(&hdr, data) {
+                    Ok(()) => any_good = true,
+                    Err(InterfaceSendError::InterfaceFull) => {
+                        wait = wait.or_else(|| p.edge.wait_handle());
+                    }
+                    Err(_) => {}
+                }
+            }
+            if any_good {
+                Ok(SendOutcome::Sent)
+            } else if let Some(wait) = wait {
+                Ok(SendOutcome::Wait(wait))
+            } else {
+                Err(InterfaceSendError::NoRouteToDest)
+            }
+        } else {
+            let intfc = self.find(&hdr, None)?;
+            match intfc.send(&hdr, data) {
+                Ok(()) => Ok(SendOutcome::Sent),
+                Err(InterfaceSendError::InterfaceFull) => intfc
+                    .wait_handle()
+                    .map(SendOutcome::Wait)
+                    .ok_or(InterfaceSendError::InterfaceFull),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    fn send_err_with_wait(
+        &mut self,
+        hdr: &crate::Header,
+        err: ProtocolError,
+        source: Option<Self::InterfaceIdent>,
+    ) -> Result<SendOutcome<Self::Wait>, InterfaceSendError> {
+        let mut hdr = hdr.clone();
+        if hdr.decrement_ttl().is_err() {
+            return Err(InterfaceSendError::NoRouteToDest);
+        }
+
+        let intfc = self.find(&hdr, source)?;
+        match intfc.send_err(&hdr, err) {
+            Ok(()) => Ok(SendOutcome::Sent),
+            Err(InterfaceSendError::InterfaceFull) => intfc
+                .wait_handle()
+                .map(SendOutcome::Wait)
+                .ok_or(InterfaceSendError::InterfaceFull),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn send_raw_with_wait(
+        &mut self,
+        hdr: &crate::HeaderSeq,
+        data: &[u8],
+        source: Self::InterfaceIdent,
+    ) -> Result<SendOutcome<Self::Wait>, InterfaceSendError> {
+        let mut hdr = hdr.clone();
+        if hdr.decrement_ttl().is_err() {
+            return Err(InterfaceSendError::NoRouteToDest);
+        }
+
+        if hdr.dst.port_id == 255 {
+            if hdr.any_all.is_none() {
+                return Err(InterfaceSendError::AnyPortMissingKey);
+            }
+            if self.direct_links.is_empty() {
+                return Err(InterfaceSendError::NoRouteToDest);
+            }
+
+            let mut default_error = InterfaceSendError::RoutingLoop;
+            let mut any_good = false;
+            let mut wait = None;
+            for (_ident, p) in self.direct_links.iter_mut() {
+                if source == p.ident {
+                    continue;
+                }
+                default_error = InterfaceSendError::NoRouteToDest;
+
+                hdr.dst.network_id = p.net_id;
+                hdr.dst.node_id = EDGE_NODE_ID;
+                match p.edge.send_raw(&hdr, data) {
+                    Ok(()) => any_good = true,
+                    Err(InterfaceSendError::InterfaceFull) => {
+                        wait = wait.or_else(|| p.edge.wait_handle());
+                    }
+                    Err(_) => {}
+                }
+            }
+            if any_good {
+                Ok(SendOutcome::Sent)
+            } else if let Some(wait) = wait {
+                Ok(SendOutcome::Wait(wait))
+            } else {
+                Err(default_error)
+            }
+        } else {
+            let nshdr = hdr.clone().into();
+            let intfc = self.find(&nshdr, Some(source))?;
+            match intfc.send_raw(&hdr, data) {
+                Ok(()) => Ok(SendOutcome::Sent),
+                Err(InterfaceSendError::InterfaceFull) => intfc
+                    .wait_handle()
+                    .map(SendOutcome::Wait)
+                    .ok_or(InterfaceSendError::InterfaceFull),
+                Err(e) => Err(e),
             }
         }
     }
@@ -600,7 +759,8 @@ mod edge_interface_plus {
     use crate::{
         Header, HeaderSeq, ProtocolError,
         interface_manager::{
-            Interface, InterfaceSendError, InterfaceSink, InterfaceState, SetStateError,
+            Interface, InterfaceSendError, InterfaceSink, InterfaceSinkWait, InterfaceState,
+            SetStateError,
             profiles::direct_edge::{CENTRAL_NODE_ID, EDGE_NODE_ID},
         },
     };
@@ -700,6 +860,13 @@ mod edge_interface_plus {
                 Ok(()) => Ok(()),
                 Err(()) => Err(InterfaceSendError::InterfaceFull),
             }
+        }
+
+        pub(super) fn wait_handle(&self) -> Option<<I::Sink as InterfaceSinkWait>::Wait>
+        where
+            I::Sink: InterfaceSinkWait,
+        {
+            self.sink.wait_handle()
         }
 
         pub(super) fn send_err(

--- a/crates/ergot/src/interface_manager/utils/cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/cobs_stream.rs
@@ -3,7 +3,10 @@
 //! The "Cobs Stream" is one flavor of interface sinks. It is intended for serial-like
 //! interfaces that require framing in software.
 
-use bbqueue::{prod_cons::stream::StreamProducer, traits::bbqhdl::BbqHandle};
+use bbqueue::{
+    prod_cons::stream::StreamProducer,
+    traits::{bbqhdl::BbqHandle, notifier::AsyncNotifier},
+};
 use postcard::{
     Serializer,
     ser_flavors::{self, Flavor},
@@ -12,7 +15,7 @@ use serde::Serialize;
 
 use crate::{
     FrameKind, HeaderSeq, ProtocolError,
-    interface_manager::InterfaceSink,
+    interface_manager::{InterfaceSink, InterfaceSinkWait, InterfaceWait},
     wire_frames::{self, MAX_HDR_ENCODED_SIZE, encode_frame_hdr},
 };
 
@@ -22,6 +25,7 @@ where
 {
     pub(crate) mtu: u16,
     pub(crate) prod: StreamProducer<Q>,
+    wait_q: Option<Q>,
 }
 
 #[allow(clippy::result_unit_err)] // todo
@@ -33,11 +37,12 @@ where
         Self {
             mtu,
             prod: q.stream_producer(),
+            wait_q: Some(q),
         }
     }
 
-    pub const fn new(prod: StreamProducer<Q>, mtu: u16) -> Self {
-        Self { mtu, prod }
+    pub const fn new(prod: StreamProducer<Q>, wait_q: Option<Q>, mtu: u16) -> Self {
+        Self { mtu, prod, wait_q }
     }
 }
 
@@ -105,5 +110,50 @@ where
         wgr.commit(len);
 
         Ok(())
+    }
+}
+
+pub struct CobsWait<Q>
+where
+    Q: BbqHandle,
+{
+    bbq: Q,
+    mtu: u16,
+}
+
+#[allow(async_fn_in_trait)]
+impl<Q> InterfaceWait for CobsWait<Q>
+where
+    Q: BbqHandle,
+    Q::Notifier: AsyncNotifier,
+{
+    async fn wait_ty(&self) {
+        let max_len = cobs::max_encoding_length(self.mtu as usize);
+        let _ = self.bbq.stream_producer().wait_grant_exact(max_len).await;
+    }
+
+    async fn wait_err(&self) {
+        let max_len = cobs::max_encoding_length(self.mtu as usize);
+        let _ = self.bbq.stream_producer().wait_grant_exact(max_len).await;
+    }
+
+    async fn wait_raw(&self, body_len: usize) {
+        let max_len = cobs::max_encoding_length(MAX_HDR_ENCODED_SIZE + body_len);
+        let _ = self.bbq.stream_producer().wait_grant_exact(max_len).await;
+    }
+}
+
+impl<Q> InterfaceSinkWait for Sink<Q>
+where
+    Q: BbqHandle + Clone,
+    Q::Notifier: AsyncNotifier,
+{
+    type Wait = CobsWait<Q>;
+
+    fn wait_handle(&self) -> Option<Self::Wait> {
+        self.wait_q.as_ref().map(|q| CobsWait {
+            bbq: q.clone(),
+            mtu: self.mtu,
+        })
     }
 }

--- a/crates/ergot/src/interface_manager/utils/framed_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/framed_stream.rs
@@ -3,7 +3,10 @@
 //! The "Framed Stream" is one flavor of interface sinks. It is intended for packet-like
 //! interfaces that do NOT require framing in software.
 
-use bbqueue::{prod_cons::framed::FramedProducer, traits::bbqhdl::BbqHandle};
+use bbqueue::{
+    prod_cons::framed::FramedProducer,
+    traits::{bbqhdl::BbqHandle, notifier::AsyncNotifier},
+};
 use postcard::{
     Serializer,
     ser_flavors::{self, Flavor, Slice},
@@ -12,7 +15,7 @@ use serde::Serialize;
 
 use crate::{
     FrameKind, HeaderSeq, ProtocolError,
-    interface_manager::InterfaceSink,
+    interface_manager::{InterfaceSink, InterfaceSinkWait, InterfaceWait},
     wire_frames::{self, MAX_HDR_ENCODED_SIZE, encode_frame_hdr},
 };
 
@@ -22,6 +25,7 @@ where
 {
     pub(crate) mtu: u16,
     pub(crate) prod: FramedProducer<Q, u16>,
+    wait_q: Option<Q>,
 }
 
 #[allow(clippy::result_unit_err)] // todo
@@ -33,11 +37,12 @@ where
         Self {
             mtu,
             prod: q.framed_producer(),
+            wait_q: Some(q),
         }
     }
 
-    pub const fn new(prod: FramedProducer<Q, u16>, mtu: u16) -> Self {
-        Self { mtu, prod }
+    pub const fn new(prod: FramedProducer<Q, u16>, wait_q: Option<Q>, mtu: u16) -> Self {
+        Self { mtu, prod, wait_q }
     }
 }
 
@@ -101,5 +106,51 @@ where
         wgr.commit(len);
 
         Ok(())
+    }
+}
+
+pub struct FramedWait<Q>
+where
+    Q: BbqHandle,
+{
+    bbq: Q,
+    mtu: u16,
+}
+
+#[allow(async_fn_in_trait)]
+impl<Q> InterfaceWait for FramedWait<Q>
+where
+    Q: BbqHandle,
+    Q::Notifier: AsyncNotifier,
+{
+    async fn wait_ty(&self) {
+        let _ = self.bbq.framed_producer::<u16>().wait_grant(self.mtu).await;
+    }
+
+    async fn wait_err(&self) {
+        let _ = self.bbq.framed_producer::<u16>().wait_grant(self.mtu).await;
+    }
+
+    async fn wait_raw(&self, body_len: usize) {
+        let max_len = MAX_HDR_ENCODED_SIZE + body_len;
+        let Ok(max_len) = u16::try_from(max_len) else {
+            return;
+        };
+        let _ = self.bbq.framed_producer::<u16>().wait_grant(max_len).await;
+    }
+}
+
+impl<Q> InterfaceSinkWait for Sink<Q>
+where
+    Q: BbqHandle + Clone,
+    Q::Notifier: AsyncNotifier,
+{
+    type Wait = FramedWait<Q>;
+
+    fn wait_handle(&self) -> Option<Self::Wait> {
+        self.wait_q.as_ref().map(|q| FramedWait {
+            bbq: q.clone(),
+            mtu: self.mtu,
+        })
     }
 }

--- a/crates/ergot/src/net_stack/inner.rs
+++ b/crates/ergot/src/net_stack/inner.rs
@@ -7,7 +7,7 @@ use crate::logging::{debug, error, trace};
 
 use crate::{
     FrameKind, Header, HeaderSeq, ProtocolError,
-    interface_manager::{self, InterfaceSendError, Profile},
+    interface_manager::{self, InterfaceSendError, Profile, ProfileBackpressure, SendOutcome},
     net_stack::NetStackSendError,
     socket::{SocketHeader, SocketSendError, SocketVTable, borser},
 };
@@ -55,19 +55,19 @@ where
         }
     }
 
-    /// Method that handles broadcast logic
+    /// Method that handles broadcast logic.
     ///
-    /// Takes closures for sending to a socket or sending to the manager to allow
-    /// for abstracting over send_raw/send_ty.
-    fn broadcast<SendSockets, SendProfile>(
+    /// Generic over `W`: non-wait callers use `W = Infallible` (where `Wait` is
+    /// unreachable), wait callers use the actual wait handle type.
+    fn broadcast<SendSockets, SendProfile, W>(
         sockets: &mut List<SocketHeader>,
         hdr: &Header,
         mut sskt: SendSockets,
         smgr: SendProfile,
-    ) -> Result<(), NetStackSendError>
+    ) -> Result<SendOutcome<W>, NetStackSendError>
     where
         SendSockets: FnMut(NonNull<SocketHeader>) -> Result<(), NetStackSendError>,
-        SendProfile: FnOnce() -> Result<(), InterfaceSendError>,
+        SendProfile: FnOnce() -> Result<SendOutcome<W>, InterfaceSendError>,
     {
         trace!("{}: Sending msg broadcast", hdr);
         let res_lcl = {
@@ -99,10 +99,11 @@ where
         };
 
         let res_rmt = match smgr() {
-            Ok(_) => {
+            Ok(SendOutcome::Sent) => {
                 debug!("{}: delivered broadcast message remotely", hdr);
                 true
             }
+            Ok(SendOutcome::Wait(w)) => return Ok(SendOutcome::Wait(w)),
             Err(InterfaceSendError::RoutingLoop) => {
                 // no need to report /errors/ on routing loops
                 debug!("{}: No external interest in msg broadcast", hdr);
@@ -120,25 +121,25 @@ where
         };
 
         if res_lcl || res_rmt {
-            Ok(())
+            Ok(SendOutcome::Sent)
         } else {
             Err(NetStackSendError::NoRoute)
         }
     }
 
-    /// Method that handles unicast logic
+    /// Method that handles unicast logic.
     ///
-    /// Takes closures for sending to a socket or sending to the manager to allow
-    /// for abstracting over send_raw/send_ty.
-    fn unicast<SendSockets, SendProfile>(
+    /// Generic over `W`: non-wait callers use `W = Infallible`, wait callers
+    /// use the actual wait handle type.
+    fn unicast<SendSockets, SendProfile, W>(
         sockets: &mut List<SocketHeader>,
         hdr: &Header,
         sskt: SendSockets,
         smgr: SendProfile,
-    ) -> Result<(), NetStackSendError>
+    ) -> Result<SendOutcome<W>, NetStackSendError>
     where
         SendSockets: FnOnce(NonNull<SocketHeader>) -> Result<(), NetStackSendError>,
-        SendProfile: FnOnce() -> Result<(), InterfaceSendError>,
+        SendProfile: FnOnce() -> Result<SendOutcome<W>, InterfaceSendError>,
     {
         trace!("{}: Sending msg unicast", hdr);
         // Can we assume the destination is local?
@@ -154,10 +155,11 @@ where
         };
 
         match res {
-            Ok(()) => {
+            Ok(SendOutcome::Sent) => {
                 debug!("{}: Externally routed msg unicast", hdr);
-                return Ok(());
+                return Ok(SendOutcome::Sent);
             }
+            Ok(SendOutcome::Wait(w)) => return Ok(SendOutcome::Wait(w)),
             // "Destination Local" and "Routing Loop" can both be returned when there is no
             // interface interest, but are non-fatal.
             Err(InterfaceSendError::DestinationLocal) | Err(InterfaceSendError::RoutingLoop) => {
@@ -175,22 +177,23 @@ where
             Self::find_one_local(sockets, hdr)
         }?;
 
-        sskt(socket)
+        sskt(socket)?;
+        Ok(SendOutcome::Sent)
     }
 
-    /// Method that handles unicast logic
+    /// Method that handles unicast error logic.
     ///
-    /// Takes closures for sending to a socket or sending to the manager to allow
-    /// for abstracting over send_raw/send_ty.
-    fn unicast_err<SendSockets, SendProfile>(
+    /// Generic over `W`: non-wait callers use `W = Infallible`, wait callers
+    /// use the actual wait handle type.
+    fn unicast_err<SendSockets, SendProfile, W>(
         sockets: &mut List<SocketHeader>,
         hdr: &Header,
         sskt: SendSockets,
         smgr: SendProfile,
-    ) -> Result<(), NetStackSendError>
+    ) -> Result<SendOutcome<W>, NetStackSendError>
     where
         SendSockets: FnOnce(NonNull<SocketHeader>) -> Result<(), NetStackSendError>,
-        SendProfile: FnOnce() -> Result<(), InterfaceSendError>,
+        SendProfile: FnOnce() -> Result<SendOutcome<W>, InterfaceSendError>,
     {
         trace!("{}: Sending err unicast", hdr);
         // Can we assume the destination is local?
@@ -206,10 +209,11 @@ where
         };
 
         match res {
-            Ok(()) => {
+            Ok(SendOutcome::Sent) => {
                 debug!("{}: Externally routed err unicast", hdr);
-                return Ok(());
+                return Ok(SendOutcome::Sent);
             }
+            Ok(SendOutcome::Wait(w)) => return Ok(SendOutcome::Wait(w)),
             Err(InterfaceSendError::DestinationLocal) => {
                 debug!("{}: No external interest in err unicast", hdr);
             }
@@ -219,7 +223,8 @@ where
         // It was a destination local error, try to honor that
         let socket = Self::find_one_err_local(sockets, hdr)?;
 
-        sskt(socket)
+        sskt(socket)?;
+        Ok(SendOutcome::Sent)
     }
 
     /// Handle sending of a raw (serialized) message
@@ -244,22 +249,30 @@ where
 
         let nshdr: Header = hdr.clone().into();
 
-        // Is this a broadcast message?
         if hdr.dst.port_id == 255 {
             Self::broadcast(
                 sockets,
                 &nshdr,
                 |skt| Self::send_raw_to_socket(skt, body, &nshdr, seq_no),
-                || manager.send_raw(hdr, body, source),
+                || {
+                    manager
+                        .send_raw(hdr, body, source)
+                        .map(|()| SendOutcome::Sent)
+                },
             )
         } else {
             Self::unicast(
                 sockets,
                 &nshdr,
                 |skt| Self::send_raw_to_socket(skt, body, &nshdr, seq_no),
-                || manager.send_raw(hdr, body, source),
+                || {
+                    manager
+                        .send_raw(hdr, body, source)
+                        .map(|()| SendOutcome::Sent)
+                },
             )
         }
+        .map(SendOutcome::unwrap_sent)
         .inspect_err(|e| {
             error!("{}: Error sending raw: {:?}", hdr, e);
         })
@@ -284,22 +297,22 @@ where
             todo!("{}: Don't do that", hdr);
         }
 
-        // Is this a broadcast message?
         if hdr.dst.port_id == 255 {
             Self::broadcast(
                 sockets,
                 hdr,
                 |skt| Self::send_ty_to_socket(skt, t, hdr, seq_no),
-                || manager.send(hdr, t),
+                || manager.send(hdr, t).map(|()| SendOutcome::Sent),
             )
         } else {
             Self::unicast(
                 sockets,
                 hdr,
                 |skt| Self::send_ty_to_socket(skt, t, hdr, seq_no),
-                || manager.send(hdr, t),
+                || manager.send(hdr, t).map(|()| SendOutcome::Sent),
             )
         }
+        .map(SendOutcome::unwrap_sent)
         .inspect_err(|e| {
             error!("{}: Error sending ty: {:?}", hdr, e);
         })
@@ -324,28 +337,28 @@ where
             todo!("{}: Don't do that", hdr);
         }
 
-        // Is this a broadcast message?
         if hdr.dst.port_id == 255 {
             Self::broadcast(
                 sockets,
                 hdr,
                 |skt| Self::send_bor_to_socket(skt, t, hdr, seq_no),
-                || manager.send(hdr, t),
+                || manager.send(hdr, t).map(|()| SendOutcome::Sent),
             )
         } else {
             Self::unicast(
                 sockets,
                 hdr,
                 |skt| Self::send_bor_to_socket(skt, t, hdr, seq_no),
-                || manager.send(hdr, t),
+                || manager.send(hdr, t).map(|()| SendOutcome::Sent),
             )
         }
+        .map(SendOutcome::unwrap_sent)
         .inspect_err(|e| {
             error!("{}: Error sending bor: {:?}", hdr, e);
         })
     }
 
-    /// Handle sending of a typed message
+    /// Handle sending of an error message
     pub(super) fn send_err(
         &mut self,
         hdr: &Header,
@@ -368,8 +381,13 @@ where
             sockets,
             hdr,
             |skt| Self::send_err_to_socket(skt, err, hdr, seq_no),
-            || manager.send_err(hdr, err, source),
+            || {
+                manager
+                    .send_err(hdr, err, source)
+                    .map(|()| SendOutcome::Sent)
+            },
         )
+        .map(SendOutcome::unwrap_sent)
     }
 
     /// Call the given closure with an iterator over current public sockets
@@ -620,6 +638,154 @@ where
         });
 
         (f)(this, body, hdr).map_err(NetStackSendError::SocketSend)
+    }
+}
+
+impl<P> NetStackInner<P>
+where
+    P: ProfileBackpressure,
+{
+    #[allow(unused_variables)]
+    pub(super) fn send_raw_with_wait(
+        &mut self,
+        hdr: &HeaderSeq,
+        body: &[u8],
+        source: P::InterfaceIdent,
+    ) -> Result<SendOutcome<P::Wait>, NetStackSendError> {
+        let Self {
+            sockets,
+            seq_no,
+            profile: manager,
+            ..
+        } = self;
+        trace!("{}: Sending msg raw from {:?}", hdr, source);
+
+        if hdr.kind == FrameKind::PROTOCOL_ERROR {
+            todo!("{}: Don't do that", hdr);
+        }
+
+        let nshdr: Header = hdr.clone().into();
+
+        if hdr.dst.port_id == 255 {
+            Self::broadcast(
+                sockets,
+                &nshdr,
+                |skt| Self::send_raw_to_socket(skt, body, &nshdr, seq_no),
+                || manager.send_raw_with_wait(hdr, body, source),
+            )
+        } else {
+            Self::unicast(
+                sockets,
+                &nshdr,
+                |skt| Self::send_raw_to_socket(skt, body, &nshdr, seq_no),
+                || manager.send_raw_with_wait(hdr, body, source),
+            )
+        }
+        .inspect_err(|e| {
+            error!("{}: Error sending raw: {:?}", hdr, e);
+        })
+    }
+
+    #[allow(unused_variables)]
+    pub(super) fn send_ty_with_wait<T: 'static + Serialize + Clone>(
+        &mut self,
+        hdr: &Header,
+        t: &T,
+    ) -> Result<SendOutcome<P::Wait>, NetStackSendError> {
+        let Self {
+            sockets,
+            seq_no,
+            profile: manager,
+            ..
+        } = self;
+        trace!("{}: Sending msg ty", hdr);
+
+        if hdr.kind == FrameKind::PROTOCOL_ERROR {
+            todo!("{}: Don't do that", hdr);
+        }
+
+        if hdr.dst.port_id == 255 {
+            Self::broadcast(
+                sockets,
+                hdr,
+                |skt| Self::send_ty_to_socket(skt, t, hdr, seq_no),
+                || manager.send_with_wait(hdr, t),
+            )
+        } else {
+            Self::unicast(
+                sockets,
+                hdr,
+                |skt| Self::send_ty_to_socket(skt, t, hdr, seq_no),
+                || manager.send_with_wait(hdr, t),
+            )
+        }
+        .inspect_err(|e| {
+            error!("{}: Error sending ty: {:?}", hdr, e);
+        })
+    }
+
+    #[allow(unused_variables)]
+    pub(super) fn send_bor_with_wait<T: Serialize>(
+        &mut self,
+        hdr: &Header,
+        t: &T,
+    ) -> Result<SendOutcome<P::Wait>, NetStackSendError> {
+        let Self {
+            sockets,
+            seq_no,
+            profile: manager,
+            ..
+        } = self;
+        trace!("{}: Sending msg bor", hdr);
+
+        if hdr.kind == FrameKind::PROTOCOL_ERROR {
+            todo!("{}: Don't do that", hdr);
+        }
+
+        if hdr.dst.port_id == 255 {
+            Self::broadcast(
+                sockets,
+                hdr,
+                |skt| Self::send_bor_to_socket(skt, t, hdr, seq_no),
+                || manager.send_bor_with_wait(hdr, t),
+            )
+        } else {
+            Self::unicast(
+                sockets,
+                hdr,
+                |skt| Self::send_bor_to_socket(skt, t, hdr, seq_no),
+                || manager.send_bor_with_wait(hdr, t),
+            )
+        }
+        .inspect_err(|e| {
+            error!("{}: Error sending bor: {:?}", hdr, e);
+        })
+    }
+
+    pub(super) fn send_err_with_wait(
+        &mut self,
+        hdr: &Header,
+        err: ProtocolError,
+        source: Option<P::InterfaceIdent>,
+    ) -> Result<SendOutcome<P::Wait>, NetStackSendError> {
+        let Self {
+            sockets,
+            seq_no,
+            profile: manager,
+            ..
+        } = self;
+        trace!("{}: Sending msg err", hdr);
+
+        if hdr.dst.port_id == 255 {
+            todo!("{}: Don't do that", hdr);
+        }
+
+        Self::unicast_err(
+            sockets,
+            hdr,
+            |skt| Self::send_err_to_socket(skt, err, hdr, seq_no),
+            || manager.send_err_with_wait(hdr, err, source),
+        )
     }
 }
 

--- a/crates/ergot/src/net_stack/mod.rs
+++ b/crates/ergot/src/net_stack/mod.rs
@@ -29,7 +29,9 @@ use topics::Topics;
 use crate::{
     FrameKind, Header, HeaderSeq, ProtocolError,
     fmtlog::{ErgotFmtTx, Level},
-    interface_manager::{self, InterfaceSendError, Profile},
+    interface_manager::{
+        self, InterfaceSendError, InterfaceWait, Profile, ProfileBackpressure, SendOutcome,
+    },
     socket::{SocketHeader, SocketSendError},
     well_known::ErgotFmtTxTopic,
 };
@@ -304,6 +306,111 @@ where
 
     pub(crate) unsafe fn with_lock<U, F: FnOnce() -> U>(&self, f: F) -> U {
         self.inner.with_lock(|_inner| f())
+    }
+}
+
+/// Async backpressure methods.
+///
+/// These `_wait` variants retry automatically when the outgoing buffer is full,
+/// awaiting space outside the mutex lock. The lock is never held across an await
+/// point.
+impl<R, P> NetStack<R, P>
+where
+    R: ScopedRawMutex,
+    P: ProfileBackpressure,
+{
+    /// Like [`send_raw`](Self::send_raw), but waits for buffer space instead of
+    /// returning `InterfaceFull`.
+    pub async fn send_raw_wait(
+        &self,
+        hdr: &HeaderSeq,
+        body: &[u8],
+        source: P::InterfaceIdent,
+    ) -> Result<(), NetStackSendError> {
+        loop {
+            let res = self
+                .inner
+                .try_with_lock(|inner| inner.send_raw_with_wait(hdr, body, source.clone()))
+                .ok_or(NetStackSendError::WouldDeadlock)?;
+            let res = res?;
+
+            match res {
+                SendOutcome::Sent => return Ok(()),
+                SendOutcome::Wait(wait) => {
+                    wait.wait_raw(body.len()).await;
+                }
+            }
+        }
+    }
+
+    /// Like [`send_ty`](Self::send_ty), but waits for buffer space instead of
+    /// returning `InterfaceFull`.
+    pub async fn send_ty_wait<T: 'static + Serialize + Clone>(
+        &self,
+        hdr: &Header,
+        t: &T,
+    ) -> Result<(), NetStackSendError> {
+        loop {
+            let res = self
+                .inner
+                .try_with_lock(|inner| inner.send_ty_with_wait(hdr, t))
+                .ok_or(NetStackSendError::WouldDeadlock)?;
+            let res = res?;
+
+            match res {
+                SendOutcome::Sent => return Ok(()),
+                SendOutcome::Wait(wait) => {
+                    wait.wait_ty().await;
+                }
+            }
+        }
+    }
+
+    /// Like [`send_bor`](Self::send_bor), but waits for buffer space instead of
+    /// returning `InterfaceFull`.
+    pub async fn send_bor_wait<T: Serialize>(
+        &self,
+        hdr: &Header,
+        t: &T,
+    ) -> Result<(), NetStackSendError> {
+        loop {
+            let res = self
+                .inner
+                .try_with_lock(|inner| inner.send_bor_with_wait(hdr, t))
+                .ok_or(NetStackSendError::WouldDeadlock)?;
+            let res = res?;
+
+            match res {
+                SendOutcome::Sent => return Ok(()),
+                SendOutcome::Wait(wait) => {
+                    wait.wait_ty().await;
+                }
+            }
+        }
+    }
+
+    /// Like [`send_err`](Self::send_err), but waits for buffer space instead of
+    /// returning `InterfaceFull`.
+    pub async fn send_err_wait(
+        &self,
+        hdr: &Header,
+        err: ProtocolError,
+        source: Option<P::InterfaceIdent>,
+    ) -> Result<(), NetStackSendError> {
+        loop {
+            let res = self
+                .inner
+                .try_with_lock(|inner| inner.send_err_with_wait(hdr, err, source.clone()))
+                .ok_or(NetStackSendError::WouldDeadlock)?;
+            let res = res?;
+
+            match res {
+                SendOutcome::Sent => return Ok(()),
+                SendOutcome::Wait(wait) => {
+                    wait.wait_err().await;
+                }
+            }
+        }
     }
 }
 

--- a/crates/ergot/src/net_stack/topics.rs
+++ b/crates/ergot/src/net_stack/topics.rs
@@ -2,6 +2,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
     Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, Key,
+    interface_manager::ProfileBackpressure,
     nash::NameHash,
     net_stack::{NetStackHandle, NetStackSendError},
     traits::Topic,
@@ -87,29 +88,9 @@ impl<NS: NetStackHandle> Topics<NS> {
         crate::socket::topic::stack_bor::Receiver::new(self.inner, queue, mtu, name)
     }
 
-    /// Send a broadcast message for the topic `T`.
-    ///
-    /// This message will be sent to all matching local socket listeners, as well
-    /// as on all interfaces, to be repeated outwards, in a "flood" style.
-    pub fn broadcast<T>(self, msg: &T::Message, name: Option<&str>) -> Result<(), NetStackSendError>
-    where
-        T: Topic,
-        T::Message: Serialize + Clone + DeserializeOwned + 'static,
-    {
-        self.broadcast_with_src_port::<T>(msg, name, 0)
-    }
-
-    pub fn broadcast_with_src_port<T>(
-        self,
-        msg: &T::Message,
-        name: Option<&str>,
-        port: u8,
-    ) -> Result<(), NetStackSendError>
-    where
-        T: Topic,
-        T::Message: Serialize + Clone + DeserializeOwned + 'static,
-    {
-        let hdr = Header {
+    /// Build the header for a broadcast topic message.
+    fn broadcast_header<T: Topic>(name: Option<&str>, port: u8, ttl: u8) -> Header {
+        Header {
             src: Address {
                 network_id: 0,
                 node_id: 0,
@@ -126,11 +107,64 @@ impl<NS: NetStackHandle> Topics<NS> {
             }),
             seq_no: None,
             kind: FrameKind::TOPIC_MSG,
-            ttl: DEFAULT_TTL,
-        };
-        let stack = self.inner.stack();
-        stack.send_ty(&hdr, msg)?;
-        Ok(())
+            ttl,
+        }
+    }
+
+    /// Send a broadcast message for the topic `T`.
+    ///
+    /// This message will be sent to all matching local socket listeners, as well
+    /// as on all interfaces, to be repeated outwards, in a "flood" style.
+    pub fn broadcast<T>(self, msg: &T::Message, name: Option<&str>) -> Result<(), NetStackSendError>
+    where
+        T: Topic,
+        T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    {
+        self.broadcast_with_src_port::<T>(msg, name, 0)
+    }
+
+    /// Like [`Self::broadcast`], but waits for buffer space if the interface is full.
+    pub async fn broadcast_wait<T>(
+        self,
+        msg: &T::Message,
+        name: Option<&str>,
+    ) -> Result<(), NetStackSendError>
+    where
+        T: Topic,
+        T::Message: Serialize + Clone + DeserializeOwned + 'static,
+        NS::Profile: ProfileBackpressure,
+    {
+        self.broadcast_with_src_port_wait::<T>(msg, name, 0).await
+    }
+
+    pub fn broadcast_with_src_port<T>(
+        self,
+        msg: &T::Message,
+        name: Option<&str>,
+        port: u8,
+    ) -> Result<(), NetStackSendError>
+    where
+        T: Topic,
+        T::Message: Serialize + Clone + DeserializeOwned + 'static,
+    {
+        let hdr = Self::broadcast_header::<T>(name, port, DEFAULT_TTL);
+        self.inner.stack().send_ty(&hdr, msg)
+    }
+
+    /// Like [`Self::broadcast_with_src_port`], but waits for buffer space if the interface is full.
+    pub async fn broadcast_with_src_port_wait<T>(
+        self,
+        msg: &T::Message,
+        name: Option<&str>,
+        port: u8,
+    ) -> Result<(), NetStackSendError>
+    where
+        T: Topic,
+        T::Message: Serialize + Clone + DeserializeOwned + 'static,
+        NS::Profile: ProfileBackpressure,
+    {
+        let hdr = Self::broadcast_header::<T>(name, port, DEFAULT_TTL);
+        self.inner.stack().send_ty_wait(&hdr, msg).await
     }
 
     /// Like [`Self::broadcast`], but with a TTL of zero so that messages are
@@ -144,33 +178,13 @@ impl<NS: NetStackHandle> Topics<NS> {
         T: Topic,
         T::Message: Serialize + Clone + DeserializeOwned + 'static,
     {
-        let hdr = Header {
-            src: Address {
-                network_id: 0,
-                node_id: 0,
-                port_id: 0,
-            },
-            dst: Address {
-                network_id: 0,
-                node_id: 0,
-                port_id: 255,
-            },
-            any_all: Some(AnyAllAppendix {
-                key: Key(T::TOPIC_KEY.to_bytes()),
-                nash: name.map(NameHash::new),
-            }),
-            seq_no: None,
-            kind: FrameKind::TOPIC_MSG,
-            ttl: 0,
-        };
-        let stack = self.inner.stack();
-        stack.send_ty(&hdr, msg)?;
-        Ok(())
+        let hdr = Self::broadcast_header::<T>(name, 0, 0);
+        self.inner.stack().send_ty(&hdr, msg)
     }
 
     /// Send a unicast message for the topic `T`.
     ///
-    /// This message will be sent directly to the destination
+    /// This message will be sent directly to the destination.
     pub fn unicast<T>(self, dest: Address, msg: &T::Message) -> Result<(), NetStackSendError>
     where
         T: Topic,
@@ -188,15 +202,10 @@ impl<NS: NetStackHandle> Topics<NS> {
             kind: FrameKind::TOPIC_MSG,
             ttl: DEFAULT_TTL,
         };
-        let stack = self.inner.stack();
-        stack.send_ty(&hdr, msg)?;
-        Ok(())
+        self.inner.stack().send_ty(&hdr, msg)
     }
 
     /// Send a broadcast message for the topic `T`.
-    ///
-    /// This message will be sent to all matching local socket listeners, as well
-    /// as on all interfaces, to be repeated outwards, in a "flood" style.
     ///
     /// The same as [`Self::broadcast`], but accepts messages with borrowed contents.
     /// This may be less efficient when delivering to local sockets.
@@ -209,33 +218,26 @@ impl<NS: NetStackHandle> Topics<NS> {
         T: Topic + Sized,
         T::Message: Serialize + Sized,
     {
-        let hdr = Header {
-            src: Address {
-                network_id: 0,
-                node_id: 0,
-                port_id: 0,
-            },
-            dst: Address {
-                network_id: 0,
-                node_id: 0,
-                port_id: 255,
-            },
-            any_all: Some(AnyAllAppendix {
-                key: Key(T::TOPIC_KEY.to_bytes()),
-                nash: name.map(NameHash::new),
-            }),
-            seq_no: None,
-            kind: FrameKind::TOPIC_MSG,
-            ttl: DEFAULT_TTL,
-        };
-        let stack = self.inner.stack();
-        stack.send_bor(&hdr, msg)?;
-        Ok(())
+        let hdr = Self::broadcast_header::<T>(name, 0, DEFAULT_TTL);
+        self.inner.stack().send_bor(&hdr, msg)
+    }
+
+    /// Like [`Self::broadcast_borrowed`], but waits for buffer space if the interface is full.
+    pub async fn broadcast_borrowed_wait<T>(
+        self,
+        msg: &T::Message,
+        name: Option<&str>,
+    ) -> Result<(), NetStackSendError>
+    where
+        T: Topic + Sized,
+        T::Message: Serialize + Sized,
+        NS::Profile: ProfileBackpressure,
+    {
+        let hdr = Self::broadcast_header::<T>(name, 0, DEFAULT_TTL);
+        self.inner.stack().send_bor_wait(&hdr, msg).await
     }
 
     /// Send a unicast message for the topic `T`.
-    ///
-    /// This message will be sent directly to the destination
     ///
     /// The same as [`Self::unicast`], but accepts messages with borrowed contents.
     /// This may be less efficient when delivering to local sockets.
@@ -260,8 +262,6 @@ impl<NS: NetStackHandle> Topics<NS> {
             kind: FrameKind::TOPIC_MSG,
             ttl: DEFAULT_TTL,
         };
-        let stack = self.inner.stack();
-        stack.send_bor(&hdr, msg)?;
-        Ok(())
+        self.inner.stack().send_bor(&hdr, msg)
     }
 }

--- a/crates/ergot/src/toolkits/mod.rs
+++ b/crates/ergot/src/toolkits/mod.rs
@@ -50,12 +50,16 @@ pub mod embedded_io_async_v0_6 {
     pub type BaseStack<Q, R> = crate::NetStack<R, EmbeddedIoManager<Q>>;
     pub type RxWorker<Q, R, D> = eio::RxWorker<&'static BaseStack<Q, R>, D>;
 
-    pub const fn new_target_stack<Q, R>(producer: StreamProducer<Q>, mtu: u16) -> Stack<Q, R>
+    pub const fn new_target_stack<Q, R>(
+        producer: StreamProducer<Q>,
+        wait_q: Option<Q>,
+        mtu: u16,
+    ) -> Stack<Q, R>
     where
         Q: BbqHandle + 'static,
         R: ScopedRawMutex + ConstInit + 'static,
     {
-        NetStack::new_with_profile(DirectEdge::new_target(Sink::new(producer, mtu)))
+        NetStack::new_with_profile(DirectEdge::new_target(Sink::new(producer, wait_q, mtu)))
     }
 }
 
@@ -85,12 +89,16 @@ pub mod embedded_io_async_v0_7 {
     pub type BaseStack<Q, R> = crate::NetStack<R, EmbeddedIoManager<Q>>;
     pub type RxWorker<Q, R, D> = eio::RxWorker<&'static BaseStack<Q, R>, D>;
 
-    pub const fn new_target_stack<Q, R>(producer: StreamProducer<Q>, mtu: u16) -> Stack<Q, R>
+    pub const fn new_target_stack<Q, R>(
+        producer: StreamProducer<Q>,
+        wait_q: Option<Q>,
+        mtu: u16,
+    ) -> Stack<Q, R>
     where
         Q: BbqHandle + 'static,
         R: ScopedRawMutex + ConstInit + 'static,
     {
-        NetStack::new_with_profile(DirectEdge::new_target(Sink::new(producer, mtu)))
+        NetStack::new_with_profile(DirectEdge::new_target(Sink::new(producer, wait_q, mtu)))
     }
 }
 
@@ -124,12 +132,16 @@ pub mod embassy_usb_v0_5 {
     pub type BaseStack<Q, R> = crate::NetStack<R, EmbassyUsbManager<Q>>;
     pub type RxWorker<Q, R, D> = eusb_0_5::RxWorker<Q, &'static BaseStack<Q, R>, D>;
 
-    pub const fn new_target_stack<Q, R>(producer: FramedProducer<Q, u16>, mtu: u16) -> Stack<Q, R>
+    pub const fn new_target_stack<Q, R>(
+        producer: FramedProducer<Q, u16>,
+        wait_q: Option<Q>,
+        mtu: u16,
+    ) -> Stack<Q, R>
     where
         Q: BbqHandle,
         R: ScopedRawMutex + ConstInit + 'static,
     {
-        NetStack::new_with_profile(DirectEdge::new_target(Sink::new(producer, mtu)))
+        NetStack::new_with_profile(DirectEdge::new_target(Sink::new(producer, wait_q, mtu)))
     }
 }
 
@@ -151,16 +163,21 @@ pub mod embassy_net_v0_7 {
 
     pub type EdgeStack<Q, R> = NetStack<R, DirectEdge<EmbassyNetInterface<Q>>>;
 
-    pub const fn new_target_stack<Q, R>(producer: FramedProducer<Q>, mtu: u16) -> EdgeStack<Q, R>
+    pub const fn new_target_stack<Q, R>(
+        producer: FramedProducer<Q>,
+        wait_q: Option<Q>,
+        mtu: u16,
+    ) -> EdgeStack<Q, R>
     where
         Q: BbqHandle,
         R: ScopedRawMutex + ConstInit + 'static,
     {
-        NetStack::new_with_profile(DirectEdge::new_target(Sink::new(producer, mtu)))
+        NetStack::new_with_profile(DirectEdge::new_target(Sink::new(producer, wait_q, mtu)))
     }
 
     pub const fn new_controller_stack<Q, R>(
         producer: FramedProducer<Q>,
+        wait_q: Option<Q>,
         mtu: u16,
     ) -> EdgeStack<Q, R>
     where
@@ -168,7 +185,7 @@ pub mod embassy_net_v0_7 {
         R: ScopedRawMutex + ConstInit + 'static,
     {
         NetStack::new_with_profile(DirectEdge::new_controller(
-            Sink::new(producer, mtu),
+            Sink::new(producer, wait_q, mtu),
             InterfaceState::Down,
         ))
     }

--- a/demos/esp32c3/esp32c3-serial/src/main.rs
+++ b/demos/esp32c3/esp32c3-serial/src/main.rs
@@ -32,10 +32,10 @@ type Stack = kit::Stack<&'static Queue, CriticalSectionRawMutex>;
 // The type of our outgoing queue
 type Queue = kit::Queue<OUT_QUEUE_SIZE, CsCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_target_stack(OUTQ.stream_producer(), MAX_PACKET_SIZE as u16);
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_target_stack(OUTQ.stream_producer(), Some(&OUTQ), MAX_PACKET_SIZE as u16);
 /// Statically store receive buffers
 static RECV_BUF: ConstStaticCell<[u8; MAX_PACKET_SIZE]> =
     ConstStaticCell::new([0u8; MAX_PACKET_SIZE]);

--- a/demos/esp32c6/esp32c6-serial/src/main.rs
+++ b/demos/esp32c6/esp32c6-serial/src/main.rs
@@ -32,10 +32,10 @@ type Stack = kit::Stack<&'static Queue, CriticalSectionRawMutex>;
 // The type of our outgoing queue
 type Queue = kit::Queue<OUT_QUEUE_SIZE, AtomicCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_target_stack(OUTQ.stream_producer(), MAX_PACKET_SIZE as u16);
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_target_stack(OUTQ.stream_producer(), Some(&OUTQ), MAX_PACKET_SIZE as u16);
 /// Statically store receive buffers
 static RECV_BUF: ConstStaticCell<[u8; MAX_PACKET_SIZE]> =
     ConstStaticCell::new([0u8; MAX_PACKET_SIZE]);

--- a/demos/nrf52840/nrf52840-eusb/src/main.rs
+++ b/demos/nrf52840/nrf52840-eusb/src/main.rs
@@ -39,12 +39,12 @@ type Stack = kit::Stack<&'static Queue, ThreadModeRawMutex>;
 // The type of our outgoing queue
 type Queue = kit::Queue<OUT_QUEUE_SIZE, AtomicCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), MAX_PACKET_SIZE as u16);
-/// Statically store our USB app buffers
-static STORAGE: kit::WireStorage<256, 256, 64, 256> = kit::WireStorage::new();
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), Some(&OUTQ), MAX_PACKET_SIZE as u16);
+/// Statically store our USB app buffers
+static STORAGE: kit::WireStorage<256, 256, 64, 256> = kit::WireStorage::new();
 
 // Define some endpoints
 endpoint!(LedEndpoint, bool, (), "led/set");

--- a/demos/rp2040/rp2040-eusb/src/main.rs
+++ b/demos/rp2040/rp2040-eusb/src/main.rs
@@ -38,12 +38,12 @@ type Stack = kit::Stack<&'static Queue, CriticalSectionRawMutex>;
 // The type of our outgoing queue
 type Queue = kit::Queue<OUT_QUEUE_SIZE, CsCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), MAX_PACKET_SIZE as u16);
-/// Statically store our USB app buffers
-static STORAGE: kit::WireStorage<256, 256, 64, 256> = kit::WireStorage::new();
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), Some(&OUTQ), MAX_PACKET_SIZE as u16);
+/// Statically store our USB app buffers
+static STORAGE: kit::WireStorage<256, 256, 64, 256> = kit::WireStorage::new();
 
 // Define some endpoints
 endpoint!(LedEndpoint, bool, (), "led/set");

--- a/demos/rp2040/rp2040-serial-pair/src/bin/controller.rs
+++ b/demos/rp2040/rp2040-serial-pair/src/bin/controller.rs
@@ -34,6 +34,7 @@ pub type Stack = NetStack<CriticalSectionRawMutex, PairedUartProfile<&'static Tx
 pub static TX_QUEUE: TxQueue = TxQueue::new();
 pub static STACK: Stack = PairedUartProfile::new_controller_stack::<CriticalSectionRawMutex>(
     TX_QUEUE.framed_producer(),
+    Some(&TX_QUEUE),
     RX_BUF_LEN as u16,
 );
 pub static RX_BUF: ConstStaticCell<[u8; RX_BUF_LEN]> = ConstStaticCell::new([0u8; RX_BUF_LEN]);

--- a/demos/rp2040/rp2040-serial-pair/src/bin/target.rs
+++ b/demos/rp2040/rp2040-serial-pair/src/bin/target.rs
@@ -34,6 +34,7 @@ pub type Stack = NetStack<CriticalSectionRawMutex, PairedUartProfile<&'static Tx
 pub static TX_QUEUE: TxQueue = TxQueue::new();
 pub static STACK: Stack = PairedUartProfile::new_target_stack::<CriticalSectionRawMutex>(
     TX_QUEUE.framed_producer(),
+    Some(&TX_QUEUE),
     RX_BUF_LEN as u16,
 );
 pub static RX_BUF: ConstStaticCell<[u8; RX_BUF_LEN]> = ConstStaticCell::new([0u8; RX_BUF_LEN]);

--- a/demos/rp2040/rp2040-serial-pair/src/lib.rs
+++ b/demos/rp2040/rp2040-serial-pair/src/lib.rs
@@ -94,11 +94,12 @@ pub struct PairedUartProfile<Q: BbqHandle + 'static> {
 impl<Q: BbqHandle + 'static> PairedUartProfile<Q> {
     pub const fn new_controller_stack<R: ScopedRawMutex + mutex::ConstInit>(
         producer: FramedProducer<Q, u16>,
+        wait_q: Option<Q>,
         mtu: u16,
     ) -> NetStack<R, Self> {
         NetStack::new_with_profile(Self {
             inner: DirectEdge::new_controller(
-                framed_stream::Sink::new(producer, mtu),
+                framed_stream::Sink::new(producer, wait_q, mtu),
                 InterfaceState::Down,
             ),
         })
@@ -106,10 +107,11 @@ impl<Q: BbqHandle + 'static> PairedUartProfile<Q> {
 
     pub const fn new_target_stack<R: ScopedRawMutex + mutex::ConstInit>(
         producer: FramedProducer<Q, u16>,
+        wait_q: Option<Q>,
         mtu: u16,
     ) -> NetStack<R, Self> {
         NetStack::new_with_profile(Self {
-            inner: DirectEdge::new_target(framed_stream::Sink::new(producer, mtu)),
+            inner: DirectEdge::new_target(framed_stream::Sink::new(producer, wait_q, mtu)),
         })
     }
 }

--- a/demos/rp2350/rp2350-eusb/src/main.rs
+++ b/demos/rp2350/rp2350-eusb/src/main.rs
@@ -38,12 +38,12 @@ type Stack = kit::Stack<&'static Queue, CriticalSectionRawMutex>;
 // The type of our outgoing queue
 type Queue = kit::Queue<OUT_QUEUE_SIZE, CsCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), MAX_PACKET_SIZE as u16);
-/// Statically store our USB app buffers
-static STORAGE: kit::WireStorage<256, 256, 64, 256> = kit::WireStorage::new();
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), Some(&OUTQ), MAX_PACKET_SIZE as u16);
+/// Statically store our USB app buffers
+static STORAGE: kit::WireStorage<256, 256, 64, 256> = kit::WireStorage::new();
 
 // Define some endpoints
 endpoint!(LedEndpoint, bool, (), "led/set");

--- a/demos/rp2350/rp2350-tilt/src/main.rs
+++ b/demos/rp2350/rp2350-tilt/src/main.rs
@@ -48,12 +48,12 @@ type Stack = kit::Stack<&'static Queue, CriticalSectionRawMutex>;
 // The type of our outgoing queue
 type Queue = kit::Queue<OUT_QUEUE_SIZE, CsCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), MAX_PACKET_SIZE as u16);
-/// Statically store our USB app buffers
-static STORAGE: kit::WireStorage<256, 256, 64, 256> = kit::WireStorage::new();
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), Some(&OUTQ), MAX_PACKET_SIZE as u16);
+/// Statically store our USB app buffers
+static STORAGE: kit::WireStorage<256, 256, 64, 256> = kit::WireStorage::new();
 
 bind_interrupts!(pub struct Irqs {
     USBCTRL_IRQ => usb::InterruptHandler<USB>;

--- a/demos/stm32g474/src/bin/rtt.rs
+++ b/demos/stm32g474/src/bin/rtt.rs
@@ -48,6 +48,7 @@ async fn main(spawner: Spawner) {
     let tx_queue = TX_QUEUE.init(Queue::new());
     let stack = STACK.init(embedded_io_async_v0_7::new_target_stack(
         tx_queue.stream_producer(),
+        None,
         ERGOT_MTU,
     ));
 

--- a/demos/stm32g474/src/bin/rtt_defmt.rs
+++ b/demos/stm32g474/src/bin/rtt_defmt.rs
@@ -57,6 +57,7 @@ async fn main(spawner: Spawner) {
     let tx_queue = TX_QUEUE.init(Queue::new());
     let stack = STACK.init(embedded_io_async_v0_7::new_target_stack(
         tx_queue.stream_producer(),
+        None,
         ERGOT_MTU,
     ));
 

--- a/demos/stm32g474/src/bin/rtt_defmt_ergot.rs
+++ b/demos/stm32g474/src/bin/rtt_defmt_ergot.rs
@@ -61,6 +61,7 @@ async fn main(spawner: Spawner) {
     let tx_queue = TX_QUEUE.init(Queue::new());
     let stack = STACK.init(embedded_io_async_v0_7::new_target_stack(
         tx_queue.stream_producer(),
+        None,
         ERGOT_MTU,
     ));
 

--- a/demos/stm32g474/src/bin/serial_defmt.rs
+++ b/demos/stm32g474/src/bin/serial_defmt.rs
@@ -83,6 +83,7 @@ async fn main(spawner: Spawner) {
     let tx_queue = TX_QUEUE.init(Queue::new());
     let stack = STACK.init(embedded_io_async_v0_7::new_target_stack(
         tx_queue.stream_producer(),
+        None,
         ERGOT_MTU,
     ));
 

--- a/demos/stm32h723zg/Cargo.lock
+++ b/demos/stm32h723zg/Cargo.lock
@@ -722,7 +722,6 @@ dependencies = [
  "const-fnv1a-hash",
  "cordyceps",
  "critical-section",
- "defmt 1.0.1",
  "embassy-futures",
  "embassy-net",
  "embassy-time",
@@ -849,7 +848,6 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
- "defmt 1.0.1",
  "hash32 0.3.1",
  "serde",
  "stable_deref_trait",

--- a/demos/stm32h723zg/nucleoh723zg-net-udp-pair/src/bin/controller.rs
+++ b/demos/stm32h723zg/nucleoh723zg-net-udp-pair/src/bin/controller.rs
@@ -37,10 +37,10 @@ const OUT_QUEUE_SIZE: usize = 4096;
 type Stack = kit::EdgeStack<&'static Queue, CriticalSectionRawMutex>;
 type Queue = kit::Queue<OUT_QUEUE_SIZE, AtomicCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_controller_stack(OUTQ.framed_producer(), UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX as u16);
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_controller_stack(OUTQ.framed_producer(), Some(&OUTQ), UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX as u16);
 /// Statically store receive buffers
 static SCRATCH_BUF: ConstStaticCell<[u8; UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX]> = ConstStaticCell::new([0u8; UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX]);
 

--- a/demos/stm32h723zg/nucleoh723zg-net-udp-pair/src/bin/target.rs
+++ b/demos/stm32h723zg/nucleoh723zg-net-udp-pair/src/bin/target.rs
@@ -37,10 +37,10 @@ const OUT_QUEUE_SIZE: usize = 4096;
 type Stack = kit::EdgeStack<&'static Queue, CriticalSectionRawMutex>;
 type Queue = kit::Queue<OUT_QUEUE_SIZE, AtomicCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX as u16);
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), Some(&OUTQ), UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX as u16);
 /// Statically store receive buffers
 static SCRATCH_BUF: ConstStaticCell<[u8; UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX]> = ConstStaticCell::new([0u8; UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX]);
 

--- a/demos/stm32h743zi/nucleoh743zi-net-udp-pair/src/bin/controller.rs
+++ b/demos/stm32h743zi/nucleoh743zi-net-udp-pair/src/bin/controller.rs
@@ -37,10 +37,10 @@ const OUT_QUEUE_SIZE: usize = 4096;
 type Stack = kit::EdgeStack<&'static Queue, CriticalSectionRawMutex>;
 type Queue = kit::Queue<OUT_QUEUE_SIZE, AtomicCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_controller_stack(OUTQ.framed_producer(), UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX as u16);
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_controller_stack(OUTQ.framed_producer(), Some(&OUTQ), UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX as u16);
 /// Statically store receive buffers
 static SCRATCH_BUF: ConstStaticCell<[u8; UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX]> = ConstStaticCell::new([0u8; UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX]);
 

--- a/demos/stm32h743zi/nucleoh743zi-net-udp-pair/src/bin/target.rs
+++ b/demos/stm32h743zi/nucleoh743zi-net-udp-pair/src/bin/target.rs
@@ -37,10 +37,10 @@ const OUT_QUEUE_SIZE: usize = 4096;
 type Stack = kit::EdgeStack<&'static Queue, CriticalSectionRawMutex>;
 type Queue = kit::Queue<OUT_QUEUE_SIZE, AtomicCoord>;
 
-/// Statically store our netstack
-static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX as u16);
 /// Statically store our outgoing packet buffer
 static OUTQ: Queue = kit::Queue::new();
+/// Statically store our netstack
+static STACK: Stack = kit::new_target_stack(OUTQ.framed_producer(), Some(&OUTQ), UDP_OVER_ETH_ERGOT_FRAME_SIZE_MAX as u16);
 /// Statically store receive buffers
 static SCRATCH_BUF: ConstStaticCell<[u8; UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX]> = ConstStaticCell::new([0u8; UDP_OVER_ETH_ERGOT_PAYLOAD_SIZE_MAX]);
 


### PR DESCRIPTION
Introduce `ProfileBackpressure` trait with `send_*_with_wait` methods that return` SendOutcome::Wait` when the output queue is full, allowing callers to await and retry instead of dropping messages.

Add async public API methods on NetStack (`send_ty_wait`, `send_raw_wait`, etc.) and Topics (`broadcast_wait`, etc.) that automatically handle the wait-and-retry loop.

Enable embedded toolkits to use backpressure by passing an optional queue handle to Sink::new(). Update all embedded toolkit constructors and demo applications.

Fix broadcast routing to properly return `InterfaceFull` when all interfaces are full instead of `NoRouteToDest`.