### PR TITLE
Add MTU discovery with typed ProtocolError enum

### DIFF
--- a/crates/ergot/Cargo.toml
+++ b/crates/ergot/Cargo.toml
@@ -31,7 +31,7 @@ std = [
     "cobs-acc/std",
     "cobs/std",
     "critical-section/std",
-    "embassy-time/std",
+    "embassy-time?/std",
     "maitake-sync/std",
     "mutex/std",
     "postcard/use-std",

--- a/crates/ergot/src/interface_manager/edge_port.rs
+++ b/crates/ergot/src/interface_manager/edge_port.rs
@@ -196,6 +196,15 @@ impl<I: Interface> EdgePort<I> {
     /// reassign one.
     #[allow(dead_code)]
     pub fn send_raw(&mut self, hdr: &HeaderSeq, data: &[u8]) -> Result<(), InterfaceSendError> {
+        // Check if the frame would exceed the outgoing interface's MTU
+        let frame_size = crate::wire_frames::MAX_HDR_ENCODED_SIZE + data.len();
+        let iface_mtu = self.sink.mtu() as usize;
+        if frame_size > iface_mtu {
+            return Err(InterfaceSendError::PacketTooBig {
+                mtu: iface_mtu as u16,
+            });
+        }
+
         let nshdr: Header = hdr.clone().into();
         let (sink, header) = self.common_send(&nshdr)?;
         sink.send_raw(&header, data)

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -322,14 +322,16 @@ pub enum SetStateError {
 impl InterfaceSendError {
     pub fn to_error(&self) -> ProtocolError {
         match self {
-            InterfaceSendError::DestinationLocal => ProtocolError::ISE_DESTINATION_LOCAL,
-            InterfaceSendError::NoRouteToDest => ProtocolError::ISE_NO_ROUTE_TO_DEST,
-            InterfaceSendError::InterfaceFull => ProtocolError::ISE_INTERFACE_FULL,
-            InterfaceSendError::InternalError => ProtocolError::ISE_INTERNAL_ERROR,
-            InterfaceSendError::AnyPortMissingKey => ProtocolError::ISE_ANY_PORT_MISSING_KEY,
-            InterfaceSendError::TtlExpired => ProtocolError::ISE_TTL_EXPIRED,
-            InterfaceSendError::RoutingLoop => ProtocolError::ISE_ROUTING_LOOP,
-            InterfaceSendError::PacketTooBig { .. } => ProtocolError::ISE_PACKET_TOO_BIG,
+            InterfaceSendError::DestinationLocal => ProtocolError::IseDestinationLocal,
+            InterfaceSendError::NoRouteToDest => ProtocolError::IseNoRouteToDest,
+            InterfaceSendError::InterfaceFull => ProtocolError::IseInterfaceFull,
+            InterfaceSendError::InternalError => ProtocolError::IseInternalError,
+            InterfaceSendError::AnyPortMissingKey => ProtocolError::IseAnyPortMissingKey,
+            InterfaceSendError::TtlExpired => ProtocolError::IseTtlExpired,
+            InterfaceSendError::RoutingLoop => ProtocolError::IseRoutingLoop,
+            InterfaceSendError::PacketTooBig { mtu } => {
+                ProtocolError::IsePacketTooBig { mtu: *mtu }
+            }
         }
     }
 }

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -232,6 +232,13 @@ pub trait Interface {
 /// TX worker.
 #[allow(clippy::result_unit_err)]
 pub trait InterfaceSink {
+    /// Returns the maximum total ergot packet size (header + payload) that this
+    /// interface can accept for sending.
+    ///
+    /// If the interface performs internal fragmentation/reassembly, this returns
+    /// the max reassembled size, not the raw link frame size.
+    fn mtu(&self) -> u16;
+
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, body: &T) -> Result<(), ()>;
     fn send_raw(&mut self, hdr: &HeaderSeq, body: &[u8]) -> Result<(), ()>;
     fn send_err(&mut self, hdr: &HeaderSeq, err: ProtocolError) -> Result<(), ()>;
@@ -256,6 +263,8 @@ pub enum InterfaceSendError {
     TtlExpired,
     /// Interface detected that a packet should be routed back to its source
     RoutingLoop,
+    /// The serialized frame exceeds the outgoing interface's MTU
+    PacketTooBig { mtu: u16 },
 }
 
 /// An error when deregistering an interface
@@ -320,6 +329,7 @@ impl InterfaceSendError {
             InterfaceSendError::AnyPortMissingKey => ProtocolError::ISE_ANY_PORT_MISSING_KEY,
             InterfaceSendError::TtlExpired => ProtocolError::ISE_TTL_EXPIRED,
             InterfaceSendError::RoutingLoop => ProtocolError::ISE_ROUTING_LOOP,
+            InterfaceSendError::PacketTooBig { .. } => ProtocolError::ISE_PACKET_TOO_BIG,
         }
     }
 }

--- a/crates/ergot/src/interface_manager/multi.rs
+++ b/crates/ergot/src/interface_manager/multi.rs
@@ -54,6 +54,12 @@ macro_rules! multi_interface {
 
         #[allow(clippy::result_unit_err)]
         impl $crate::interface_manager::InterfaceSink for $sink_name {
+            fn mtu(&self) -> u16 {
+                match self {
+                    $( Self::$variant(s) => s.mtu(), )+
+                }
+            }
+
             fn send_ty<T: ::serde::Serialize>(
                 &mut self,
                 hdr: &$crate::HeaderSeq,

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -846,18 +846,19 @@ pub fn process_frame<N>(
                 "{} packet too big for outgoing interface (mtu={})",
                 hdr, mtu
             );
-            // Send PROTOCOL_ERROR back to source with the bottleneck MTU
             let err_hdr = Header {
-                src: hdr.dst.into(),
-                dst: hdr.src.into(),
+                src: hdr.dst,
+                dst: hdr.src,
                 any_all: None,
                 seq_no: Some(hdr.seq_no),
                 kind: crate::FrameKind::PROTOCOL_ERROR,
                 ttl: crate::DEFAULT_TTL,
             };
-            let _ = nsh
-                .stack()
-                .send_err(&err_hdr, ProtocolError::ISE_PACKET_TOO_BIG, Some(ident));
+            let _ = nsh.stack().send_err(
+                &err_hdr,
+                ProtocolError::IsePacketTooBig { mtu },
+                Some(ident),
+            );
         }
         Err(e) => {
             warn!("{} recv->send error: {:?}", hdr, e);

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -831,14 +831,33 @@ pub fn process_frame<N>(
     let nshdr: Header = hdr.clone().into();
 
     let res = match frame.body {
-        Ok(body) => nsh.stack().send_raw(&hdr, body, ident),
-        Err(e) => nsh.stack().send_err(&nshdr, e, Some(ident)),
+        Ok(body) => nsh.stack().send_raw(&hdr, body, ident.clone()),
+        Err(e) => nsh.stack().send_err(&nshdr, e, Some(ident.clone())),
     };
 
-    #[allow(unused_variables)]
     match res {
         Ok(()) => {
             debug!("{}: frame delivered", hdr);
+        }
+        Err(crate::net_stack::NetStackSendError::InterfaceSend(
+            InterfaceSendError::PacketTooBig { mtu },
+        )) => {
+            warn!(
+                "{} packet too big for outgoing interface (mtu={})",
+                hdr, mtu
+            );
+            // Send PROTOCOL_ERROR back to source with the bottleneck MTU
+            let err_hdr = Header {
+                src: hdr.dst.into(),
+                dst: hdr.src.into(),
+                any_all: None,
+                seq_no: Some(hdr.seq_no),
+                kind: crate::FrameKind::PROTOCOL_ERROR,
+                ttl: crate::DEFAULT_TTL,
+            };
+            let _ = nsh
+                .stack()
+                .send_err(&err_hdr, ProtocolError::ISE_PACKET_TOO_BIG, Some(ident));
         }
         Err(e) => {
             warn!("{} recv->send error: {:?}", hdr, e);

--- a/crates/ergot/src/interface_manager/transports/mod.rs
+++ b/crates/ergot/src/interface_manager/transports/mod.rs
@@ -5,6 +5,8 @@
 //!
 //! [`FrameProcessor`]: crate::interface_manager::FrameProcessor
 
+pub mod packet;
+
 #[cfg(any(feature = "embedded-io-async-v0_6", feature = "embedded-io-async-v0_7"))]
 pub mod eio;
 

--- a/crates/ergot/src/interface_manager/transports/packet.rs
+++ b/crates/ergot/src/interface_manager/transports/packet.rs
@@ -36,7 +36,9 @@
 //! ```
 
 use crate::interface_manager::{FrameProcessor, InterfaceState, Profile};
-use crate::logging::{error, trace, warn};
+use crate::logging::trace;
+#[cfg(feature = "embassy-time")]
+use crate::logging::warn;
 use crate::net_stack::NetStackHandle;
 use bbqueue::prod_cons::framed::FramedConsumer;
 use bbqueue::traits::bbqhdl::BbqHandle;
@@ -185,8 +187,8 @@ where
             .nsh
             .stack()
             .manage_profile(|im| im.set_interface_state(self.ident.clone(), initial_state))
-            .inspect_err(|e| {
-                error!("Error setting interface state: {:?}", e);
+            .inspect_err(|_e| {
+                crate::logging::error!("Error setting interface state: {:?}", _e);
             });
         #[cfg(feature = "embassy-time")]
         self.notify();

--- a/crates/ergot/src/interface_manager/transports/packet.rs
+++ b/crates/ergot/src/interface_manager/transports/packet.rs
@@ -333,10 +333,18 @@ where
     P: FrameProcessor<N>,
 {
     fn drop(&mut self) {
-        self.nsh.stack().manage_profile(|im| {
-            _ = im.set_interface_state(self.ident.clone(), InterfaceState::Down);
+        let needs_down = self.nsh.stack().manage_profile(|im| {
+            !matches!(
+                im.interface_state(self.ident.clone()),
+                Some(InterfaceState::Down) | None
+            )
         });
-        #[cfg(feature = "embassy-time")]
-        self.notify();
+        if needs_down {
+            self.nsh.stack().manage_profile(|im| {
+                _ = im.set_interface_state(self.ident.clone(), InterfaceState::Down);
+            });
+            #[cfg(feature = "embassy-time")]
+            self.notify();
+        }
     }
 }

--- a/crates/ergot/src/interface_manager/transports/packet.rs
+++ b/crates/ergot/src/interface_manager/transports/packet.rs
@@ -1,0 +1,340 @@
+//! Generic packet (frame-based) RX/TX worker.
+//!
+//! Eliminates boilerplate for transports where each receive/send
+//! operation yields a complete ergot frame (BLE L2CAP, UDP datagrams,
+//! CAN FD, ESP-NOW, SPI, etc.).
+//!
+//! Transport authors implement [`PacketReceiver`] and [`PacketSender`],
+//! then use [`PacketRxTxWorker`] to get the full RX/TX loop with
+//! optional liveness timeout and state change notifications.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use ergot::interface_manager::transports::packet::*;
+//!
+//! struct MyReceiver { /* ... */ }
+//! impl PacketReceiver for MyReceiver {
+//!     type Error = MyError;
+//!     async fn recv(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+//!         // receive one complete frame
+//!     }
+//! }
+//!
+//! struct MySender { /* ... */ }
+//! impl PacketSender for MySender {
+//!     type Error = MyError;
+//!     async fn send(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+//!         // send one complete frame
+//!     }
+//! }
+//!
+//! let mut worker = PacketRxTxWorker::new(nsh, rx, tx, processor, ident, consumer)
+//!     .with_liveness(LivenessConfig { timeout_ms: 5000 })
+//!     .with_state_notify(&STATE_NOTIFY);
+//! worker.run(InterfaceState::Inactive, &mut scratch_buf).await?;
+//! ```
+
+use crate::interface_manager::{FrameProcessor, InterfaceState, Profile};
+use crate::logging::{error, trace, warn};
+use crate::net_stack::NetStackHandle;
+use bbqueue::prod_cons::framed::FramedConsumer;
+use bbqueue::traits::bbqhdl::BbqHandle;
+use bbqueue::traits::notifier::AsyncNotifier;
+use embassy_futures::select::{Either, select};
+
+#[cfg(feature = "embassy-time")]
+use crate::interface_manager::LivenessConfig;
+#[cfg(feature = "embassy-time")]
+use maitake_sync::WaitQueue;
+
+/// Receive one complete frame from the transport.
+///
+/// Implementations fill `buf` with a single frame and return the number of
+/// bytes written. The slice `&buf[..n]` is passed directly to
+/// [`FrameProcessor::process_frame`].
+pub trait PacketReceiver {
+    type Error: core::fmt::Debug;
+
+    /// Receive a single packet into `buf`. Returns the number of bytes received.
+    fn recv(
+        &mut self,
+        buf: &mut [u8],
+    ) -> impl core::future::Future<Output = Result<usize, Self::Error>>;
+}
+
+/// Send one complete frame over the transport.
+///
+/// `data` is a serialized ergot frame read from the outgoing bbqueue.
+pub trait PacketSender {
+    type Error: core::fmt::Debug;
+
+    /// Send a single packet.
+    fn send(&mut self, data: &[u8]) -> impl core::future::Future<Output = Result<(), Self::Error>>;
+}
+
+/// Error returned by [`PacketRxTxWorker::run`].
+#[derive(Debug)]
+pub enum PacketWorkerError<RxE: core::fmt::Debug, TxE: core::fmt::Debug> {
+    /// The receiver returned an error.
+    Rx(RxE),
+    /// The sender returned an error.
+    Tx(TxE),
+}
+
+/// Generic combined RX/TX worker for packet-based transports.
+///
+/// Multiplexes between receiving frames from the transport and sending
+/// serialized frames from the bbqueue. Optionally tracks liveness and
+/// notifies observers on interface state changes.
+pub struct PacketRxTxWorker<N, Rx, Tx, Q, P>
+where
+    N: NetStackHandle,
+    Rx: PacketReceiver,
+    Tx: PacketSender,
+    Q: BbqHandle,
+    Q::Notifier: AsyncNotifier,
+    P: FrameProcessor<N>,
+{
+    nsh: N,
+    receiver: Rx,
+    sender: Tx,
+    processor: P,
+    ident: <<N as NetStackHandle>::Profile as Profile>::InterfaceIdent,
+    consumer: FramedConsumer<Q>,
+    #[cfg(feature = "embassy-time")]
+    liveness: Option<LivenessConfig>,
+    #[cfg(feature = "embassy-time")]
+    state_notify: Option<&'static WaitQueue>,
+    #[cfg(feature = "embassy-time")]
+    have_received: bool,
+}
+
+impl<N, Rx, Tx, Q, P> PacketRxTxWorker<N, Rx, Tx, Q, P>
+where
+    N: NetStackHandle,
+    Rx: PacketReceiver,
+    Tx: PacketSender,
+    Q: BbqHandle,
+    Q::Notifier: AsyncNotifier,
+    P: FrameProcessor<N>,
+{
+    /// Create a new packet worker.
+    pub fn new(
+        nsh: N,
+        receiver: Rx,
+        sender: Tx,
+        processor: P,
+        ident: <<N as NetStackHandle>::Profile as Profile>::InterfaceIdent,
+        consumer: FramedConsumer<Q>,
+    ) -> Self {
+        Self {
+            nsh,
+            receiver,
+            sender,
+            processor,
+            ident,
+            consumer,
+            #[cfg(feature = "embassy-time")]
+            liveness: None,
+            #[cfg(feature = "embassy-time")]
+            state_notify: None,
+            #[cfg(feature = "embassy-time")]
+            have_received: false,
+        }
+    }
+
+    /// Enable liveness tracking.
+    ///
+    /// When enabled, the worker transitions the interface to
+    /// [`InterfaceState::Inactive`] if no frames are received within
+    /// `config.timeout_ms`. The timer only starts after the first frame.
+    /// Recovery is automatic — when frames resume, the processor
+    /// transitions back to `Active`.
+    #[cfg(feature = "embassy-time")]
+    pub fn with_liveness(mut self, config: LivenessConfig) -> Self {
+        self.liveness = Some(config);
+        self
+    }
+
+    /// Set a [`WaitQueue`] to be notified on interface state transitions.
+    #[cfg(feature = "embassy-time")]
+    pub fn with_state_notify(mut self, notify: &'static WaitQueue) -> Self {
+        self.state_notify = Some(notify);
+        self
+    }
+
+    #[cfg(feature = "embassy-time")]
+    fn notify(&self) {
+        if let Some(notify) = self.state_notify {
+            notify.wake_all();
+        }
+    }
+
+    /// Run the combined RX/TX loop.
+    ///
+    /// Sets `initial_state` on the interface before entering the loop.
+    /// On exit (transport error or drop), the interface transitions to
+    /// [`InterfaceState::Down`].
+    pub async fn run(
+        &mut self,
+        initial_state: InterfaceState,
+        scratch: &mut [u8],
+    ) -> Result<(), PacketWorkerError<Rx::Error, Tx::Error>> {
+        _ = self
+            .nsh
+            .stack()
+            .manage_profile(|im| im.set_interface_state(self.ident.clone(), initial_state))
+            .inspect_err(|e| {
+                error!("Error setting interface state: {:?}", e);
+            });
+        #[cfg(feature = "embassy-time")]
+        self.notify();
+
+        let res = self.run_inner(scratch).await;
+
+        _ = self
+            .nsh
+            .stack()
+            .manage_profile(|im| im.set_interface_state(self.ident.clone(), InterfaceState::Down));
+        #[cfg(feature = "embassy-time")]
+        self.notify();
+
+        res
+    }
+
+    #[cfg(not(feature = "embassy-time"))]
+    async fn run_inner(
+        &mut self,
+        scratch: &mut [u8],
+    ) -> Result<(), PacketWorkerError<Rx::Error, Tx::Error>> {
+        loop {
+            let rx_fut = self.receiver.recv(scratch);
+            let tx_fut = self.consumer.wait_read();
+
+            match select(rx_fut, tx_fut).await {
+                Either::First(recv_result) => {
+                    let used = recv_result.map_err(PacketWorkerError::Rx)?;
+                    trace!("packet rx: {} bytes", used);
+                    let data = &scratch[..used];
+                    self.processor
+                        .process_frame(data, &self.nsh, self.ident.clone());
+                }
+                Either::Second(grant) => {
+                    trace!("packet tx: {} bytes", grant.len());
+                    self.sender
+                        .send(&grant)
+                        .await
+                        .map_err(PacketWorkerError::Tx)?;
+                    grant.release();
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "embassy-time")]
+    async fn run_inner(
+        &mut self,
+        scratch: &mut [u8],
+    ) -> Result<(), PacketWorkerError<Rx::Error, Tx::Error>> {
+        use embassy_futures::select::{Either3, select3};
+
+        loop {
+            let rx_fut = self.receiver.recv(scratch);
+            let tx_fut = self.consumer.wait_read();
+
+            let liveness_active = self.liveness.is_some() && self.have_received;
+
+            if liveness_active {
+                let timeout_ms = self.liveness.as_ref().unwrap().timeout_ms;
+                let timer = embassy_time::Timer::after_millis(timeout_ms);
+
+                match select3(rx_fut, tx_fut, timer).await {
+                    Either3::First(recv_result) => {
+                        let used = recv_result.map_err(PacketWorkerError::Rx)?;
+                        trace!("packet rx: {} bytes", used);
+                        let data = &scratch[..used];
+                        let changed =
+                            self.processor
+                                .process_frame(data, &self.nsh, self.ident.clone());
+                        self.have_received = true;
+                        if changed {
+                            self.notify();
+                        }
+                    }
+                    Either3::Second(grant) => {
+                        trace!("packet tx: {} bytes", grant.len());
+                        self.sender
+                            .send(&grant)
+                            .await
+                            .map_err(PacketWorkerError::Tx)?;
+                        grant.release();
+                    }
+                    Either3::Third(()) => {
+                        warn!("Liveness timeout — interface inactive");
+                        let changed = self.nsh.stack().manage_profile(|im| {
+                            if matches!(
+                                im.interface_state(self.ident.clone()),
+                                Some(InterfaceState::Active { .. })
+                            ) {
+                                _ = im.set_interface_state(
+                                    self.ident.clone(),
+                                    InterfaceState::Inactive,
+                                );
+                                true
+                            } else {
+                                false
+                            }
+                        });
+                        if changed {
+                            self.notify();
+                        }
+                        self.processor.reset();
+                        self.have_received = false;
+                    }
+                }
+            } else {
+                match select(rx_fut, tx_fut).await {
+                    Either::First(recv_result) => {
+                        let used = recv_result.map_err(PacketWorkerError::Rx)?;
+                        trace!("packet rx: {} bytes", used);
+                        let data = &scratch[..used];
+                        let changed =
+                            self.processor
+                                .process_frame(data, &self.nsh, self.ident.clone());
+                        self.have_received = true;
+                        if changed {
+                            self.notify();
+                        }
+                    }
+                    Either::Second(grant) => {
+                        trace!("packet tx: {} bytes", grant.len());
+                        self.sender
+                            .send(&grant)
+                            .await
+                            .map_err(PacketWorkerError::Tx)?;
+                        grant.release();
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<N, Rx, Tx, Q, P> Drop for PacketRxTxWorker<N, Rx, Tx, Q, P>
+where
+    N: NetStackHandle,
+    Rx: PacketReceiver,
+    Tx: PacketSender,
+    Q: BbqHandle,
+    Q::Notifier: AsyncNotifier,
+    P: FrameProcessor<N>,
+{
+    fn drop(&mut self) {
+        self.nsh.stack().manage_profile(|im| {
+            _ = im.set_interface_state(self.ident.clone(), InterfaceState::Down);
+        });
+        #[cfg(feature = "embassy-time")]
+        self.notify();
+    }
+}

--- a/crates/ergot/src/interface_manager/utils/cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/cobs_stream.rs
@@ -46,6 +46,10 @@ impl<Q> InterfaceSink for Sink<Q>
 where
     Q: BbqHandle,
 {
+    fn mtu(&self) -> u16 {
+        self.mtu
+    }
+
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, body: &T) -> Result<(), ()> {
         let is_err = hdr.kind == FrameKind::PROTOCOL_ERROR;
 

--- a/crates/ergot/src/interface_manager/utils/framed_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/framed_stream.rs
@@ -45,6 +45,10 @@ impl<Q> InterfaceSink for Sink<Q>
 where
     Q: BbqHandle,
 {
+    fn mtu(&self) -> u16 {
+        self.mtu
+    }
+
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, body: &T) -> Result<(), ()> {
         let is_err = hdr.kind == FrameKind::PROTOCOL_ERROR;
 

--- a/crates/ergot/src/interface_manager/utils/std.rs
+++ b/crates/ergot/src/interface_manager/utils/std.rs
@@ -23,10 +23,12 @@ pub(crate) mod acc {
 
     pub use cobs_acc::FeedResult;
 
+    #[allow(dead_code)]
     pub struct CobsAccumulator {
         inner: cobs_acc::CobsAccumulator<Box<[u8]>>,
     }
 
+    #[allow(dead_code)]
     impl CobsAccumulator {
         #[inline]
         pub fn new(size: usize) -> Self {

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -137,6 +137,7 @@ impl ProtocolError {
     pub const ISE_ANY_PORT_MISSING_KEY: Self = Self(15);
     pub const ISE_TTL_EXPIRED: Self = Self(16);
     pub const ISE_ROUTING_LOOP: Self = Self(17);
+    pub const ISE_PACKET_TOO_BIG: Self = Self(18);
     // 21..31: NetStackSendError
     pub const NSSE_NO_ROUTE: Self = Self(21);
     pub const NSSE_ANY_PORT_MISSING_KEY: Self = Self(22);
@@ -144,6 +145,15 @@ impl ProtocolError {
     pub const NSSE_ANY_PORT_NOT_UNIQUE: Self = Self(24);
     pub const NSSE_ALL_PORT_MISSING_KEY: Self = Self(25);
     pub const NSSE_WOULD_DEADLOCK: Self = Self(26);
+}
+
+/// Payload for `ISE_PACKET_TOO_BIG` protocol errors.
+///
+/// Contains the MTU of the bottleneck interface so the sender knows the limit.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
+pub struct PacketTooBig {
+    pub mtu: u16,
 }
 
 impl Header {

--- a/crates/ergot/src/lib.rs
+++ b/crates/ergot/src/lib.rs
@@ -38,8 +38,58 @@ pub struct FrameKind(pub u8);
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Key(pub [u8; 8]);
 
+#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub struct ProtocolError(pub u16);
+#[non_exhaustive]
+pub enum ProtocolError {
+    // 0: Reserved
+    Reserved,
+
+    // 1..11: SocketSendError
+    /// Socket has no space for the message
+    SseNoSpace,
+    /// Deserialization failed at the socket
+    SseDeserFailed,
+    /// Type mismatch at the socket
+    SseTypeMismatch,
+    /// Internal socket error
+    SseWhatTheHell,
+
+    // 11..21: InterfaceSendError
+    /// Refusing to send local destination remotely
+    IseDestinationLocal,
+    /// Profile does not know how to route to requested destination
+    IseNoRouteToDest,
+    /// Outgoing interface is full
+    IseInterfaceFull,
+    /// Internal interface manager error
+    IseInternalError,
+    /// Destination was an "any" port but key was missing
+    IseAnyPortMissingKey,
+    /// TTL expired
+    IseTtlExpired,
+    /// Routing loop detected
+    IseRoutingLoop,
+    /// Packet exceeds outgoing interface MTU
+    IsePacketTooBig {
+        /// The MTU of the bottleneck interface
+        mtu: u16,
+    },
+
+    // 21..31: NetStackSendError
+    /// No route to destination
+    NsseNoRoute,
+    /// "Any" port missing key
+    NsseAnyPortMissingKey,
+    /// Wrong port kind
+    NsseWrongPortKind,
+    /// "Any" port not unique
+    NsseAnyPortNotUnique,
+    /// "All" port missing key
+    NsseAllPortMissingKey,
+    /// Would deadlock
+    NsseWouldDeadlock,
+}
 
 #[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
 #[derive(Debug, Clone, PartialEq)]
@@ -120,40 +170,6 @@ impl postcard_schema::Schema for Key {
             name: "Key",
             ty: <[u8; 8]>::SCHEMA.ty,
         };
-}
-
-impl ProtocolError {
-    pub const RESERVED: Self = Self(0);
-    // 1..11: SocketSendError
-    pub const SSE_NO_SPACE: Self = Self(1);
-    pub const SSE_DESER_FAILED: Self = Self(2);
-    pub const SSE_TYPE_MISMATCH: Self = Self(3);
-    pub const SSE_WHAT_THE_HELL: Self = Self(4);
-    // 11..21: InterfaceSendError
-    pub const ISE_DESTINATION_LOCAL: Self = Self(11);
-    pub const ISE_NO_ROUTE_TO_DEST: Self = Self(12);
-    pub const ISE_INTERFACE_FULL: Self = Self(13);
-    pub const ISE_INTERNAL_ERROR: Self = Self(14);
-    pub const ISE_ANY_PORT_MISSING_KEY: Self = Self(15);
-    pub const ISE_TTL_EXPIRED: Self = Self(16);
-    pub const ISE_ROUTING_LOOP: Self = Self(17);
-    pub const ISE_PACKET_TOO_BIG: Self = Self(18);
-    // 21..31: NetStackSendError
-    pub const NSSE_NO_ROUTE: Self = Self(21);
-    pub const NSSE_ANY_PORT_MISSING_KEY: Self = Self(22);
-    pub const NSSE_WRONG_PORT_KIND: Self = Self(23);
-    pub const NSSE_ANY_PORT_NOT_UNIQUE: Self = Self(24);
-    pub const NSSE_ALL_PORT_MISSING_KEY: Self = Self(25);
-    pub const NSSE_WOULD_DEADLOCK: Self = Self(26);
-}
-
-/// Payload for `ISE_PACKET_TOO_BIG` protocol errors.
-///
-/// Contains the MTU of the bottleneck interface so the sender knows the limit.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
-pub struct PacketTooBig {
-    pub mtu: u16,
 }
 
 impl Header {

--- a/crates/ergot/src/net_stack/mod.rs
+++ b/crates/ergot/src/net_stack/mod.rs
@@ -422,12 +422,12 @@ impl NetStackSendError {
             NetStackSendError::InterfaceSend(interface_send_error) => {
                 interface_send_error.to_error()
             }
-            NetStackSendError::NoRoute => ProtocolError::NSSE_NO_ROUTE,
-            NetStackSendError::AnyPortMissingKey => ProtocolError::NSSE_ANY_PORT_MISSING_KEY,
-            NetStackSendError::WrongPortKind { .. } => ProtocolError::NSSE_WRONG_PORT_KIND,
-            NetStackSendError::AnyPortNotUnique => ProtocolError::NSSE_ANY_PORT_NOT_UNIQUE,
-            NetStackSendError::AllPortMissingKey => ProtocolError::NSSE_ALL_PORT_MISSING_KEY,
-            NetStackSendError::WouldDeadlock => ProtocolError::NSSE_WOULD_DEADLOCK,
+            NetStackSendError::NoRoute => ProtocolError::NsseNoRoute,
+            NetStackSendError::AnyPortMissingKey => ProtocolError::NsseAnyPortMissingKey,
+            NetStackSendError::WrongPortKind { .. } => ProtocolError::NsseWrongPortKind,
+            NetStackSendError::AnyPortNotUnique => ProtocolError::NsseAnyPortNotUnique,
+            NetStackSendError::AllPortMissingKey => ProtocolError::NsseAllPortMissingKey,
+            NetStackSendError::WouldDeadlock => ProtocolError::NsseWouldDeadlock,
         }
     }
 }

--- a/crates/ergot/src/socket/borrow.rs
+++ b/crates/ergot/src/socket/borrow.rs
@@ -481,7 +481,7 @@ impl<Q: BbqHandle, T> Drop for ResponseGrant<Q, T> {
     fn drop(&mut self) {
         let old = core::mem::replace(
             &mut self.inner,
-            ResponseGrantInner::Err(ProtocolError(u16::MAX)),
+            ResponseGrantInner::Err(ProtocolError::Reserved),
         );
         match old {
             ResponseGrantInner::Ok { grant, .. } => {

--- a/crates/ergot/src/socket/mod.rs
+++ b/crates/ergot/src/socket/mod.rs
@@ -210,10 +210,10 @@ unsafe impl Linked<Links<SocketHeader>> for SocketHeader {
 impl SocketSendError {
     pub fn to_error(&self) -> ProtocolError {
         match self {
-            SocketSendError::NoSpace => ProtocolError::SSE_NO_SPACE,
-            SocketSendError::DeserFailed => ProtocolError::SSE_DESER_FAILED,
-            SocketSendError::TypeMismatch => ProtocolError::SSE_TYPE_MISMATCH,
-            SocketSendError::WhatTheHell => ProtocolError::SSE_WHAT_THE_HELL,
+            SocketSendError::NoSpace => ProtocolError::SseNoSpace,
+            SocketSendError::DeserFailed => ProtocolError::SseDeserFailed,
+            SocketSendError::TypeMismatch => ProtocolError::SseTypeMismatch,
+            SocketSendError::WhatTheHell => ProtocolError::SseWhatTheHell,
         }
     }
 }

--- a/crates/ergot/src/well_known.rs
+++ b/crates/ergot/src/well_known.rs
@@ -138,3 +138,23 @@ pub struct SeedRouterRefreshRequest {
     pub refresh_net: u16,
     pub refresh_token: [u8; 8],
 }
+
+// Path MTU Discovery
+endpoint!(
+    ErgotPathMtuEndpoint,
+    PathMtuQuery,
+    PathMtuResult,
+    "ergot/.well-known/path-mtu"
+);
+
+#[derive(Debug, Serialize, Deserialize, Schema, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
+pub struct PathMtuQuery {
+    pub path_mtu: u16,
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
+pub struct PathMtuResult {
+    pub path_mtu: u16,
+}

--- a/crates/ergot/tests/bridge_router.rs
+++ b/crates/ergot/tests/bridge_router.rs
@@ -477,7 +477,7 @@ fn bridge_send_err_forwards_upstream() {
     };
 
     router
-        .send_err(&hdr, ProtocolError::NSSE_NO_ROUTE, None)
+        .send_err(&hdr, ProtocolError::NsseNoRoute, None)
         .unwrap();
 
     let entries = log.lock().unwrap();

--- a/crates/ergot/tests/bridge_router.rs
+++ b/crates/ergot/tests/bridge_router.rs
@@ -28,6 +28,9 @@ impl RecordingSink {
 }
 
 impl InterfaceSink for RecordingSink {
+    fn mtu(&self) -> u16 {
+        2048
+    }
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, _body: &T) -> Result<(), ()> {
         self.log
             .lock()

--- a/crates/ergot/tests/direct_router.rs
+++ b/crates/ergot/tests/direct_router.rs
@@ -25,6 +25,9 @@ impl RecordingSink {
 }
 
 impl InterfaceSink for RecordingSink {
+    fn mtu(&self) -> u16 {
+        2048
+    }
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, _body: &T) -> Result<(), ()> {
         self.log
             .lock()

--- a/crates/ergot/tests/mtu_discovery.rs
+++ b/crates/ergot/tests/mtu_discovery.rs
@@ -1,0 +1,278 @@
+//! MTU discovery tests: wire format round-trip and router PacketTooBig e2e.
+
+#![cfg(any(feature = "std", feature = "nostd-seed-router"))]
+
+use ergot::interface_manager::{
+    Interface, InterfaceSendError, InterfaceSink, Profile, profiles::router::Router,
+};
+use ergot::wire_frames::{de_frame, encode_frame_err};
+use ergot::{Address, FrameKind, HeaderSeq, ProtocolError};
+use rand_core::RngCore;
+use serde::Serialize;
+use std::sync::{Arc, Mutex};
+
+// --- Mock RNG ---
+
+struct MockRng(u64);
+
+impl RngCore for MockRng {
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64() as u32
+    }
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(1);
+        self.0
+    }
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        for b in dest.iter_mut() {
+            *b = self.next_u64() as u8;
+        }
+    }
+}
+
+// --- Mock sink with configurable MTU ---
+
+#[derive(Clone)]
+struct MtuSink {
+    mtu: u16,
+    log: Arc<Mutex<Vec<SinkEvent>>>,
+    label: &'static str,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+enum SinkEvent {
+    SendTy {
+        label: &'static str,
+        dst: Address,
+    },
+    SendRaw {
+        label: &'static str,
+        dst: Address,
+    },
+    SendErr {
+        label: &'static str,
+        dst: Address,
+        err: ProtocolError,
+    },
+}
+
+impl MtuSink {
+    fn new(label: &'static str, mtu: u16, log: Arc<Mutex<Vec<SinkEvent>>>) -> Self {
+        Self { mtu, log, label }
+    }
+}
+
+impl InterfaceSink for MtuSink {
+    fn mtu(&self) -> u16 {
+        self.mtu
+    }
+    fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, _body: &T) -> Result<(), ()> {
+        self.log.lock().unwrap().push(SinkEvent::SendTy {
+            label: self.label,
+            dst: hdr.dst,
+        });
+        Ok(())
+    }
+    fn send_raw(&mut self, hdr: &HeaderSeq, _body: &[u8]) -> Result<(), ()> {
+        self.log.lock().unwrap().push(SinkEvent::SendRaw {
+            label: self.label,
+            dst: hdr.dst,
+        });
+        Ok(())
+    }
+    fn send_err(&mut self, hdr: &HeaderSeq, err: ProtocolError) -> Result<(), ()> {
+        self.log.lock().unwrap().push(SinkEvent::SendErr {
+            label: self.label,
+            dst: hdr.dst,
+            err,
+        });
+        Ok(())
+    }
+}
+
+struct MockInterface;
+impl Interface for MockInterface {
+    type Sink = MtuSink;
+}
+
+// --- Wire format round-trip tests ---
+
+#[test]
+fn error_frame_round_trip_simple() {
+    // Encode a simple error (no payload) and decode it
+    let hdr = HeaderSeq {
+        src: Address {
+            network_id: 1,
+            node_id: 1,
+            port_id: 10,
+        },
+        dst: Address {
+            network_id: 2,
+            node_id: 2,
+            port_id: 20,
+        },
+        any_all: None,
+        seq_no: 42,
+        kind: FrameKind::PROTOCOL_ERROR,
+        ttl: 8,
+    };
+
+    let flav = postcard::ser_flavors::StdVec::new();
+    let encoded = encode_frame_err(flav, &hdr, ProtocolError::IseNoRouteToDest).unwrap();
+
+    let frame = de_frame(&encoded).expect("should decode");
+    assert_eq!(frame.hdr.src, hdr.src);
+    assert_eq!(frame.hdr.dst, hdr.dst);
+    assert_eq!(frame.hdr.seq_no, 42);
+    assert_eq!(frame.hdr.kind, FrameKind::PROTOCOL_ERROR);
+    assert_eq!(frame.body, Err(ProtocolError::IseNoRouteToDest));
+}
+
+#[test]
+fn error_frame_round_trip_packet_too_big() {
+    // Encode a PacketTooBig error WITH the MTU payload and decode it
+    let hdr = HeaderSeq {
+        src: Address {
+            network_id: 1,
+            node_id: 1,
+            port_id: 10,
+        },
+        dst: Address {
+            network_id: 2,
+            node_id: 2,
+            port_id: 20,
+        },
+        any_all: None,
+        seq_no: 99,
+        kind: FrameKind::PROTOCOL_ERROR,
+        ttl: 8,
+    };
+
+    let err = ProtocolError::IsePacketTooBig { mtu: 512 };
+    let flav = postcard::ser_flavors::StdVec::new();
+    let encoded = encode_frame_err(flav, &hdr, err).unwrap();
+
+    let frame = de_frame(&encoded).expect("should decode");
+    assert_eq!(frame.hdr.seq_no, 99);
+    assert_eq!(frame.body, Err(ProtocolError::IsePacketTooBig { mtu: 512 }));
+}
+
+#[test]
+fn error_frame_round_trip_max_mtu() {
+    // Ensure maximum u16 MTU value survives the round-trip
+    let hdr = HeaderSeq {
+        src: Address {
+            network_id: 1,
+            node_id: 1,
+            port_id: 10,
+        },
+        dst: Address {
+            network_id: 1,
+            node_id: 2,
+            port_id: 20,
+        },
+        any_all: None,
+        seq_no: 0,
+        kind: FrameKind::PROTOCOL_ERROR,
+        ttl: 1,
+    };
+
+    let err = ProtocolError::IsePacketTooBig { mtu: u16::MAX };
+    let flav = postcard::ser_flavors::StdVec::new();
+    let encoded = encode_frame_err(flav, &hdr, err).unwrap();
+
+    let frame = de_frame(&encoded).expect("should decode");
+    assert_eq!(
+        frame.body,
+        Err(ProtocolError::IsePacketTooBig { mtu: u16::MAX })
+    );
+}
+
+// --- Router PacketTooBig e2e test ---
+
+#[test]
+fn router_send_raw_packet_too_big() {
+    // Set up a router with two interfaces: one with large MTU, one with small MTU.
+    // Send a raw frame from the large-MTU interface destined for the small-MTU one.
+    // The router should return PacketTooBig with the small interface's MTU.
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut router: Router<MockInterface, MockRng, 4, 8> = Router::new(MockRng(0));
+
+    // Interface 0: large MTU (source)
+    let _id_large = router
+        .register_interface(MtuSink::new("large", 2048, log.clone()))
+        .unwrap();
+    // Interface 1: small MTU (destination) — 64 bytes
+    let _id_small = router
+        .register_interface(MtuSink::new("small", 64, log.clone()))
+        .unwrap();
+
+    // Build a raw frame that's larger than the small interface's MTU.
+    // Interface 0 has net_id=1, interface 1 has net_id=2.
+    // Source is on net_id=1, destination is on net_id=2.
+    let hdr = HeaderSeq {
+        src: Address {
+            network_id: 1,
+            node_id: 2,
+            port_id: 10,
+        },
+        dst: Address {
+            network_id: 2,
+            node_id: 2,
+            port_id: 20,
+        },
+        any_all: None,
+        seq_no: 1,
+        kind: FrameKind::ENDPOINT_REQ,
+        ttl: 16,
+    };
+
+    // 100 bytes of payload — well over the 64 byte MTU
+    let big_payload = [0xABu8; 100];
+
+    let result = router.send_raw(&hdr, &big_payload, _id_large);
+    assert_eq!(result, Err(InterfaceSendError::PacketTooBig { mtu: 64 }));
+}
+
+#[test]
+fn router_send_raw_within_mtu_succeeds() {
+    // Verify that sending a frame within MTU works fine
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut router: Router<MockInterface, MockRng, 4, 8> = Router::new(MockRng(0));
+
+    let id0 = router
+        .register_interface(MtuSink::new("src", 2048, log.clone()))
+        .unwrap();
+    let _id1 = router
+        .register_interface(MtuSink::new("dst", 2048, log.clone()))
+        .unwrap();
+
+    let hdr = HeaderSeq {
+        src: Address {
+            network_id: 1,
+            node_id: 2,
+            port_id: 10,
+        },
+        dst: Address {
+            network_id: 2,
+            node_id: 2,
+            port_id: 20,
+        },
+        any_all: None,
+        seq_no: 1,
+        kind: FrameKind::ENDPOINT_REQ,
+        ttl: 16,
+    };
+
+    let small_payload = [0xABu8; 10];
+    let result = router.send_raw(&hdr, &small_payload, id0);
+    assert!(result.is_ok());
+
+    let events = log.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        SinkEvent::SendRaw { label: "dst", .. }
+    ));
+}

--- a/crates/ergot/tests/multi_interface.rs
+++ b/crates/ergot/tests/multi_interface.rs
@@ -13,6 +13,9 @@ static LAST_SINK: AtomicU8 = AtomicU8::new(0);
 struct MockSinkA;
 
 impl InterfaceSink for MockSinkA {
+    fn mtu(&self) -> u16 {
+        2048
+    }
     fn send_ty<T: Serialize>(&mut self, _hdr: &HeaderSeq, _body: &T) -> Result<(), ()> {
         LAST_SINK.store(1, Ordering::SeqCst);
         Ok(())
@@ -30,6 +33,9 @@ impl InterfaceSink for MockSinkA {
 struct MockSinkB;
 
 impl InterfaceSink for MockSinkB {
+    fn mtu(&self) -> u16 {
+        2048
+    }
     fn send_ty<T: Serialize>(&mut self, _hdr: &HeaderSeq, _body: &T) -> Result<(), ()> {
         LAST_SINK.store(2, Ordering::SeqCst);
         Ok(())
@@ -47,6 +53,9 @@ impl InterfaceSink for MockSinkB {
 struct MockSinkC;
 
 impl InterfaceSink for MockSinkC {
+    fn mtu(&self) -> u16 {
+        2048
+    }
     fn send_ty<T: Serialize>(&mut self, _hdr: &HeaderSeq, _body: &T) -> Result<(), ()> {
         LAST_SINK.store(3, Ordering::SeqCst);
         Ok(())

--- a/crates/ergot/tests/multi_interface.rs
+++ b/crates/ergot/tests/multi_interface.rs
@@ -130,7 +130,7 @@ fn multi_interface_dispatches_to_correct_sink() {
 
     let mut sink_c: TestSink = TestSink::C(MockSinkC);
     LAST_SINK.store(0, Ordering::SeqCst);
-    sink_c.send_err(&hdr, ProtocolError::RESERVED).unwrap();
+    sink_c.send_err(&hdr, ProtocolError::Reserved).unwrap();
     assert_eq!(LAST_SINK.load(Ordering::SeqCst), 3);
 }
 

--- a/crates/ergot/tests/no_std_router.rs
+++ b/crates/ergot/tests/no_std_router.rs
@@ -44,6 +44,9 @@ impl RecordingSink {
 }
 
 impl InterfaceSink for RecordingSink {
+    fn mtu(&self) -> u16 {
+        2048
+    }
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, _body: &T) -> Result<(), ()> {
         self.log
             .lock()

--- a/crates/ergot/tests/processor_stale_net_id.rs
+++ b/crates/ergot/tests/processor_stale_net_id.rs
@@ -38,6 +38,9 @@ impl CaptureSink {
 }
 
 impl InterfaceSink for CaptureSink {
+    fn mtu(&self) -> u16 {
+        2048
+    }
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, _body: &T) -> Result<(), ()> {
         self.frames.lock().unwrap().push((hdr.src, hdr.dst));
         Ok(())

--- a/crates/ergot/tests/smoke.rs
+++ b/crates/ergot/tests/smoke.rs
@@ -233,7 +233,7 @@ async fn hello_err() {
                     kind: FrameKind::PROTOCOL_ERROR,
                     ttl: 1,
                 },
-                ProtocolError::NSSE_NO_ROUTE,
+                ProtocolError::NsseNoRoute,
                 None,
             )
             .unwrap();
@@ -256,7 +256,7 @@ async fn hello_err() {
         },
         msg.hdr.dst
     );
-    assert_eq!(ProtocolError::NSSE_NO_ROUTE, msg.t);
+    assert_eq!(ProtocolError::NsseNoRoute, msg.t);
 
     tsk.await.unwrap();
 }


### PR DESCRIPTION
Add MTU discovery so routers can detect and report oversized frames. `InterfaceSink` gains an `mtu()` method, `EdgePort::send_raw` checks frame size before sending, and the router replies with a `PacketTooBig` error carrying the bottleneck MTU value. To make this work cleanly on the wire, `ProtocolError` is changed from a `struct(u16)` newtype to a proper enum — each variant can now carry its own typed payload (e.g. `IsePacketTooBig { mtu: u16 }`), serialized natively by postcard.

- Add `mtu()` to `InterfaceSink` trait; implement in `cobs_stream::Sink`, `framed_stream::Sink`, and `multi_interface!` macro
- Add `InterfaceSendError::PacketTooBig { mtu }` variant with MTU check in `EdgePort::send_raw`
- Router `process_frame` catches `PacketTooBig` and sends error back to source with the MTU value
- Replace `ProtocolError(u16)` + associated constants with `enum ProtocolError` — variants carry typed data
- Remove the separate `PacketTooBig` struct and `encode_frame_err_with_payload` (enum handles this natively)
- Add `ErgotPathMtuEndpoint` well-known endpoint (types only, no server yet)
- Add 5 tests: wire round-trip (simple error, PacketTooBig with MTU, max MTU), router PacketTooBig e2e, send-within-MTU success

Breaking changes:
- `ProtocolError` is now an enum — all code matching on `ProtocolError::SSE_NO_SPACE` etc. must use `ProtocolError::SseNoSpace` style variants
- `InterfaceSink` implementations must add `fn mtu(&self) -> u16`