### PR TITLE
Fix UDP peer-learning deadlock for link-local addressing

### DIFF
--- a/crates/ergot/src/interface_manager/transports/tokio_udp.rs
+++ b/crates/ergot/src/interface_manager/transports/tokio_udp.rs
@@ -273,9 +273,15 @@ where
     let arc_socket = Arc::new(socket);
     let closer = Arc::new(WaitQueue::new());
 
-    // Determine if target mode for peer discovery: target has net_id=0
-    // (link-local) or Inactive, controller has a real net_id > 0.
-    let is_target = !matches!(initial_state, InterfaceState::Active { net_id, .. } if net_id > 0);
+    // Peer discovery is needed only for an *unconnected* socket — a server that
+    // binds a well-known port and learns the remote address from the first
+    // datagram it receives, then replies with `send_to`. A *connected* socket
+    // (the typical edge/initiator, which called `connect()`) already has a
+    // destination and must `send()` immediately; gating it on peer learning
+    // would deadlock, since the initiator has to transmit before it ever
+    // receives anything. Decide from the socket itself rather than from the
+    // initial addressing state.
+    let learn_peer = arc_socket.peer_addr().is_err();
 
     stack.stack().manage_profile(|im| {
         match im.interface_state(()) {
@@ -291,7 +297,7 @@ where
         notify.wake_all();
     }
 
-    let (peer_sender, peer_receiver) = if is_target {
+    let (peer_sender, peer_receiver) = if learn_peer {
         let (tx, rx) = watch::channel(None);
         (Some(tx), Some(rx))
     } else {
@@ -391,6 +397,19 @@ where
     };
     let closer = Arc::new(WaitQueue::new());
 
+    // A Router over an *unconnected* socket (e.g. a device that binds a
+    // well-known port and waits for an edge to reach it) must learn the
+    // remote address from received datagrams to reply via `send_to`. A
+    // Router over a *connected* socket (e.g. a bridge dialing upstream)
+    // already has a destination and uses `send()`. Mirror the edge logic.
+    let learn_peer = arc_socket.peer_addr().is_err();
+    let (peer_sender, peer_receiver) = if learn_peer {
+        let (tx, rx) = watch::channel(None);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
     let notify_clone = state_notify.clone();
     let nsh_clone = stack.clone();
 
@@ -411,7 +430,11 @@ where
     tokio::task::spawn(async move {
         let close = rx_worker.closer.clone();
         select! {
-            _run = rx_worker.run(|_addr| {}) => {
+            _run = rx_worker.run(|addr| {
+                if let Some(peer_tx) = &peer_sender {
+                    let _ = peer_tx.send(Some(addr));
+                }
+            }) => {
                 close.close();
             },
             _clf = close.wait() => {},
@@ -428,7 +451,7 @@ where
             socket: arc_socket,
             consumer: <StdQueue as BbqHandle>::framed_consumer(&q),
             closer: closer.clone(),
-            peer_rx: None,
+            peer_rx: peer_receiver,
         }
         .run(),
     );

--- a/crates/ergot/src/interface_manager/transports/tokio_udp.rs
+++ b/crates/ergot/src/interface_manager/transports/tokio_udp.rs
@@ -156,6 +156,10 @@ where
 /// `send_to` (for *unconnected* sockets). If `peer_rx` is `None`, it
 /// uses `socket.send()` (for *connected* sockets).
 ///
+/// The learned peer is latched on first receipt and reused for the rest
+/// of the session: the unconnected path assumes a single peer (one
+/// remote per bound port) and does not follow source-address changes.
+///
 /// On exit, calls `closer.close()` to ensure the RxWorker also
 /// shuts down.
 pub struct UdpTxWorker {
@@ -253,7 +257,9 @@ pub struct EdgeRegistrationError;
 /// Peer discovery is decided separately, from the socket's connectedness —
 /// not from `initial_state`. An *unconnected* socket learns its peer from
 /// the first inbound datagram and replies via `send_to`; a *connected*
-/// socket uses `send()` immediately.
+/// socket uses `send()` immediately. The unconnected path latches the first
+/// peer it learns and replies there for the rest of the session (one peer
+/// per bound port).
 pub async fn register_edge<N, I>(
     stack: N,
     socket: UdpSocket,
@@ -364,7 +370,9 @@ pub struct RouterRegistrationError;
 /// [`register_edge`]: an *unconnected* socket (a device that binds a
 /// well-known port and waits to be reached) learns the remote address from
 /// the first datagram and replies via `send_to`; a *connected* socket (a
-/// router dialing a fixed upstream) uses `send()`.
+/// router dialing a fixed upstream) uses `send()`. The unconnected path
+/// latches the first peer it learns and replies there for the rest of the
+/// session (one peer per bound port).
 pub async fn register_router<N, I, Rng, const M: usize, const SS: usize>(
     stack: N,
     socket: UdpSocket,

--- a/crates/ergot/src/interface_manager/transports/tokio_udp.rs
+++ b/crates/ergot/src/interface_manager/transports/tokio_udp.rs
@@ -45,14 +45,6 @@ where
     pub state_notify: Option<Arc<WaitQueue>>,
 }
 
-/// Result of receiving a UDP datagram.
-pub struct RecvResult {
-    /// Number of bytes received.
-    pub len: usize,
-    /// Source address of the datagram.
-    pub addr: SocketAddr,
-}
-
 impl<N, P> UdpRxWorker<N, P>
 where
     N: NetStackHandle,
@@ -160,9 +152,9 @@ where
 /// via a shared [`UdpSocket`].
 ///
 /// Supports optional peer discovery: if `peer_rx` is `Some`, the
-/// worker waits for a peer address before sending (used by
-/// unconnected target sockets). If `peer_rx` is `None`, uses
-/// `socket.send()` (for connected controller sockets).
+/// worker waits for a learned peer address before sending, then uses
+/// `send_to` (for *unconnected* sockets). If `peer_rx` is `None`, it
+/// uses `socket.send()` (for *connected* sockets).
 ///
 /// On exit, calls `closer.close()` to ensure the RxWorker also
 /// shuts down.
@@ -252,11 +244,16 @@ pub struct EdgeRegistrationError;
 
 /// Register a UDP transport on a [`DirectEdge`] profile.
 ///
-/// `initial_state` controls target vs controller mode:
-/// - Target: `InterfaceState::Active { net_id: 0, node_id: EDGE_NODE_ID }` with `EdgeFrameProcessor::new()`
-///   — creates a watch channel internally for peer address learning.
+/// `initial_state` sets the edge's role (addressing only):
+/// - Target: `InterfaceState::Active { net_id: 0, node_id: EDGE_NODE_ID }`
+///   with `EdgeFrameProcessor::new()`.
 /// - Controller: `InterfaceState::Active { net_id: 1, node_id: 1 }` with
-///   `EdgeFrameProcessor::new_controller(1)` — uses connected socket (`send()`).
+///   `EdgeFrameProcessor::new_controller(1)`.
+///
+/// Peer discovery is decided separately, from the socket's connectedness —
+/// not from `initial_state`. An *unconnected* socket learns its peer from
+/// the first inbound datagram and replies via `send_to`; a *connected*
+/// socket uses `send()` immediately.
 pub async fn register_edge<N, I>(
     stack: N,
     socket: UdpSocket,
@@ -363,7 +360,11 @@ pub struct RouterRegistrationError;
 
 /// Register a UDP transport on a [`Router`] profile.
 ///
-/// Router always uses connected sockets, so no peer discovery is needed.
+/// Peer discovery is decided from the socket's connectedness, mirroring
+/// [`register_edge`]: an *unconnected* socket (a device that binds a
+/// well-known port and waits to be reached) learns the remote address from
+/// the first datagram and replies via `send_to`; a *connected* socket (a
+/// router dialing a fixed upstream) uses `send()`.
 pub async fn register_router<N, I, Rng, const M: usize, const SS: usize>(
     stack: N,
     socket: UdpSocket,

--- a/crates/ergot/src/toolkits.rs
+++ b/crates/ergot/src/toolkits.rs
@@ -288,6 +288,12 @@ pub mod tokio_udp {
         ArcNetStack<CriticalSectionRawMutex, Router<TokioUdpInterface, rand::rngs::StdRng, 64, 64>>;
     pub type EdgeStack = ArcNetStack<CriticalSectionRawMutex, DirectEdge<TokioUdpInterface>>;
 
+    /// Register a UDP [`Router`] interface.
+    ///
+    /// The send path is selected from `socket`'s connectedness: pass a
+    /// `connect()`ed socket to `send()` to a fixed upstream immediately, or an
+    /// unconnected socket (the usual device that binds a well-known port) to
+    /// learn the peer from the first inbound datagram and reply via `send_to`.
     pub async fn register_router_interface(
         stack: &RouterStack,
         socket: UdpSocket,
@@ -305,6 +311,12 @@ pub mod tokio_udp {
         .await
     }
 
+    /// Register a UDP [`DirectEdge`] target (link-local, net_id=0).
+    ///
+    /// The send path is selected from `socket`'s connectedness: pass a
+    /// `connect()`ed socket to `send()` immediately (an edge that initiates to
+    /// a known peer), or an unconnected socket to learn the peer from the
+    /// first inbound datagram and reply via `send_to` (a target reached first).
     pub async fn register_edge_target_interface(
         stack: &EdgeStack,
         socket: UdpSocket,
@@ -327,6 +339,12 @@ pub mod tokio_udp {
         .await
     }
 
+    /// Register a UDP [`DirectEdge`] controller (net_id=1, central).
+    ///
+    /// The send path is selected from `socket`'s connectedness: pass a
+    /// `connect()`ed socket to `send()` to a fixed target immediately, or an
+    /// unconnected socket to learn the peer from the first inbound datagram
+    /// and reply via `send_to`.
     pub async fn register_edge_controller_interface(
         stack: &EdgeStack,
         socket: UdpSocket,

--- a/crates/ergot/tests/e2e_udp.rs
+++ b/crates/ergot/tests/e2e_udp.rs
@@ -1,18 +1,26 @@
-//! End-to-end test for UDP link-local addressing — regression for the
-//! peer-learning deadlock.
+//! End-to-end tests for UDP peer-learning — regression for the deadlock that
+//! followed from deciding peer discovery by addressing role instead of by the
+//! socket's connectedness.
 //!
-//! Reproduces the exact host<->device scenario: an edge initiates over a
-//! *connected* UDP socket using link-local addressing (net_id=0), while the
-//! device runs a `Router` over an *unconnected* socket.
+//! Before the fix, the tx worker decided whether to learn a peer from an
+//! `is_target` heuristic keyed on net_id (net_id==0 => wait to learn a peer
+//! before sending), and the `Router` had no peer-learning path at all. A
+//! link-local edge has net_id=0 yet, over a *connected* socket, must transmit
+//! first — so it waited forever for a peer it could only learn from an inbound
+//! datagram that never came, and the `Router` could not reply to whoever
+//! reached it.
 //!
-//! Before the fix, the edge's tx worker decided whether to learn a peer from
-//! an `is_target` heuristic keyed on net_id (net_id==0 => wait to learn a peer
-//! before sending). A link-local edge has net_id=0 yet, over a *connected*
-//! socket, must transmit first — so it waited forever for a peer it could only
-//! learn from an inbound datagram that never came. The `Router`, in turn, had
-//! no peer-learning path and could not reply to whoever reached it. This test
-//! times out on that code and passes once peer-learning is decided from the
-//! socket's connectedness instead.
+//! The two tests cover both branches of the connectedness decision:
+//! - [`edge_initiates_link_local_ping_over_udp`]: a *connected* edge initiates,
+//!   an *unconnected* `Router` learns its peer. This is the actual regression —
+//!   it deadlocks on the old `is_target` heuristic and only passes once
+//!   peer-learning is decided from connectedness.
+//! - [`controller_initiates_ping_to_unconnected_edge_target`]: a *connected*
+//!   controller initiates, an *unconnected* edge target learns its peer. The
+//!   old net_id heuristic also handled this case (a net_id=0 target was always
+//!   treated as `is_target`), so it does not reproduce the bug; it guards the
+//!   edge learn-peer branch so the connectedness rule can't silently break the
+//!   server-side edge in a future refactor.
 
 #![cfg(feature = "tokio-std")]
 #![cfg(not(miri))]
@@ -27,7 +35,7 @@ use ergot::{
     well_known::ErgotPingEndpoint,
 };
 use tokio::net::UdpSocket;
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 
 /// Spawn a ping server (echoes the `u32` it receives) on the router stack.
 fn spawn_router_ping_server(stack: &RouterStack) {
@@ -90,11 +98,9 @@ async fn edge_initiates_link_local_ping_over_udp() {
     };
     let response = timeout(
         Duration::from_secs(3),
-        edge_stack.endpoints().request::<ErgotPingEndpoint>(
-            router_link_local,
-            &42,
-            Some("ping"),
-        ),
+        edge_stack
+            .endpoints()
+            .request::<ErgotPingEndpoint>(router_link_local, &42, Some("ping")),
     )
     .await
     .expect("ping timed out — edge never transmitted (UDP peer-learning deadlock)")
@@ -106,6 +112,115 @@ async fn edge_initiates_link_local_ping_over_udp() {
         Some(InterfaceState::Active { net_id, node_id }) => {
             assert_eq!(net_id, 1, "edge should have discovered net_id=1");
             assert_eq!(node_id, 2, "edge node_id should be EDGE_NODE_ID");
+        }
+        other => panic!("expected Active state, got {other:?}"),
+    }
+}
+
+/// Spawn a ping server (echoes the `u32` it receives) on an edge stack.
+fn spawn_edge_ping_server(stack: &EdgeStack) {
+    tokio::spawn({
+        let stack = stack.clone();
+        async move {
+            let server = stack
+                .endpoints()
+                .bounded_server::<ErgotPingEndpoint, 4>(Some("ping"));
+            let server = pin!(server);
+            let mut hdl = server.attach();
+            loop {
+                let _ = hdl
+                    .serve(|val: &u32| {
+                        let v = *val;
+                        async move { v }
+                    })
+                    .await;
+            }
+        }
+    });
+}
+
+/// Ping with retries: the first request bootstraps the target's net_id and may
+/// land before its server has attached, so retry a few times before giving up.
+async fn ping_with_retry(stack: &EdgeStack, addr: Address, val: u32) -> u32 {
+    for _ in 0..20 {
+        let result = timeout(
+            Duration::from_millis(500),
+            stack
+                .endpoints()
+                .request::<ErgotPingEndpoint>(addr, &val, Some("ping")),
+        )
+        .await;
+        if let Ok(Ok(v)) = result {
+            return v;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    panic!("ping failed after retries — UDP peer-learning likely deadlocked");
+}
+
+/// A controller on a *connected* UDP socket initiates a ping to an edge
+/// *target* on an *unconnected* socket. The target must learn the controller's
+/// address from the first datagram it receives to reply via `send_to`.
+///
+/// This is the mirror of [`edge_initiates_link_local_ping_over_udp`]: it
+/// exercises the *edge* learn-peer path (`learn_peer = true` over an
+/// unconnected socket) plus a connected controller (`learn_peer = false`),
+/// rather than the router one. Unlike the link-local test it does not
+/// reproduce the original deadlock — the old net_id heuristic treated a
+/// net_id=0 target as `is_target` and so also learned a peer here. Its job is
+/// to pin the edge learn-peer branch in place so the switch to a
+/// connectedness-based decision can't silently break the server-side edge.
+#[tokio::test]
+async fn controller_initiates_ping_to_unconnected_edge_target() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Target side: bind an *unconnected* socket and register as a link-local
+    // edge target. It learns its peer from the first datagram the controller
+    // sends, then replies via `send_to`.
+    let target_queue = tokio_udp::new_std_queue(4096);
+    let target_stack: EdgeStack = tokio_udp::new_target_stack(&target_queue, 512);
+    let target_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let target_addr = target_sock.local_addr().unwrap();
+    tokio_udp::register_edge_target_interface(
+        &target_stack,
+        target_sock,
+        &target_queue,
+        None,
+        None,
+    )
+    .await
+    .expect("target registration");
+    spawn_edge_ping_server(&target_stack);
+
+    // Controller side: bind a socket, `connect()` it to the target (so it is a
+    // *connected* socket), and register as a controller (net_id=1, central).
+    let ctrl_queue = tokio_udp::new_std_queue(4096);
+    let ctrl_stack: EdgeStack = tokio_udp::new_controller_stack(&ctrl_queue, 512);
+    let ctrl_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    ctrl_sock
+        .connect(target_addr)
+        .await
+        .expect("controller connect to target");
+    tokio_udp::register_edge_controller_interface(&ctrl_stack, ctrl_sock, &ctrl_queue, None, None)
+        .await
+        .expect("controller registration");
+
+    // The controller initiates first, addressing the target at its assigned
+    // address (net_id=1, node_id=2=EDGE_NODE_ID). The first ping bootstraps the
+    // target's net_id.
+    let target = Address {
+        network_id: 1,
+        node_id: 2,
+        port_id: 0,
+    };
+    let response = ping_with_retry(&ctrl_stack, target, 42).await;
+    assert_eq!(response, 42);
+
+    // The target should have adopted the controller's net_id.
+    match target_stack.manage_profile(|im| im.interface_state(())) {
+        Some(InterfaceState::Active { net_id, node_id }) => {
+            assert_eq!(net_id, 1, "target should have adopted net_id=1");
+            assert_eq!(node_id, 2, "target node_id should be EDGE_NODE_ID");
         }
         other => panic!("expected Active state, got {other:?}"),
     }

--- a/crates/ergot/tests/e2e_udp.rs
+++ b/crates/ergot/tests/e2e_udp.rs
@@ -1,0 +1,112 @@
+//! End-to-end test for UDP link-local addressing — regression for the
+//! peer-learning deadlock.
+//!
+//! Reproduces the exact host<->device scenario: an edge initiates over a
+//! *connected* UDP socket using link-local addressing (net_id=0), while the
+//! device runs a `Router` over an *unconnected* socket.
+//!
+//! Before the fix, the edge's tx worker decided whether to learn a peer from
+//! an `is_target` heuristic keyed on net_id (net_id==0 => wait to learn a peer
+//! before sending). A link-local edge has net_id=0 yet, over a *connected*
+//! socket, must transmit first — so it waited forever for a peer it could only
+//! learn from an inbound datagram that never came. The `Router`, in turn, had
+//! no peer-learning path and could not reply to whoever reached it. This test
+//! times out on that code and passes once peer-learning is decided from the
+//! socket's connectedness instead.
+
+#![cfg(feature = "tokio-std")]
+#![cfg(not(miri))]
+
+use std::pin::pin;
+use std::time::Duration;
+
+use ergot::{
+    Address,
+    interface_manager::{InterfaceState, Profile},
+    toolkits::tokio_udp::{self, EdgeStack, RouterStack},
+    well_known::ErgotPingEndpoint,
+};
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+
+/// Spawn a ping server (echoes the `u32` it receives) on the router stack.
+fn spawn_router_ping_server(stack: &RouterStack) {
+    tokio::spawn({
+        let stack = stack.clone();
+        async move {
+            let server = stack
+                .endpoints()
+                .bounded_server::<ErgotPingEndpoint, 4>(Some("ping"));
+            let server = pin!(server);
+            let mut hdl = server.attach();
+            loop {
+                let _ = hdl
+                    .serve(|val: &u32| {
+                        let v = *val;
+                        async move { v }
+                    })
+                    .await;
+            }
+        }
+    });
+}
+
+/// An edge on a *connected* UDP socket initiates a link-local ping to a
+/// `Router` on an *unconnected* socket. The edge must send first; the router
+/// must learn the edge's address from that first datagram to reply.
+#[tokio::test]
+async fn edge_initiates_link_local_ping_over_udp() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Router side: bind an *unconnected* socket on an ephemeral port and run a
+    // Router over it. It will learn its peer from the first datagram received.
+    let router_stack: RouterStack = RouterStack::new();
+    let router_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let router_addr = router_sock.local_addr().unwrap();
+    tokio_udp::register_router_interface(&router_stack, router_sock, 512, 4096)
+        .await
+        .expect("router registration");
+    spawn_router_ping_server(&router_stack);
+
+    // Edge side: bind a socket, `connect()` it to the router (so it is a
+    // *connected* socket), and register as a link-local target (net_id=0).
+    let edge_queue = tokio_udp::new_std_queue(4096);
+    let edge_stack: EdgeStack = tokio_udp::new_target_stack(&edge_queue, 512);
+    let edge_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    edge_sock
+        .connect(router_addr)
+        .await
+        .expect("edge connect to router");
+    tokio_udp::register_edge_target_interface(&edge_stack, edge_sock, &edge_queue, None, None)
+        .await
+        .expect("edge registration");
+
+    // The edge initiates first, addressing the router link-local
+    // (net_id=0, node_id=1=CENTRAL_NODE_ID, port wildcard → find by key).
+    let router_link_local = Address {
+        network_id: 0,
+        node_id: 1,
+        port_id: 0,
+    };
+    let response = timeout(
+        Duration::from_secs(3),
+        edge_stack.endpoints().request::<ErgotPingEndpoint>(
+            router_link_local,
+            &42,
+            Some("ping"),
+        ),
+    )
+    .await
+    .expect("ping timed out — edge never transmitted (UDP peer-learning deadlock)")
+    .expect("ping request failed");
+    assert_eq!(response, 42);
+
+    // The edge should have discovered its real net_id from the router's reply.
+    match edge_stack.manage_profile(|im| im.interface_state(())) {
+        Some(InterfaceState::Active { net_id, node_id }) => {
+            assert_eq!(net_id, 1, "edge should have discovered net_id=1");
+            assert_eq!(node_id, 2, "edge node_id should be EDGE_NODE_ID");
+        }
+        other => panic!("expected Active state, got {other:?}"),
+    }
+}


### PR DESCRIPTION
UDP peer discovery was decided from an `is_target` heuristic keyed on `net_id`, which deadlocked link-local addressing. A link-local edge has `net_id=0` but, over a *connected* socket, must transmit first — so it waited forever for a peer it could only learn from an inbound datagram that never came, while the `Router` had no peer-learning path to reply at all. This decides peer learning from the socket's connectedness instead: a connected socket sends immediately, an unconnected socket learns its peer from the first datagram and replies via `send_to`. That is what lets a host reach a device-side `Router` over UDP using link-local addressing.

- Decide UDP peer-learning from the socket's connectedness (`peer_addr().is_err()`) rather than the `net_id`-based `is_target` heuristic, in both `register_edge` and `register_router`; add the peer-learning path to `register_router`, which was previously send-only and could not reply to an edge that reached it.
- Drop the dead `RecvResult` struct and correct stale transport docs.
- Document that the unconnected tx path latches the first peer it learns (one peer per bound port) on `UdpTxWorker`, `register_edge`, and `register_router`, and document the connectedness contract on the `tokio_udp` toolkit wrappers.
- Add `e2e_udp` end-to-end tests: a link-local edge initiating to an unconnected `Router` (the regression — deadlocks on the old heuristic), and a connected controller pinging an unconnected edge target (guards the edge learn-peer branch against future regressions).
