### PR TITLE
Fix remote_log handler printing network_id twice instead of node_id

### DIFF
--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -223,7 +223,7 @@ fn log_fmtlog(msg: HeaderMessage<ErgotFmtRxOwned>) {
             target: "remote_log",
             "({}.{}:{}): {}",
             msg.hdr.src.network_id,
-            msg.hdr.src.network_id,
+            msg.hdr.src.node_id,
             msg.hdr.src.port_id,
             msg.t.inner
         ),
@@ -231,7 +231,7 @@ fn log_fmtlog(msg: HeaderMessage<ErgotFmtRxOwned>) {
             target: "remote_log",
             "({}.{}:{}): {}",
             msg.hdr.src.network_id,
-            msg.hdr.src.network_id,
+            msg.hdr.src.node_id,
             msg.hdr.src.port_id,
             msg.t.inner
         ),
@@ -239,7 +239,7 @@ fn log_fmtlog(msg: HeaderMessage<ErgotFmtRxOwned>) {
             target: "remote_log",
             "({}.{}:{}): {}",
             msg.hdr.src.network_id,
-            msg.hdr.src.network_id,
+            msg.hdr.src.node_id,
             msg.hdr.src.port_id,
             msg.t.inner
         ),
@@ -247,7 +247,7 @@ fn log_fmtlog(msg: HeaderMessage<ErgotFmtRxOwned>) {
             target: "remote_log",
             "({}.{}:{}): {}",
             msg.hdr.src.network_id,
-            msg.hdr.src.network_id,
+            msg.hdr.src.node_id,
             msg.hdr.src.port_id,
             msg.t.inner
         ),
@@ -255,7 +255,7 @@ fn log_fmtlog(msg: HeaderMessage<ErgotFmtRxOwned>) {
             target: "remote_log",
             "({}.{}:{}): {}",
             msg.hdr.src.network_id,
-            msg.hdr.src.network_id,
+            msg.hdr.src.node_id,
             msg.hdr.src.port_id,
             msg.t.inner
         ),


### PR DESCRIPTION
log_fmtlog formatted the source address as ({network_id}.{network_id}:{port_id}), duplicating network_id in the node slot. Print node_id instead, matching the canonical Address Display and the stdout log handler.