### PR TITLE
Make the COBS stream transport runtime-agnostic; Router profile on wasm

### DIFF
--- a/crates/ergot/Cargo.lock
+++ b/crates/ergot/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "embedded-io-async 0.6.1",
  "embedded-io-async 0.7.0",
  "env_logger",
+ "futures-io",
  "heapless 0.9.2",
  "log",
  "maitake-sync",
@@ -611,6 +612,7 @@ dependencies = [
  "static_cell",
  "tokio",
  "tokio-serial",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1537,6 +1539,20 @@ dependencies = [
  "log",
  "mio-serial",
  "serialport",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/crates/ergot/Cargo.lock
+++ b/crates/ergot/Cargo.lock
@@ -117,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +619,7 @@ dependencies = [
  "tokio",
  "tokio-serial",
  "tokio-util",
+ "web-time",
 ]
 
 [[package]]
@@ -848,6 +855,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1757,6 +1775,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/ergot/Cargo.toml
+++ b/crates/ergot/Cargo.toml
@@ -28,6 +28,7 @@ disable-cache-padding = [
 ]
 std = [
     "bbqueue/std",
+    "dep:web-time",
     "cobs-acc/std",
     "cobs/std",
     "critical-section/std",
@@ -125,6 +126,7 @@ nostd-seed-router = [
     "dep:rand_core",
 ]
 futures-io = ["dep:futures-io", "std"]
+web-time = ["dep:web-time"]
 [dependencies]
 const-fnv1a-hash    = "1.1.0"
 critical-section    = "1.2.0"
@@ -181,6 +183,7 @@ embassy-sync = { version = "0.8", default-features = false, optional = true }
 rand_core = { version = "0.9", optional = true, default-features = false }
 futures-io = { version = "0.3.32", optional = true }
 tokio-util = { version = "0.7.18", features = ["compat"], optional = true }
+web-time = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 tokio   = { version = "1.45.1", features = ["macros", "rt-multi-thread", "time", "io-util", "net", "sync"] }

--- a/crates/ergot/Cargo.toml
+++ b/crates/ergot/Cargo.toml
@@ -42,6 +42,8 @@ std = [
 tokio-std = [
     "tokio",
     "std",
+    "futures-io",
+    "dep:tokio-util",
 ]
 embassy-usb-v0_5 = [
     "dep:embassy-usb-0_5",
@@ -178,6 +180,7 @@ portable-atomic = "1.11.1"
 embassy-sync = { version = "0.8", default-features = false, optional = true }
 rand_core = { version = "0.9", optional = true, default-features = false }
 futures-io = { version = "0.3.32", optional = true }
+tokio-util = { version = "0.7.18", features = ["compat"], optional = true }
 
 [dev-dependencies]
 tokio   = { version = "1.45.1", features = ["macros", "rt-multi-thread", "time", "io-util", "net", "sync"] }

--- a/crates/ergot/Cargo.toml
+++ b/crates/ergot/Cargo.toml
@@ -122,6 +122,7 @@ nostd-seed-router = [
     "dep:embassy-time",
     "dep:rand_core",
 ]
+futures-io = ["dep:futures-io", "std"]
 [dependencies]
 const-fnv1a-hash    = "1.1.0"
 critical-section    = "1.2.0"
@@ -176,6 +177,7 @@ ssmarshal = { version = "1.0", optional = true }
 portable-atomic = "1.11.1"
 embassy-sync = { version = "0.8", default-features = false, optional = true }
 rand_core = { version = "0.9", optional = true, default-features = false }
+futures-io = { version = "0.3.32", optional = true }
 
 [dev-dependencies]
 tokio   = { version = "1.45.1", features = ["macros", "rt-multi-thread", "time", "io-util", "net", "sync"] }

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -9,8 +9,11 @@
 //!
 //! Requires either `std` or `nostd-seed-router` feature (for time and RNG).
 
+// `web-time` re-exports `std::time` on native targets, and provides a
+// `performance.now()`-based `Instant` on wasm32-unknown-unknown, where
+// `std::time::Instant::now()` panics.
 #[cfg(feature = "std")]
-use std::time::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 #[cfg(all(not(feature = "std"), feature = "nostd-seed-router"))]
 use embassy_time::{Duration, Instant};

--- a/crates/ergot/src/interface_manager/transports/futures_io.rs
+++ b/crates/ergot/src/interface_manager/transports/futures_io.rs
@@ -1,21 +1,39 @@
-//! Futures-IO COBS stream RxWorker.
+//! Futures-IO COBS stream transport.
 //!
-//! Runtime-agnostic transport using `futures_io::AsyncRead`. Works with any
-//! async executor (tokio, wasm, embassy via adapters, etc.).
+//! Runtime-agnostic transport using `futures_io::AsyncRead`/`AsyncWrite`.
+//! Works with any async executor (tokio via compat, wasm-bindgen-futures,
+//! smol, etc.).
 //!
 //! Generic over any [`FrameProcessor`], so it works with [`DirectEdge`],
 //! [`Router`], or any future profile.
+//!
+//! Optional features are injected rather than tied to a runtime:
+//! - **Graceful shutdown**: [`RxWorker::with_closer`] — a
+//!   [`maitake_sync::WaitQueue`] that ends the loop when woken or closed.
+//! - **State change notifications**: [`RxWorker::with_state_notify`] — woken
+//!   whenever the interface state changes (frame processing or liveness).
+//! - **Liveness timeout**: [`RxWorker::run_with_liveness`] — takes a
+//!   `sleeper` closure so any runtime's timer can drive it (e.g.
+//!   `tokio::time::sleep`, `gloo_timers::future::sleep`).
+//!
+//! The caller is responsible for setting the initial interface state before
+//! running the worker. On exit (or drop), the interface is set to
+//! [`InterfaceState::Down`].
 //!
 //! [`FrameProcessor`]: crate::interface_manager::FrameProcessor
 //! [`DirectEdge`]: crate::interface_manager::profiles::direct_edge::DirectEdge
 //! [`Router`]: crate::interface_manager::profiles::router::Router
 
+use core::future::Future;
 use core::pin::Pin;
+use std::sync::Arc;
 
 use cobs_acc::{CobsAccumulator, FeedResult};
+use embassy_futures::select::{Either3, select3};
+use maitake_sync::WaitQueue;
 
 use crate::{
-    interface_manager::{FrameProcessor, InterfaceState, Profile},
+    interface_manager::{FrameProcessor, InterfaceState, LivenessConfig, Profile},
     net_stack::NetStackHandle,
 };
 
@@ -25,6 +43,15 @@ async fn async_read<R: futures_io::AsyncRead + Unpin>(
     buf: &mut [u8],
 ) -> Result<usize, std::io::Error> {
     core::future::poll_fn(|cx| Pin::new(&mut *reader).poll_read(cx, buf)).await
+}
+
+/// Why an [`RxWorker`] run loop ended (without a transport error).
+#[derive(Debug, PartialEq)]
+pub enum RxEnd {
+    /// The peer closed the connection (read returned 0 bytes).
+    Eof,
+    /// The closer was woken or closed.
+    Closed,
 }
 
 /// A generic futures-io COBS stream RxWorker.
@@ -41,6 +68,8 @@ where
     rx: R,
     processor: P,
     ident: <<N as NetStackHandle>::Profile as Profile>::InterfaceIdent,
+    closer: Option<Arc<WaitQueue>>,
+    state_notify: Option<Arc<WaitQueue>>,
 }
 
 impl<N, R, P> RxWorker<N, R, P>
@@ -64,68 +93,179 @@ where
             rx,
             processor,
             ident,
+            closer: None,
+            state_notify: None,
         }
     }
 
-    /// Run the receive loop with an initial state.
+    /// End the run loop when `closer` is woken or closed.
     ///
-    /// Sets `initial_state` on the interface before entering the frame
-    /// loop. On exit (transport error or drop), the interface is set to
+    /// Allows graceful shutdown coordinated with a TX worker sharing
+    /// the same closer.
+    pub fn with_closer(mut self, closer: Arc<WaitQueue>) -> Self {
+        self.closer = Some(closer);
+        self
+    }
+
+    /// Wake `notify` whenever the interface state changes (e.g. a frame
+    /// activates the interface, or a liveness timeout deactivates it).
+    pub fn with_state_notify(mut self, notify: Arc<WaitQueue>) -> Self {
+        self.state_notify = Some(notify);
+        self
+    }
+
+    fn notify(&self) {
+        if let Some(notify) = &self.state_notify {
+            notify.wake_all();
+        }
+    }
+
+    /// Run the receive loop.
+    ///
+    /// The caller must set the interface state before calling. On exit
+    /// (transport error, EOF, closer, or drop), the interface is set to
     /// [`InterfaceState::Down`].
     pub async fn run(
         &mut self,
-        initial_state: InterfaceState,
         frame: &mut [u8],
         scratch: &mut [u8],
-    ) -> Result<(), std::io::Error> {
-        _ = self
-            .nsh
-            .stack()
-            .manage_profile(|im| im.set_interface_state(self.ident.clone(), initial_state));
-
-        let res = self.run_inner(frame, scratch).await;
-
-        _ = self
-            .nsh
-            .stack()
-            .manage_profile(|im| im.set_interface_state(self.ident.clone(), InterfaceState::Down));
-
+    ) -> Result<RxEnd, std::io::Error> {
+        let res = self
+            .run_inner(frame, scratch, None::<(_, fn(u64) -> core::future::Pending<()>)>)
+            .await;
+        self.set_down();
         res
     }
 
-    async fn run_inner(
+    /// Run the receive loop with a liveness timeout.
+    ///
+    /// Once at least one frame has been received, going `liveness.timeout_ms`
+    /// milliseconds without a frame transitions the interface to
+    /// [`InterfaceState::Inactive`] and resets the processor; the loop keeps
+    /// running and recovers when frames resume.
+    ///
+    /// `sleeper` provides the timer: a closure from milliseconds to a future
+    /// that resolves after that long (e.g.
+    /// `|ms| tokio::time::sleep(Duration::from_millis(ms))`).
+    pub async fn run_with_liveness<S, F>(
         &mut self,
         frame: &mut [u8],
         scratch: &mut [u8],
-    ) -> Result<(), std::io::Error> {
-        let mut acc = CobsAccumulator::new(frame);
+        liveness: LivenessConfig,
+        sleeper: S,
+    ) -> Result<RxEnd, std::io::Error>
+    where
+        S: Fn(u64) -> F,
+        F: Future<Output = ()>,
+    {
+        let res = self
+            .run_inner(frame, scratch, Some((liveness, sleeper)))
+            .await;
+        self.set_down();
+        res
+    }
 
-        'outer: loop {
-            let used = async_read(&mut self.rx, scratch).await?;
+    async fn run_inner<S, F>(
+        &mut self,
+        frame: &mut [u8],
+        scratch: &mut [u8],
+        liveness: Option<(LivenessConfig, S)>,
+    ) -> Result<RxEnd, std::io::Error>
+    where
+        S: Fn(u64) -> F,
+        F: Future<Output = ()>,
+    {
+        let mut acc = CobsAccumulator::new(frame);
+        let closer = self.closer.clone();
+        let mut have_received = false;
+
+        loop {
+            let close_fut = async {
+                match &closer {
+                    Some(c) => {
+                        // Both a wake and a close mean "shut down".
+                        let _ = c.wait().await;
+                    }
+                    None => core::future::pending().await,
+                }
+            };
+            let timeout_fut = async {
+                match &liveness {
+                    Some((cfg, sleeper)) if have_received => sleeper(cfg.timeout_ms).await,
+                    _ => core::future::pending().await,
+                }
+            };
+
+            let used =
+                match select3(async_read(&mut self.rx, scratch), close_fut, timeout_fut).await {
+                    Either3::First(res) => res?,
+                    Either3::Second(()) => return Ok(RxEnd::Closed),
+                    Either3::Third(()) => {
+                        self.liveness_timeout();
+                        have_received = false;
+                        acc.reset();
+                        continue;
+                    }
+                };
             if used == 0 {
                 // EOF — peer closed the connection
-                return Ok(());
+                return Ok(RxEnd::Eof);
             }
 
             let mut remain = &mut scratch[..used];
 
-            loop {
-                match acc.feed_raw(remain) {
-                    FeedResult::Consumed => continue 'outer,
-                    FeedResult::OverFull(items) => {
-                        remain = items;
-                    }
-                    FeedResult::DecodeError(items) => {
-                        remain = items;
-                    }
+            while !remain.is_empty() {
+                remain = match acc.feed_raw(remain) {
+                    FeedResult::Consumed => break,
+                    FeedResult::OverFull(items) => items,
+                    FeedResult::DecodeError(items) => items,
                     FeedResult::Success { data, remaining }
                     | FeedResult::SuccessInput { data, remaining } => {
-                        self.processor
-                            .process_frame(data, &self.nsh, self.ident.clone());
-                        remain = remaining;
+                        let changed =
+                            self.processor
+                                .process_frame(data, &self.nsh, self.ident.clone());
+                        have_received = true;
+                        if changed {
+                            self.notify();
+                        }
+                        remaining
                     }
-                }
+                };
             }
+        }
+    }
+
+    /// Handle a liveness timeout: deactivate the interface (if active)
+    /// and reset the processor so the next frame triggers re-discovery.
+    fn liveness_timeout(&mut self) {
+        let changed = self.nsh.stack().manage_profile(|im| {
+            if matches!(
+                im.interface_state(self.ident.clone()),
+                Some(InterfaceState::Active { .. })
+            ) {
+                _ = im.set_interface_state(self.ident.clone(), InterfaceState::Inactive);
+                true
+            } else {
+                false
+            }
+        });
+        if changed {
+            self.notify();
+        }
+        self.processor.reset();
+    }
+
+    fn set_down(&self) {
+        let changed = self.nsh.stack().manage_profile(|im| {
+            let was_down = matches!(
+                im.interface_state(self.ident.clone()),
+                Some(InterfaceState::Down) | None
+            );
+            _ = im.set_interface_state(self.ident.clone(), InterfaceState::Down);
+            !was_down
+        });
+        if changed {
+            self.notify();
         }
     }
 }
@@ -137,9 +277,7 @@ where
     P: FrameProcessor<N>,
 {
     fn drop(&mut self) {
-        self.nsh.stack().manage_profile(|im| {
-            _ = im.set_interface_state(self.ident.clone(), InterfaceState::Down);
-        });
+        self.set_down();
     }
 }
 

--- a/crates/ergot/src/interface_manager/transports/futures_io.rs
+++ b/crates/ergot/src/interface_manager/transports/futures_io.rs
@@ -1,0 +1,188 @@
+//! Futures-IO COBS stream RxWorker.
+//!
+//! Runtime-agnostic transport using `futures_io::AsyncRead`. Works with any
+//! async executor (tokio, wasm, embassy via adapters, etc.).
+//!
+//! Generic over any [`FrameProcessor`], so it works with [`DirectEdge`],
+//! [`Router`], or any future profile.
+//!
+//! [`FrameProcessor`]: crate::interface_manager::FrameProcessor
+//! [`DirectEdge`]: crate::interface_manager::profiles::direct_edge::DirectEdge
+//! [`Router`]: crate::interface_manager::profiles::router::Router
+
+use core::pin::Pin;
+
+use cobs_acc::{CobsAccumulator, FeedResult};
+
+use crate::{
+    interface_manager::{FrameProcessor, InterfaceState, Profile},
+    net_stack::NetStackHandle,
+};
+
+/// Async read helper: wraps `futures_io::AsyncRead::poll_read` into a future.
+async fn async_read<R: futures_io::AsyncRead + Unpin>(
+    reader: &mut R,
+    buf: &mut [u8],
+) -> Result<usize, std::io::Error> {
+    core::future::poll_fn(|cx| Pin::new(&mut *reader).poll_read(cx, buf)).await
+}
+
+/// A generic futures-io COBS stream RxWorker.
+///
+/// Reads bytes from a `futures_io::AsyncRead` source, decodes COBS
+/// frames, and feeds them to a [`FrameProcessor`].
+pub struct RxWorker<N, R, P>
+where
+    N: NetStackHandle,
+    R: futures_io::AsyncRead + Unpin,
+    P: FrameProcessor<N>,
+{
+    nsh: N,
+    rx: R,
+    processor: P,
+    ident: <<N as NetStackHandle>::Profile as Profile>::InterfaceIdent,
+}
+
+impl<N, R, P> RxWorker<N, R, P>
+where
+    N: NetStackHandle,
+    R: futures_io::AsyncRead + Unpin,
+    P: FrameProcessor<N>,
+{
+    /// Create a new RX worker.
+    ///
+    /// `processor` handles decoded frames (profile-specific logic).
+    /// `ident` is the interface identifier used for state management.
+    pub fn new(
+        nsh: N,
+        rx: R,
+        processor: P,
+        ident: <<N as NetStackHandle>::Profile as Profile>::InterfaceIdent,
+    ) -> Self {
+        Self {
+            nsh,
+            rx,
+            processor,
+            ident,
+        }
+    }
+
+    /// Run the receive loop with an initial state.
+    ///
+    /// Sets `initial_state` on the interface before entering the frame
+    /// loop. On exit (transport error or drop), the interface is set to
+    /// [`InterfaceState::Down`].
+    pub async fn run(
+        &mut self,
+        initial_state: InterfaceState,
+        frame: &mut [u8],
+        scratch: &mut [u8],
+    ) -> Result<(), std::io::Error> {
+        _ = self
+            .nsh
+            .stack()
+            .manage_profile(|im| im.set_interface_state(self.ident.clone(), initial_state));
+
+        let res = self.run_inner(frame, scratch).await;
+
+        _ = self
+            .nsh
+            .stack()
+            .manage_profile(|im| im.set_interface_state(self.ident.clone(), InterfaceState::Down));
+
+        res
+    }
+
+    async fn run_inner(
+        &mut self,
+        frame: &mut [u8],
+        scratch: &mut [u8],
+    ) -> Result<(), std::io::Error> {
+        let mut acc = CobsAccumulator::new(frame);
+
+        'outer: loop {
+            let used = async_read(&mut self.rx, scratch).await?;
+            if used == 0 {
+                // EOF — peer closed the connection
+                return Ok(());
+            }
+
+            let mut remain = &mut scratch[..used];
+
+            loop {
+                match acc.feed_raw(remain) {
+                    FeedResult::Consumed => continue 'outer,
+                    FeedResult::OverFull(items) => {
+                        remain = items;
+                    }
+                    FeedResult::DecodeError(items) => {
+                        remain = items;
+                    }
+                    FeedResult::Success { data, remaining }
+                    | FeedResult::SuccessInput { data, remaining } => {
+                        self.processor
+                            .process_frame(data, &self.nsh, self.ident.clone());
+                        remain = remaining;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<N, R, P> Drop for RxWorker<N, R, P>
+where
+    N: NetStackHandle,
+    R: futures_io::AsyncRead + Unpin,
+    P: FrameProcessor<N>,
+{
+    fn drop(&mut self) {
+        self.nsh.stack().manage_profile(|im| {
+            _ = im.set_interface_state(self.ident.clone(), InterfaceState::Down);
+        });
+    }
+}
+
+/// Transmitter worker task.
+///
+/// Reads COBS-encoded frames from a bbqueue consumer and writes them
+/// to a `futures_io::AsyncWrite` sink.
+pub async fn tx_worker<W, Q>(
+    tx: &mut W,
+    rx: bbqueue::prod_cons::stream::StreamConsumer<Q>,
+) -> Result<(), std::io::Error>
+where
+    W: futures_io::AsyncWrite + Unpin,
+    Q: bbqueue::traits::bbqhdl::BbqHandle,
+    Q::Notifier: bbqueue::traits::notifier::AsyncNotifier,
+{
+    loop {
+        let data = rx.wait_read().await;
+        let len = data.len();
+        if len == 0 {
+            return Ok(());
+        }
+        async_write_all(tx, &data).await?;
+        data.release(len);
+    }
+}
+
+/// Async write helper: writes all bytes, handling partial writes.
+async fn async_write_all<W: futures_io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    mut buf: &[u8],
+) -> Result<(), std::io::Error> {
+    while !buf.is_empty() {
+        let n = core::future::poll_fn(|cx| Pin::new(&mut *writer).poll_write(cx, buf)).await?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "write zero",
+            ));
+        }
+        buf = &buf[n..];
+    }
+    // Flush after each frame batch
+    core::future::poll_fn(|cx| Pin::new(&mut *writer).poll_flush(cx)).await?;
+    Ok(())
+}

--- a/crates/ergot/src/interface_manager/transports/mod.rs
+++ b/crates/ergot/src/interface_manager/transports/mod.rs
@@ -10,6 +10,9 @@ pub mod packet;
 #[cfg(any(feature = "embedded-io-async-v0_6", feature = "embedded-io-async-v0_7"))]
 pub mod eio;
 
+#[cfg(feature = "futures-io")]
+pub mod futures_io;
+
 #[cfg(feature = "embassy-usb-v0_5")]
 pub mod eusb_0_5;
 

--- a/crates/ergot/src/interface_manager/transports/tokio_cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/transports/tokio_cobs_stream.rs
@@ -1,36 +1,37 @@
 //! Generic tokio COBS stream transport.
 //!
-//! Provides generic RxWorker, TxWorker, and profile-specific registration
-//! functions for any `AsyncRead`/`AsyncWrite` COBS-framed transport
-//! (TCP, serial, generic streams).
+//! Thin wrapper around the [`futures_io`] transport, adding tokio-specific
+//! features: graceful shutdown via closer, liveness timeout, and
+//! profile-specific registration functions that spawn tokio tasks.
 //!
-//! [`FrameProcessor`]: crate::interface_manager::FrameProcessor
+//! [`futures_io`]: super::futures_io
 
 use std::sync::Arc;
 
 use crate::{
     interface_manager::{
         FrameProcessor, Interface, InterfaceState, LivenessConfig, Profile,
-        utils::std::{
-            ReceiverError, StdQueue,
-            acc::{CobsAccumulator, FeedResult},
-        },
+        utils::std::{ReceiverError, StdQueue},
     },
-    logging::{error, info, trace, warn},
+    logging::{error, info, warn},
     net_stack::NetStackHandle,
 };
-use bbqueue::{prod_cons::stream::StreamConsumer, traits::bbqhdl::BbqHandle};
+use bbqueue::traits::bbqhdl::BbqHandle;
 use maitake_sync::WaitQueue;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     select,
 };
+use tokio_util::compat::TokioAsyncWriteCompatExt;
 
 // ---------------------------------------------------------------------------
 // RxWorker
 // ---------------------------------------------------------------------------
 
 /// A generic COBS stream RxWorker for tokio-based transports.
+///
+/// Wraps the [`futures_io::RxWorker`](super::futures_io::RxWorker) with
+/// tokio-specific closer and liveness timeout support.
 pub struct CobsStreamRxWorker<N, R, P>
 where
     N: NetStackHandle,
@@ -60,6 +61,8 @@ where
     }
 
     pub async fn run(&mut self) -> ReceiverError {
+        use crate::interface_manager::utils::std::acc::{CobsAccumulator, FeedResult};
+
         let mut cobs_buf = CobsAccumulator::new(self.cobs_buf_size);
         let mut raw_buf = vec![0u8; 4096].into_boxed_slice();
         let mut have_received = false;
@@ -101,7 +104,7 @@ where
         &mut self,
         buf: &mut [u8],
         have_received: &mut bool,
-        cobs_buf: &mut CobsAccumulator,
+        cobs_buf: &mut crate::interface_manager::utils::std::acc::CobsAccumulator,
     ) -> Result<usize, ReceiverError> {
         loop {
             let rd = self.reader.read(buf);
@@ -148,7 +151,7 @@ where
                         }
                         self.processor.reset();
                         *have_received = false;
-                        *cobs_buf = CobsAccumulator::new(self.cobs_buf_size);
+                        *cobs_buf = crate::interface_manager::utils::std::acc::CobsAccumulator::new(self.cobs_buf_size);
                         continue;
                     }
                 }
@@ -180,36 +183,29 @@ where
 
 /// A generic COBS stream TxWorker for tokio-based transports.
 ///
-/// On exit, calls `closer.close()` to ensure the RxWorker also shuts down.
+/// Wraps the [`futures_io::tx_worker`](super::futures_io::tx_worker) with
+/// closer support. On exit, calls `closer.close()` to ensure the RxWorker
+/// also shuts down.
 pub struct CobsStreamTxWorker<W: AsyncWriteExt + Unpin> {
     pub writer: W,
-    pub consumer: StreamConsumer<StdQueue>,
+    pub consumer: bbqueue::prod_cons::stream::StreamConsumer<StdQueue>,
     pub closer: Arc<WaitQueue>,
 }
 
 impl<W: AsyncWriteExt + Unpin> CobsStreamTxWorker<W> {
-    pub async fn run(mut self) {
+    pub async fn run(self) {
         info!("Started COBS stream tx_worker");
-        loop {
-            let rxf = self.consumer.wait_read();
-            let clf = self.closer.wait();
+        let mut compat_writer = self.writer.compat_write();
 
-            let frame = select! {
-                r = rxf => r,
-                _c = clf => {
-                    break;
+        select! {
+            res = super::futures_io::tx_worker(&mut compat_writer, self.consumer) => {
+                if let Err(e) = res {
+                    error!("Tx Error: {:?}", e);
                 }
-            };
-
-            let len = frame.len();
-            trace!("sending pkt len:{}", len);
-            let res = self.writer.write_all(&frame).await;
-            frame.release(len);
-            if let Err(e) = res {
-                error!("Tx Error: {:?}", e);
-                break;
             }
+            _c = self.closer.wait() => {}
         }
+
         warn!("Closing COBS stream tx_worker");
         self.closer.close();
     }

--- a/crates/ergot/src/interface_manager/transports/tokio_cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/transports/tokio_cobs_stream.rs
@@ -1,7 +1,9 @@
 //! Generic tokio COBS stream transport.
 //!
-//! Thin wrapper around the [`futures_io`] transport, adding tokio-specific
-//! features: graceful shutdown via closer, liveness timeout, and
+//! Thin wrapper around the runtime-agnostic [`futures_io`] transport:
+//! the RX/TX loops, closer handling, and liveness timeout all live there.
+//! This module adapts tokio I/O types via `tokio-util` compat, provides
+//! `tokio::time::sleep` as the liveness sleeper, and offers
 //! profile-specific registration functions that spawn tokio tasks.
 //!
 //! [`futures_io`]: super::futures_io
@@ -10,8 +12,8 @@ use std::sync::Arc;
 
 use crate::{
     interface_manager::{
-        FrameProcessor, Interface, InterfaceState, LivenessConfig, Profile,
-        utils::std::{ReceiverError, StdQueue},
+        Interface, InterfaceState, LivenessConfig, Profile,
+        utils::std::StdQueue,
     },
     logging::{error, info, warn},
     net_stack::NetStackHandle,
@@ -22,158 +24,38 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     select,
 };
-use tokio_util::compat::TokioAsyncWriteCompatExt;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-// ---------------------------------------------------------------------------
-// RxWorker
-// ---------------------------------------------------------------------------
+use super::futures_io::RxWorker;
 
-/// A generic COBS stream RxWorker for tokio-based transports.
-///
-/// Wraps the [`futures_io::RxWorker`](super::futures_io::RxWorker) with
-/// tokio-specific closer and liveness timeout support.
-pub struct CobsStreamRxWorker<N, R, P>
-where
-    N: NetStackHandle,
-    R: AsyncReadExt + Unpin,
-    P: FrameProcessor<N>,
-{
-    pub nsh: N,
-    pub reader: R,
-    pub closer: Arc<WaitQueue>,
-    pub processor: P,
-    pub ident: <<N as NetStackHandle>::Profile as Profile>::InterfaceIdent,
-    pub liveness: Option<LivenessConfig>,
-    pub state_notify: Option<Arc<WaitQueue>>,
-    pub cobs_buf_size: usize,
+/// The liveness sleeper for tokio-based transports.
+fn tokio_sleeper(ms: u64) -> tokio::time::Sleep {
+    tokio::time::sleep(tokio::time::Duration::from_millis(ms))
 }
 
-impl<N, R, P> CobsStreamRxWorker<N, R, P>
-where
+/// Run an [`RxWorker`] to completion, with or without a liveness timeout.
+async fn run_rx_worker<N, R, P>(
+    rx_worker: &mut RxWorker<N, R, P>,
+    liveness: Option<LivenessConfig>,
+    cobs_buf_size: usize,
+) where
     N: NetStackHandle,
-    R: AsyncReadExt + Unpin,
-    P: FrameProcessor<N>,
+    R: futures_io::AsyncRead + Unpin,
+    P: crate::interface_manager::FrameProcessor<N>,
 {
-    fn notify(&self) {
-        if let Some(notify) = &self.state_notify {
-            notify.wake_all();
-        }
-    }
-
-    pub async fn run(&mut self) -> ReceiverError {
-        use crate::interface_manager::utils::std::acc::{CobsAccumulator, FeedResult};
-
-        let mut cobs_buf = CobsAccumulator::new(self.cobs_buf_size);
-        let mut raw_buf = vec![0u8; 4096].into_boxed_slice();
-        let mut have_received = false;
-
-        loop {
-            let ct = match self
-                .read_or_timeout(&mut raw_buf, &mut have_received, &mut cobs_buf)
+    let mut frame = vec![0u8; cobs_buf_size].into_boxed_slice();
+    let mut scratch = vec![0u8; 4096].into_boxed_slice();
+    let res = match liveness {
+        Some(cfg) => {
+            rx_worker
+                .run_with_liveness(&mut frame, &mut scratch, cfg, tokio_sleeper)
                 .await
-            {
-                Ok(ct) => ct,
-                Err(e) => return e,
-            };
-
-            let buf = &mut raw_buf[..ct];
-            let mut window = buf;
-
-            'cobs: while !window.is_empty() {
-                window = match cobs_buf.feed_raw(window) {
-                    FeedResult::Consumed => break 'cobs,
-                    FeedResult::OverFull(new_wind) => new_wind,
-                    FeedResult::DecodeError(new_wind) => new_wind,
-                    FeedResult::Success { data, remaining }
-                    | FeedResult::SuccessInput { data, remaining } => {
-                        let changed =
-                            self.processor
-                                .process_frame(data, &self.nsh, self.ident.clone());
-                        have_received = true;
-                        if changed {
-                            self.notify();
-                        }
-                        remaining
-                    }
-                };
-            }
         }
-    }
-
-    async fn read_or_timeout(
-        &mut self,
-        buf: &mut [u8],
-        have_received: &mut bool,
-        cobs_buf: &mut crate::interface_manager::utils::std::acc::CobsAccumulator,
-    ) -> Result<usize, ReceiverError> {
-        loop {
-            let rd = self.reader.read(buf);
-            let close = self.closer.wait();
-
-            let liveness_active = self.liveness.is_some() && *have_received;
-
-            let ct = if liveness_active {
-                let liveness = self.liveness.as_ref().unwrap();
-                let timeout =
-                    tokio::time::sleep(tokio::time::Duration::from_millis(liveness.timeout_ms));
-
-                select! {
-                    r = rd => {
-                        match r {
-                            Ok(0) | Err(_) => {
-                                warn!("recv run closed");
-                                return Err(ReceiverError::SocketClosed);
-                            }
-                            Ok(ct) => ct,
-                        }
-                    }
-                    _c = close => {
-                        return Err(ReceiverError::SocketClosed);
-                    }
-                    _ = timeout => {
-                        let changed = self.nsh.stack().manage_profile(|im| {
-                            if matches!(
-                                im.interface_state(self.ident.clone()),
-                                Some(InterfaceState::Active { .. })
-                            ) {
-                                _ = im.set_interface_state(
-                                    self.ident.clone(),
-                                    InterfaceState::Inactive,
-                                );
-                                true
-                            } else {
-                                false
-                            }
-                        });
-                        if changed {
-                            warn!("Liveness timeout — interface inactive");
-                            self.notify();
-                        }
-                        self.processor.reset();
-                        *have_received = false;
-                        *cobs_buf = crate::interface_manager::utils::std::acc::CobsAccumulator::new(self.cobs_buf_size);
-                        continue;
-                    }
-                }
-            } else {
-                select! {
-                    r = rd => {
-                        match r {
-                            Ok(0) | Err(_) => {
-                                warn!("recv run closed");
-                                return Err(ReceiverError::SocketClosed);
-                            }
-                            Ok(ct) => ct,
-                        }
-                    }
-                    _c = close => {
-                        return Err(ReceiverError::SocketClosed);
-                    }
-                }
-            };
-
-            return Ok(ct);
-        }
+        None => rx_worker.run(&mut frame, &mut scratch).await,
+    };
+    match res {
+        Ok(end) => info!("rx_worker ended: {:?}", end),
+        Err(e) => warn!("rx_worker ended with error: {:?}", e),
     }
 }
 
@@ -259,38 +141,24 @@ where
         notify.wake_all();
     }
 
-    let notify_clone = state_notify.clone();
-    let stack_clone = stack.clone();
+    let mut rx_worker =
+        RxWorker::new(stack, reader.compat(), processor, ()).with_closer(closer.clone());
+    if let Some(notify) = state_notify {
+        rx_worker = rx_worker.with_state_notify(notify);
+    }
 
-    let mut rx_worker = CobsStreamRxWorker {
-        nsh: stack,
-        reader,
-        closer: closer.clone(),
-        processor,
-        ident: (),
-        liveness,
-        state_notify,
-        cobs_buf_size: 1024 * 1024,
-    };
-
+    let rx_closer = closer.clone();
     tokio::task::spawn(async move {
-        let close = rx_worker.closer.clone();
-        select! {
-            _run = rx_worker.run() => { close.close(); },
-            _clf = close.wait() => {},
-        }
-        stack_clone.stack().manage_profile(|im| {
-            _ = im.set_interface_state((), InterfaceState::Down);
-        });
-        if let Some(notify) = &notify_clone {
-            notify.wake_all();
-        }
+        run_rx_worker(&mut rx_worker, liveness, 1024 * 1024).await;
+        // Ensure the TX worker also shuts down. The RxWorker itself sets
+        // the interface Down and wakes the state notifier on exit.
+        rx_closer.close();
     });
     tokio::task::spawn(
         CobsStreamTxWorker {
             writer,
             consumer: <StdQueue as BbqHandle>::stream_consumer(&queue),
-            closer: closer.clone(),
+            closer,
         }
         .run(),
     );
@@ -349,34 +217,31 @@ where
     let overhead = cobs::max_encoding_overhead(max_ergot_packet_size as usize);
     let cobs_buf_size = max_ergot_packet_size as usize + overhead;
 
-    let notify_clone = state_notify.clone();
     let nsh_clone = stack.clone();
 
-    let mut rx_worker = CobsStreamRxWorker {
-        nsh: stack.clone(),
-        reader,
-        closer: closer.clone(),
-        processor: RouterFrameProcessor::new(net_id),
+    let mut rx_worker = RxWorker::new(
+        stack.clone(),
+        reader.compat(),
+        RouterFrameProcessor::new(net_id),
         ident,
-        liveness,
-        state_notify,
-        cobs_buf_size,
-    };
+    )
+    .with_closer(closer.clone());
+    if let Some(notify) = state_notify.clone() {
+        rx_worker = rx_worker.with_state_notify(notify);
+    }
 
     stack.stack().manage_profile(|im| {
         im.set_interface_closer(ident, closer.clone());
     });
 
+    let rx_closer = closer.clone();
     tokio::task::spawn(async move {
-        let close = rx_worker.closer.clone();
-        select! {
-            _run = rx_worker.run() => { close.close(); },
-            _clf = close.wait() => {},
-        }
+        run_rx_worker(&mut rx_worker, liveness, cobs_buf_size).await;
+        rx_closer.close();
         nsh_clone.stack().manage_profile(|im| {
             _ = im.deregister_interface(ident);
         });
-        if let Some(notify) = &notify_clone {
+        if let Some(notify) = &state_notify {
             notify.wake_all();
         }
     });
@@ -384,7 +249,7 @@ where
         CobsStreamTxWorker {
             writer,
             consumer: <StdQueue as BbqHandle>::stream_consumer(&q),
-            closer: closer.clone(),
+            closer,
         }
         .run(),
     );
@@ -436,38 +301,27 @@ where
         notify.wake_all();
     }
 
-    let notify_clone = state_notify.clone();
-    let stack_clone = stack.clone();
+    let mut rx_worker = RxWorker::new(
+        stack,
+        reader.compat(),
+        EdgeFrameProcessor::new(),
+        UPSTREAM_IDENT.into(),
+    )
+    .with_closer(closer.clone());
+    if let Some(notify) = state_notify {
+        rx_worker = rx_worker.with_state_notify(notify);
+    }
 
-    let mut rx_worker = CobsStreamRxWorker {
-        nsh: stack,
-        reader,
-        closer: closer.clone(),
-        processor: EdgeFrameProcessor::new(),
-        ident: UPSTREAM_IDENT.into(),
-        liveness,
-        state_notify,
-        cobs_buf_size: 1024 * 1024,
-    };
-
+    let rx_closer = closer.clone();
     tokio::task::spawn(async move {
-        let close = rx_worker.closer.clone();
-        select! {
-            _run = rx_worker.run() => { close.close(); },
-            _clf = close.wait() => {},
-        }
-        stack_clone.stack().manage_profile(|im| {
-            _ = im.set_interface_state(UPSTREAM_IDENT.into(), InterfaceState::Down);
-        });
-        if let Some(notify) = &notify_clone {
-            notify.wake_all();
-        }
+        run_rx_worker(&mut rx_worker, liveness, 1024 * 1024).await;
+        rx_closer.close();
     });
     tokio::task::spawn(
         CobsStreamTxWorker {
             writer,
             consumer: <StdQueue as BbqHandle>::stream_consumer(&queue),
-            closer: closer.clone(),
+            closer,
         }
         .run(),
     );

--- a/crates/ergot/src/interface_manager/utils/std.rs
+++ b/crates/ergot/src/interface_manager/utils/std.rs
@@ -17,32 +17,3 @@ pub type StdQueue = Arc<BBQueue<BoxedSlice, AtomicCoord, MaiNotSpsc>>;
 pub fn new_std_queue(buffer: usize) -> StdQueue {
     Arc::new(BBQueue::new_with_storage(BoxedSlice::new(buffer)))
 }
-
-pub(crate) mod acc {
-    //! Basically postcard's cobs accumulator, but without the deser part
-
-    pub use cobs_acc::FeedResult;
-
-    #[allow(dead_code)]
-    pub struct CobsAccumulator {
-        inner: cobs_acc::CobsAccumulator<Box<[u8]>>,
-    }
-
-    #[allow(dead_code)]
-    impl CobsAccumulator {
-        #[inline]
-        pub fn new(size: usize) -> Self {
-            Self {
-                inner: cobs_acc::CobsAccumulator::new_boxslice(size),
-            }
-        }
-
-        #[inline(always)]
-        pub fn feed_raw<'me, 'input>(
-            &'me mut self,
-            input: &'input mut [u8],
-        ) -> FeedResult<'input, 'me> {
-            self.inner.feed_raw(input)
-        }
-    }
-}

--- a/crates/ergot/tests/e2e_bridge_seed.rs
+++ b/crates/ergot/tests/e2e_bridge_seed.rs
@@ -27,7 +27,10 @@ use ergot::{
             direct_edge::EdgeFrameProcessor,
             router::{Router, UPSTREAM_IDENT},
         },
-        transports::tokio_cobs_stream::{self, CobsStreamRxWorker, CobsStreamTxWorker},
+        transports::{
+            futures_io::RxWorker,
+            tokio_cobs_stream::{self, CobsStreamTxWorker},
+        },
         utils::{cobs_stream, std::new_std_queue},
     },
     net_stack::{ArcNetStack, services::bridge_seed_assign},
@@ -36,11 +39,11 @@ use ergot::{
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
-    select,
     time::{sleep, timeout},
 };
+use tokio_util::compat::TokioAsyncReadCompatExt;
 
-// Note: this test still manually constructs CobsStreamRxWorker/TxWorker for the
+// Note: this test still manually constructs the RX/TX workers for the
 // bridge *downstream pending* case (RouterFrameProcessor::new(0) before seed assign).
 // The bridge *upstream* uses tokio_cobs_stream::register_bridge_upstream.
 
@@ -158,23 +161,21 @@ async fn bridge_seed_routing_e2e_ping() {
         });
 
         let stack_clone = bridge_stack.clone();
-        let mut rx_worker = CobsStreamRxWorker {
-            nsh: bridge_stack.clone(),
-            reader: Box::new(bridge_d0_read) as Box<dyn AsyncRead + Unpin + Send>,
-            closer: closer.clone(),
-            processor: ergot::interface_manager::profiles::router::RouterFrameProcessor::new(0), // placeholder, will be updated
-            ident: bridge_d0_ident,
-            liveness: None,
-            state_notify: None,
-            cobs_buf_size: 1024 * 1024,
-        };
+        let reader = (Box::new(bridge_d0_read) as Box<dyn AsyncRead + Unpin + Send>).compat();
+        let mut rx_worker = RxWorker::new(
+            bridge_stack.clone(),
+            reader,
+            ergot::interface_manager::profiles::router::RouterFrameProcessor::new(0), // placeholder, will be updated
+            bridge_d0_ident,
+        )
+        .with_closer(closer.clone());
 
+        let rx_closer = closer.clone();
         tokio::task::spawn(async move {
-            let close = rx_worker.closer.clone();
-            select! {
-                _run = rx_worker.run() => { close.close(); },
-                _clf = close.wait() => {},
-            }
+            let mut frame = vec![0u8; 1024 * 1024].into_boxed_slice();
+            let mut scratch = vec![0u8; 4096].into_boxed_slice();
+            let _ = rx_worker.run(&mut frame, &mut scratch).await;
+            rx_closer.close();
             stack_clone.manage_profile(|im| {
                 let _ = im.deregister_interface(bridge_d0_ident);
             });


### PR DESCRIPTION
This makes the COBS stream transport runtime-agnostic and the Router profile usable on wasm32-unknown-unknown. One RxWorker, generic over `futures_io::AsyncRead`, owns the whole stream RX story: graceful shutdown, state notification, and liveness are injected rather than tied to a runtime — a `maitake_sync::WaitQueue` closer, an optional state-notify queue, and a liveness timeout driven by a caller-provided sleeper closure (tokio passes `tokio::time::sleep`, wasm passes gloo-timers, embedded could pass `embassy_time`). The tokio module becomes a thin compat wrapper and the duplicated accumulator/select loops are deleted, so the net diff in the tokio path is negative while gaining a new target. The motivating consumer is a browser playground running real ergot stacks in WASM (https://okhsunrog.github.io/ergot-demo/, sources at https://github.com/okhsunrog/ergot-demo), but the refactor stands on its own: less code on main, and `eio` could share the same inner loop later.

- add `transports::futures_io`: COBS stream `RxWorker` + `tx_worker` generic over `futures_io::AsyncRead`/`AsyncWrite`, behind a new `futures-io` feature (implies `std`)
- optional closer and state-notify (`maitake_sync::WaitQueue`); liveness via an injected sleeper future
- rewrite the tokio `CobsStreamTxWorker` and the `register_edge`/`register_router`/`register_bridge_upstream` functions on top of it via `tokio-util` compat
- drop the now-unused private boxed `CobsAccumulator` duplicate in `utils::std`
- the RxWorker no longer sets the initial interface state — registration code already owns that
- use `web-time` for the Router profile's seed-lease bookkeeping: `std::time::Instant::now()` panics on wasm32-unknown-unknown (while the NetStack mutex is held, deadlocking the stack); `web-time` is a pure re-export of `std::time` on native targets

Breaking changes: `tokio_cobs_stream::CobsStreamRxWorker` is removed (the public `register_*` functions keep their signatures); `e2e_bridge_seed`, which constructed it manually, is ported to the new worker.

Testing: both CI feature combos (`--features std`, `--features tokio-std`) pass; the wasm path is exercised end-to-end by the browser demo's test suite (multi-hop routing, bridges with seed leases and refresh, both stream and packet link flavors).