### PR TITLE
Add link-local addressing (net_id=0) for edge-initiated communication

### DIFF
--- a/crates/ergot/src/interface_manager/edge_port.rs
+++ b/crates/ergot/src/interface_manager/edge_port.rs
@@ -131,10 +131,6 @@ impl<I: Interface> EdgePort<I> {
             _ => return Err(InterfaceSendError::NoRouteToDest),
         };
 
-        if net_id == 0 {
-            return Err(InterfaceSendError::NoRouteToDest);
-        }
-
         // If the packet is destined for us, signal back to the caller
         if hdr.dst.network_id == net_id && hdr.dst.node_id == self.own_node_id {
             return Err(InterfaceSendError::DestinationLocal);

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -827,6 +827,13 @@ pub fn process_frame<N>(
         frame.hdr.src.network_id = net_id;
     }
 
+    // Rewrite zero dst net_id to this interface's net_id (link-local addressing).
+    // An edge that doesn't yet know its net_id sends dst=(0, CENTRAL_NODE_ID, port)
+    // meaning "deliver to my directly connected router".
+    if frame.hdr.dst.network_id == 0 {
+        frame.hdr.dst.network_id = net_id;
+    }
+
     let hdr = frame.hdr.clone();
     let nshdr: Header = hdr.clone().into();
 

--- a/crates/ergot/src/interface_manager/transports/eusb_0_5.rs
+++ b/crates/ergot/src/interface_manager/transports/eusb_0_5.rs
@@ -117,9 +117,16 @@ where
 
             info!("Connection established");
 
-            // Mark the interface as established
+            // Mark the interface as established with link-local addressing
+            // (net_id=0). The real net_id is discovered from the first incoming frame.
             _ = self.nsh.stack().manage_profile(|im| {
-                im.set_interface_state(self.ident.clone(), InterfaceState::Inactive)
+                im.set_interface_state(
+                    self.ident.clone(),
+                    InterfaceState::Active {
+                        net_id: 0,
+                        node_id: crate::interface_manager::edge_port::EDGE_NODE_ID,
+                    },
+                )
             });
             self.notify();
 

--- a/crates/ergot/src/interface_manager/transports/eusb_0_6.rs
+++ b/crates/ergot/src/interface_manager/transports/eusb_0_6.rs
@@ -117,9 +117,16 @@ where
 
             info!("Connection established");
 
-            // Mark the interface as established
+            // Mark the interface as established with link-local addressing
+            // (net_id=0). The real net_id is discovered from the first incoming frame.
             _ = self.nsh.stack().manage_profile(|im| {
-                im.set_interface_state(self.ident.clone(), InterfaceState::Inactive)
+                im.set_interface_state(
+                    self.ident.clone(),
+                    InterfaceState::Active {
+                        net_id: 0,
+                        node_id: crate::interface_manager::edge_port::EDGE_NODE_ID,
+                    },
+                )
             });
             self.notify();
 

--- a/crates/ergot/src/interface_manager/transports/nusb.rs
+++ b/crates/ergot/src/interface_manager/transports/nusb.rs
@@ -231,7 +231,7 @@ pub struct EdgeRegistrationError;
 /// Register a nusb USB bulk transport on a [`DirectEdge`] profile.
 ///
 /// `initial_state` and `processor` control target vs controller mode:
-/// - Target: `InterfaceState::Inactive` with `EdgeFrameProcessor::new()`
+/// - Target: `InterfaceState::Active { net_id: 0, node_id: EDGE_NODE_ID }` with `EdgeFrameProcessor::new()`
 /// - Controller: `InterfaceState::Active { net_id: 1, node_id: 1 }` with
 ///   `EdgeFrameProcessor::new_controller(1)`
 pub async fn register_edge<N, I>(

--- a/crates/ergot/src/interface_manager/transports/tokio_cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/transports/tokio_cobs_stream.rs
@@ -228,7 +228,7 @@ pub struct EdgeRegistrationError;
 /// Register a COBS-framed stream transport on a [`DirectEdge`] profile.
 ///
 /// `initial_state` controls target vs controller mode:
-/// - Target: `InterfaceState::Inactive` with `EdgeFrameProcessor::new()`
+/// - Target: `InterfaceState::Active { net_id: 0, node_id: EDGE_NODE_ID }` with `EdgeFrameProcessor::new()`
 /// - Controller: `InterfaceState::Active { net_id: 1, node_id: 1 }` with
 ///   `EdgeFrameProcessor::new_controller(1)`
 #[allow(clippy::too_many_arguments)]

--- a/crates/ergot/src/interface_manager/transports/tokio_udp.rs
+++ b/crates/ergot/src/interface_manager/transports/tokio_udp.rs
@@ -247,7 +247,7 @@ pub struct EdgeRegistrationError;
 /// Register a UDP transport on a [`DirectEdge`] profile.
 ///
 /// `initial_state` controls target vs controller mode:
-/// - Target: `InterfaceState::Inactive` with `EdgeFrameProcessor::new()`
+/// - Target: `InterfaceState::Active { net_id: 0, node_id: EDGE_NODE_ID }` with `EdgeFrameProcessor::new()`
 ///   — creates a watch channel internally for peer address learning.
 /// - Controller: `InterfaceState::Active { net_id: 1, node_id: 1 }` with
 ///   `EdgeFrameProcessor::new_controller(1)` — uses connected socket (`send()`).
@@ -267,8 +267,9 @@ where
     let arc_socket = Arc::new(socket);
     let closer = Arc::new(WaitQueue::new());
 
-    // Determine if target mode (Inactive) for peer discovery
-    let is_target = matches!(initial_state, InterfaceState::Inactive);
+    // Determine if target mode for peer discovery: target has net_id=0
+    // (link-local) or Inactive, controller has a real net_id > 0.
+    let is_target = !matches!(initial_state, InterfaceState::Active { net_id, .. } if net_id > 0);
 
     stack.stack().manage_profile(|im| {
         match im.interface_state(()) {

--- a/crates/ergot/src/toolkits.rs
+++ b/crates/ergot/src/toolkits.rs
@@ -249,7 +249,10 @@ pub mod tokio_tcp {
             tx,
             queue.clone(),
             EdgeFrameProcessor::new(),
-            InterfaceState::Inactive,
+            InterfaceState::Active {
+                net_id: 0,
+                node_id: crate::interface_manager::edge_port::EDGE_NODE_ID,
+            },
             None,
             None,
         )
@@ -314,7 +317,10 @@ pub mod tokio_udp {
             socket,
             queue.clone(),
             EdgeFrameProcessor::new(),
-            InterfaceState::Inactive,
+            InterfaceState::Active {
+                net_id: 0,
+                node_id: crate::interface_manager::edge_port::EDGE_NODE_ID,
+            },
             liveness,
             state_notify,
         )
@@ -392,7 +398,10 @@ pub mod tokio_stream {
             writer,
             queue,
             EdgeFrameProcessor::new(),
-            InterfaceState::Inactive,
+            InterfaceState::Active {
+                net_id: 0,
+                node_id: crate::interface_manager::edge_port::EDGE_NODE_ID,
+            },
             liveness,
             state_notify,
         )
@@ -546,7 +555,10 @@ pub mod tokio_serial_v5 {
             baud,
             queue.clone(),
             crate::interface_manager::profiles::direct_edge::EdgeFrameProcessor::new(),
-            crate::interface_manager::InterfaceState::Inactive,
+            crate::interface_manager::InterfaceState::Active {
+                net_id: 0,
+                node_id: crate::interface_manager::edge_port::EDGE_NODE_ID,
+            },
             liveness,
             state_notify,
         )

--- a/crates/ergot/tests/common/mod.rs
+++ b/crates/ergot/tests/common/mod.rs
@@ -65,6 +65,7 @@ pub async fn ping_with_retry<N: NetStackHandle + Clone>(stack: &N, addr: Address
     panic!("ping failed after retries");
 }
 
+#[allow(dead_code)]
 pub async fn wait_active(stack: &EdgeStack) {
     for _ in 0..50 {
         let state = stack.manage_profile(|im| im.interface_state(()));

--- a/crates/ergot/tests/e2e_link_local.rs
+++ b/crates/ergot/tests/e2e_link_local.rs
@@ -1,0 +1,351 @@
+//! End-to-end test for link-local addressing.
+//!
+//! Verifies that an edge device can initiate communication with net_id=0
+//! (link-local) before receiving any frame from the router, and that it
+//! correctly discovers its real net_id from the router's response.
+
+#![cfg(feature = "tokio-std")]
+#![cfg(not(miri))]
+
+mod common;
+
+use std::{pin::pin, time::Duration};
+
+use common::make_edge_stack;
+use ergot::{
+    Address,
+    interface_manager::{
+        InterfaceState, Profile,
+        interface_impls::tokio_stream::TokioStreamInterface,
+        profiles::direct_edge::EdgeFrameProcessor,
+        profiles::router::Router,
+        transports::tokio_cobs_stream,
+    },
+    net_stack::ArcNetStack,
+    well_known::ErgotPingEndpoint,
+};
+use mutex::raw_impls::cs::CriticalSectionRawMutex;
+use tokio::time::{sleep, timeout};
+
+type RouterStack =
+    ArcNetStack<CriticalSectionRawMutex, Router<TokioStreamInterface, rand::rngs::StdRng, 64, 64>>;
+
+/// Spawn a ping server on the router stack.
+fn spawn_router_ping_server(stack: &RouterStack) {
+    tokio::spawn({
+        let stack = stack.clone();
+        async move {
+            let server = stack
+                .endpoints()
+                .bounded_server::<ErgotPingEndpoint, 4>(Some("ping"));
+            let server = pin!(server);
+            let mut hdl = server.attach();
+            loop {
+                let _ = hdl
+                    .serve(|val: &u32| {
+                        let v = *val;
+                        async move { v }
+                    })
+                    .await;
+            }
+        }
+    });
+}
+
+/// Edge initiates ping to the router using link-local addressing (net_id=0).
+///
+/// The edge has never received a frame from the router, so it doesn't know
+/// its real net_id. It sends to (0, CENTRAL_NODE_ID, 0) which means
+/// "my directly connected router, find the ping endpoint by key".
+///
+/// The router rewrites dst.network_id=0 to the real net_id, delivers
+/// locally, and responds. The edge discovers its net_id from the response.
+#[tokio::test]
+async fn edge_initiates_link_local_ping() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let router_stack: RouterStack = RouterStack::new();
+    let (edge_stack, edge_queue) = make_edge_stack();
+
+    // Create in-memory duplex pipes
+    let (e_read, r_write) = tokio::io::duplex(8192);
+    let (r_read, e_write) = tokio::io::duplex(8192);
+
+    // Register router side
+    tokio_cobs_stream::register_router(
+        router_stack.clone(),
+        r_read,
+        r_write,
+        512,
+        4096,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Register edge side — starts as Active { net_id: 0 }
+    tokio_cobs_stream::register_edge::<_, TokioStreamInterface, _, _>(
+        edge_stack.clone(),
+        e_read,
+        e_write,
+        edge_queue,
+        EdgeFrameProcessor::new(),
+        InterfaceState::Active {
+            net_id: 0,
+            node_id: 2, // EDGE_NODE_ID
+        },
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Start ping server on the ROUTER (not the edge)
+    spawn_router_ping_server(&router_stack);
+
+    // Edge pings router at link-local address: net_id=0, node_id=1 (CENTRAL_NODE_ID)
+    let router_link_local = Address {
+        network_id: 0,
+        node_id: 1,
+        port_id: 0, // wildcard — find ping endpoint by key
+    };
+
+    // Edge initiates first! No router-to-edge ping happened before this.
+    let response = timeout(
+        Duration::from_secs(5),
+        edge_stack
+            .endpoints()
+            .request::<ErgotPingEndpoint>(router_link_local, &42, Some("ping")),
+    )
+    .await
+    .expect("ping timed out")
+    .expect("ping request failed");
+
+    assert_eq!(response, 42);
+
+    // Verify edge discovered its real net_id (should be 1, first allocated)
+    let state = edge_stack.manage_profile(|im| im.interface_state(()));
+    match state {
+        Some(InterfaceState::Active { net_id, node_id }) => {
+            assert_eq!(net_id, 1, "edge should have discovered net_id=1");
+            assert_eq!(node_id, 2, "edge node_id should be EDGE_NODE_ID");
+        }
+        other => panic!("expected Active state, got {:?}", other),
+    }
+}
+
+/// After link-local discovery, the edge can communicate normally using
+/// its real net_id — including pinging the router at the discovered address.
+#[tokio::test]
+async fn edge_link_local_then_normal_ping() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let router_stack: RouterStack = RouterStack::new();
+    let (edge_stack, edge_queue) = make_edge_stack();
+
+    let (e_read, r_write) = tokio::io::duplex(8192);
+    let (r_read, e_write) = tokio::io::duplex(8192);
+
+    tokio_cobs_stream::register_router(
+        router_stack.clone(),
+        r_read,
+        r_write,
+        512,
+        4096,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    tokio_cobs_stream::register_edge::<_, TokioStreamInterface, _, _>(
+        edge_stack.clone(),
+        e_read,
+        e_write,
+        edge_queue,
+        EdgeFrameProcessor::new(),
+        InterfaceState::Active {
+            net_id: 0,
+            node_id: 2,
+        },
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    spawn_router_ping_server(&router_stack);
+
+    // Step 1: link-local ping to discover net_id
+    let router_link_local = Address {
+        network_id: 0,
+        node_id: 1,
+        port_id: 0,
+    };
+
+    let response = timeout(
+        Duration::from_secs(5),
+        edge_stack
+            .endpoints()
+            .request::<ErgotPingEndpoint>(router_link_local, &1, Some("ping")),
+    )
+    .await
+    .expect("link-local ping timed out")
+    .expect("link-local ping failed");
+    assert_eq!(response, 1);
+
+    // Step 2: now ping the router using the real address
+    let router_real_addr = Address {
+        network_id: 1,
+        node_id: 1,
+        port_id: 0,
+    };
+
+    let response = timeout(
+        Duration::from_secs(5),
+        edge_stack
+            .endpoints()
+            .request::<ErgotPingEndpoint>(router_real_addr, &99, Some("ping")),
+    )
+    .await
+    .expect("real-address ping timed out")
+    .expect("real-address ping failed");
+    assert_eq!(response, 99);
+}
+
+/// Two edges connected to the same router: one initiates via link-local,
+/// the other is bootstrapped normally. They can then ping each other.
+#[tokio::test]
+async fn link_local_edge_pings_normal_edge() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let router_stack: RouterStack = RouterStack::new();
+    let (edge1_stack, edge1_queue) = make_edge_stack();
+    let (edge2_stack, edge2_queue) = make_edge_stack();
+
+    // Edge1 <-> Router
+    let (e1_read, r1_write) = tokio::io::duplex(8192);
+    let (r1_read, e1_write) = tokio::io::duplex(8192);
+    // Edge2 <-> Router
+    let (e2_read, r2_write) = tokio::io::duplex(8192);
+    let (r2_read, e2_write) = tokio::io::duplex(8192);
+
+    tokio_cobs_stream::register_router(
+        router_stack.clone(),
+        r1_read,
+        r1_write,
+        512,
+        4096,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    tokio_cobs_stream::register_router(
+        router_stack.clone(),
+        r2_read,
+        r2_write,
+        512,
+        4096,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Edge1: link-local (Active with net_id=0)
+    tokio_cobs_stream::register_edge::<_, TokioStreamInterface, _, _>(
+        edge1_stack.clone(),
+        e1_read,
+        e1_write,
+        edge1_queue,
+        EdgeFrameProcessor::new(),
+        InterfaceState::Active {
+            net_id: 0,
+            node_id: 2,
+        },
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Edge2: also link-local
+    tokio_cobs_stream::register_edge::<_, TokioStreamInterface, _, _>(
+        edge2_stack.clone(),
+        e2_read,
+        e2_write,
+        edge2_queue,
+        EdgeFrameProcessor::new(),
+        InterfaceState::Active {
+            net_id: 0,
+            node_id: 2,
+        },
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    spawn_router_ping_server(&router_stack);
+    common::spawn_ping_server(&edge1_stack);
+    common::spawn_ping_server(&edge2_stack);
+
+    // Edge1 discovers its net_id via link-local ping to router
+    let router_link_local = Address {
+        network_id: 0,
+        node_id: 1,
+        port_id: 0,
+    };
+
+    let r = timeout(
+        Duration::from_secs(5),
+        edge1_stack
+            .endpoints()
+            .request::<ErgotPingEndpoint>(router_link_local, &10, Some("ping")),
+    )
+    .await
+    .expect("edge1 link-local ping timed out")
+    .expect("edge1 link-local ping failed");
+    assert_eq!(r, 10);
+
+    // Edge2 discovers its net_id via link-local ping to router
+    let r = timeout(
+        Duration::from_secs(5),
+        edge2_stack
+            .endpoints()
+            .request::<ErgotPingEndpoint>(router_link_local, &20, Some("ping")),
+    )
+    .await
+    .expect("edge2 link-local ping timed out")
+    .expect("edge2 link-local ping failed");
+    assert_eq!(r, 20);
+
+    // Both edges should now have real net_ids
+    let edge1_net = match edge1_stack.manage_profile(|im| im.interface_state(())) {
+        Some(InterfaceState::Active { net_id, .. }) => net_id,
+        other => panic!("edge1 expected Active, got {:?}", other),
+    };
+    let edge2_net = match edge2_stack.manage_profile(|im| im.interface_state(())) {
+        Some(InterfaceState::Active { net_id, .. }) => net_id,
+        other => panic!("edge2 expected Active, got {:?}", other),
+    };
+    assert_ne!(edge1_net, edge2_net, "edges should have different net_ids");
+    assert_ne!(edge1_net, 0);
+    assert_ne!(edge2_net, 0);
+
+    // Edge1 pings Edge2 through the router
+    let edge2_addr = Address {
+        network_id: edge2_net,
+        node_id: 2,
+        port_id: 0,
+    };
+
+    // Give a moment for routing to stabilize
+    sleep(Duration::from_millis(50)).await;
+
+    let r = common::ping_with_retry(&edge1_stack, edge2_addr, 77).await;
+    assert_eq!(r, 77);
+}


### PR DESCRIPTION
Previously, an edge device could not send any frames until the router pinged it first — the edge started as `Inactive` and had no net_id to put in outgoing headers. This forced a router-initiates-first bootstrap flow, which is awkward when the edge wants to request something from the router immediately on connection (e.g. configuration, seed assignment).

This PR allows edges to send frames with `net_id=0` as "link-local" addressing. The edge starts as `Active { net_id: 0 }` and can immediately send to `(0, CENTRAL_NODE_ID, port)` meaning "my directly connected router". The router rewrites `dst.network_id=0` to the real net_id of that interface and delivers locally. The response carries the real net_id back, and the edge discovers its address from that first response — no protocol change needed.

- Remove `net_id == 0` send guard in `EdgePort::common_send`
- Add `dst.network_id == 0` rewriting in router's `process_frame` (mirrors existing src rewriting)
- Target edges now initialize as `Active { net_id: 0, node_id: EDGE_NODE_ID }` instead of `Inactive` across all transports (TCP, UDP, USB, serial, embassy-usb)
- Update UDP transport `is_target` check to handle new initial state

Testing: 3 new e2e tests — edge-initiated link-local ping, link-local then real-address ping, two link-local edges pinging each other through a router. All existing e2e tests pass unchanged.