### PR TITLE
fix router's gc function

### DIFF
--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -308,10 +308,18 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize> Router<I, R, N, S
     }
 
     /// Garbage-collect expired tombstones from the seed route table.
+    /// Also check if active routes expired to then make them tombstones.
     fn gc_seed_routes(&mut self) {
         let now = Instant::now();
-        self.seed_routes.retain(|sr| match sr.kind {
-            SeedRouteKind::Active { .. } => true,
+        self.seed_routes.retain_mut(|sr| match sr.kind {
+            SeedRouteKind::Active { expiration, .. } => {
+                if now >= expiration {
+                    sr.kind = SeedRouteKind::Tombstone {
+                        clear_time: now + Duration::from_secs(TOMBSTONE_DURATION_SECS),
+                    }
+                }
+                true
+            }
             SeedRouteKind::Tombstone { clear_time } => clear_time > now,
         });
     }

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -314,11 +314,16 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize> Router<I, R, N, S
         self.seed_routes.retain_mut(|sr| match sr.kind {
             SeedRouteKind::Active { expiration, .. } => {
                 if now >= expiration {
-                    sr.kind = SeedRouteKind::Tombstone {
-                        clear_time: now + Duration::from_secs(TOMBSTONE_DURATION_SECS),
+                    let clear_time = expiration + Duration::from_secs(TOMBSTONE_DURATION_SECS);
+                    if now >= clear_time {
+                        false
+                    } else {
+                        sr.kind = SeedRouteKind::Tombstone { clear_time };
+                        true
                     }
+                } else {
+                    true
                 }
-                true
             }
             SeedRouteKind::Tombstone { clear_time } => clear_time > now,
         });


### PR DESCRIPTION
before this, any new device that wanted to connect after net ids were exhausted couldn't. now the gc_seed_routes function checks if an active route expires and if so turns it into a tombstone