### PR TITLE
Fix permanent defmt network-sink stall — exact-size grants via scratch buffer

### DIFF
--- a/crates/ergot/src/logging/defmt_sink.rs
+++ b/crates/ergot/src/logging/defmt_sink.rs
@@ -156,15 +156,22 @@ mod bbq {
     }
     pub use consts::DEFMT_SINK_BUF_SIZE;
 
-    /// Maximum size for a single defmt frame (half the buffer size).
+    /// Maximum size for a single defmt frame.
     ///
     /// Frames that exceed this are silently dropped (truncated frames would
-    /// corrupt the host-side stream decoder). The halving ensures at least
-    /// two frames can coexist in the buffer, reducing drops under load.
-    const MAX_FRAME_SIZE: usize = if DEFMT_SINK_BUF_SIZE > 16 {
-        // Leave some headroom for the framing header (2 bytes for u16)
-        // and to allow multiple small frames in the buffer
-        DEFMT_SINK_BUF_SIZE / 2
+    /// corrupt the host-side stream decoder).
+    ///
+    /// Strictly BELOW half the ring, not exactly half: a framed grant of
+    /// `n` payload bytes needs `n + 2` (u16 header) CONTIGUOUS bytes, and
+    /// on an empty ring parked at write offset `w` that fits either in the
+    /// tail (`w <= Q - n - 2`) or via wrap (`n + 2 <= w`). The two windows
+    /// cover every `w` iff `n + 2 <= Q/2` — so capping at `Q/2 - 4` makes
+    /// every accepted frame placeable at ANY pointer position, and the
+    /// only remaining drop cause is a genuinely full queue (consumer
+    /// behind). At exactly `Q/2` there is a ~4-byte dead band of pointer
+    /// positions where an empty ring cannot take the frame.
+    pub(super) const MAX_FRAME_SIZE: usize = if DEFMT_SINK_BUF_SIZE > 16 {
+        DEFMT_SINK_BUF_SIZE / 2 - 4
     } else {
         DEFMT_SINK_BUF_SIZE
     };
@@ -605,5 +612,74 @@ where
                 name,
             );
         frame.release();
+    }
+}
+
+#[cfg(all(test, feature = "defmt-sink-network"))]
+mod tests {
+    use super::bbq;
+
+    /// Push one frame through the accumulator; returns true if it landed in
+    /// the queue (commit is infallible-looking, so observe via the consumer).
+    ///
+    /// NB: this drives `FrameAccumulator` (and thus `SCRATCH`) outside the
+    /// defmt `Logger::acquire`/`release` critical section that guarantees
+    /// exclusivity in production. That is sound here only because the test
+    /// is single-threaded and no defmt logger is active — accumulators are
+    /// created and committed strictly sequentially.
+    fn push(consumer: &bbq::DefmtConsumer, payload: &[u8]) -> bool {
+        let mut acc = bbq::FrameAccumulator::try_new().unwrap();
+        acc.write(payload);
+        acc.commit();
+        match consumer.read() {
+            Ok(grant) => {
+                assert_eq!(&grant[..], payload, "frame must round-trip intact");
+                grant.release();
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Regression for the half-ring dead zone (fixed 2026-07-08): the old
+    /// design granted MAX_FRAME_SIZE (= ring/2) per frame, and an empty
+    /// ring parked with its pointers at exactly ring/2 could satisfy that
+    /// grant neither in the tail nor via wrap — every subsequent frame
+    /// dropped, FOREVER. Exact-size grants (+ the MAX cap strictly below
+    /// half the ring) must survive that park and every other position.
+    ///
+    /// One test fn on purpose: the queue is a global static, parallel test
+    /// fns would interleave.
+    #[test]
+    fn frames_survive_any_ring_position() {
+        let consumer = bbq::init();
+        let q = bbq::DEFMT_SINK_BUF_SIZE;
+
+        // Park the ring exactly at q/2: two fillers of q/4 each (payload
+        // q/4 - 2 + u16 header), written and drained — ring is EMPTY with
+        // both pointers at the historical dead spot.
+        let filler = vec![0xA5u8; q / 4 - 2];
+        assert!(push(&consumer, &filler));
+        assert!(push(&consumer, &filler));
+
+        // The killer case: a maximum-size frame at the q/2 park. Under the
+        // old half-ring grant this failed forever.
+        let max = vec![0x5Au8; bbq::MAX_FRAME_SIZE];
+        assert!(
+            push(&consumer, &max),
+            "max-size frame must fit on an empty ring parked at q/2"
+        );
+
+        // Sweep: mixed sizes drive the pointers through wraps and odd
+        // offsets; every frame must land (ring is drained each time, so
+        // the only possible failure is grant geometry).
+        for i in 0..200usize {
+            let len = 1 + (i * 37) % bbq::MAX_FRAME_SIZE;
+            let payload: Vec<u8> = (0..len).map(|b| (b ^ i) as u8).collect();
+            assert!(
+                push(&consumer, &payload),
+                "frame {i} (len {len}) dropped on a drained ring"
+            );
+        }
     }
 }

--- a/crates/ergot/src/logging/defmt_sink.rs
+++ b/crates/ergot/src/logging/defmt_sink.rs
@@ -143,7 +143,7 @@ static NETWORK_ENABLED: AtomicBool = AtomicBool::new(false);
 mod bbq {
     use bbqueue::{
         BBQueue,
-        prod_cons::framed::{FramedConsumer, FramedGrantR, FramedGrantW},
+        prod_cons::framed::{FramedConsumer, FramedGrantR},
         traits::{
             bbqhdl::BbqHandle, coordination::cas::AtomicCoord, notifier::maitake::MaiNotSpsc,
             storage::Inline,
@@ -175,66 +175,86 @@ mod bbq {
     /// Static BBQueue for defmt frames (framed mode)
     static BBQ: DefmtQueue = BBQueue::new();
 
+    /// Scratch buffer for accumulating one defmt frame before the bbqueue
+    /// grant. Accessed ONLY between `Logger::acquire()` and
+    /// `Logger::release()`, which hold a critical section and assert
+    /// non-reentrancy — so this is effectively a single-owner buffer.
+    static mut SCRATCH: [u8; MAX_FRAME_SIZE] = [0; MAX_FRAME_SIZE];
+
     /// Frame accumulator for building complete defmt frames before committing.
     ///
     /// This solves the problem where defmt's encoder calls the write callback
-    /// multiple times per log message. We accumulate all writes into a single
-    /// bbqueue grant, then commit once at the end to create one complete frame.
+    /// multiple times per log message: writes accumulate into a scratch
+    /// buffer, and `commit()` takes a bbqueue grant of EXACTLY the frame
+    /// size.
+    ///
+    /// Why not grant `MAX_FRAME_SIZE` up front and commit less (the original
+    /// design): a framed grant needs CONTIGUOUS ring space, and a
+    /// half-buffer grant has a geometric dead zone — for certain write/read
+    /// pointer positions neither the tail nor the wrapped head can fit
+    /// buf/2 contiguous bytes even though the ring is EMPTY. Since only
+    /// successful grants advance the pointer, parking in the dead zone was
+    /// PERMANENT: every subsequent frame failed the grant and the network
+    /// sink went silent forever (observed on STM32F405 + USB transport,
+    /// 2026-07-07: grant_fail counting up at the exact log rate, zero
+    /// commits, from boot until reset). Exact-size grants keep the pointer
+    /// moving and have no practical dead zone at defmt frame sizes.
     pub(super) struct FrameAccumulator {
-        grant: FramedGrantW<&'static DefmtQueue, u16>,
         pos: usize,
-        capacity: usize,
         truncated: bool,
     }
 
     impl FrameAccumulator {
-        /// Try to acquire a new frame accumulator.
+        /// Start accumulating a new frame.
         ///
-        /// Returns `None` if the buffer is full or doesn't have enough space.
+        /// Must only be called from `Logger::acquire()` (critical section
+        /// held, non-reentrant) — see `SCRATCH`.
         pub fn try_new() -> Option<Self> {
-            // Use u16 header to match the consumer
-            let prod = <&DefmtQueue as BbqHandle>::framed_producer::<u16>(&&BBQ);
-            // MAX_FRAME_SIZE is guaranteed to fit in u16 since it's at most DEFMT_SINK_BUF_SIZE/2
-            let grant = prod.grant(MAX_FRAME_SIZE as u16).ok()?;
-            let capacity = grant.len();
             Some(Self {
-                grant,
                 pos: 0,
-                capacity,
                 truncated: false,
             })
         }
 
         /// Append data to the frame being accumulated.
         ///
-        /// If the frame would overflow, the extra data is silently dropped.
-        /// This is better than panicking in an ISR context.
+        /// If the frame would overflow, the frame is marked truncated and
+        /// dropped at commit (a corrupted defmt frame is worse than a lost
+        /// one).
         pub fn write(&mut self, data: &[u8]) {
-            let remaining = self.capacity - self.pos;
+            let remaining = MAX_FRAME_SIZE - self.pos;
             if data.len() > remaining {
-                // Frame overflowed — mark as truncated so commit() drops it.
-                // A corrupted defmt frame is worse than a lost one.
                 self.truncated = true;
             }
             let to_write = data.len().min(remaining);
             if to_write > 0 {
-                self.grant[self.pos..self.pos + to_write].copy_from_slice(&data[..to_write]);
+                // SAFETY: see `SCRATCH` — exclusive access is guaranteed by
+                // the defmt logger's critical section + reentrancy check.
+                unsafe {
+                    let scratch = &mut *core::ptr::addr_of_mut!(SCRATCH);
+                    scratch[self.pos..self.pos + to_write].copy_from_slice(&data[..to_write]);
+                }
                 self.pos += to_write;
             }
         }
 
-        /// Commit the accumulated frame and make it available to the consumer.
-        ///
-        /// This consumes the accumulator.
+        /// Grant exactly `pos` bytes, copy the frame in, and commit.
         pub fn commit(self) {
-            if self.truncated {
-                // Drop the grant without committing — bbqueue's Drop impl
-                // will abort the frame automatically. A corrupted defmt frame
-                // would cause decode errors on the host.
+            if self.truncated || self.pos == 0 {
                 return;
             }
-            // pos is guaranteed to fit in u16 since capacity <= MAX_FRAME_SIZE < u16::MAX
-            self.grant.commit(self.pos as u16);
+            let prod = <&DefmtQueue as BbqHandle>::framed_producer::<u16>(&&BBQ);
+            // pos <= MAX_FRAME_SIZE <= u16::MAX by construction.
+            let Ok(mut grant) = prod.grant(self.pos as u16) else {
+                // Queue genuinely full (consumer behind) — drop this frame.
+                return;
+            };
+            // SAFETY: see `SCRATCH`.
+            unsafe {
+                let scratch = &*core::ptr::addr_of!(SCRATCH);
+                grant[..self.pos].copy_from_slice(&scratch[..self.pos]);
+            }
+            grant.commit(self.pos as u16);
         }
     }
 


### PR DESCRIPTION
Debugging defmt-over-USB on an STM32F405 surfaced a permanent stall in the defmt network sink. The FrameAccumulator granted MAX_FRAME_SIZE (= ring/2) up front for every log message and committed less; a framed bbqueue grant needs contiguous ring space, and a half-ring grant has a geometric dead zone of write-pointer positions where no grant can succeed even on an empty ring. Since only successful grants advance the pointer, parking there was permanent: every subsequent frame failed its grant and was silently dropped, and the network defmt sink went dead from boot onward — whether a given boot survived depended on where the boot burst left the pointer.

- Accumulate the frame into a static scratch buffer (safe: the accumulator only lives between Logger::acquire and Logger::release, which hold a critical section and assert non-reentrancy) and take the bbqueue grant at commit time with exactly the frame size — small grants keep the pointer moving, and a failed grant now means the queue is genuinely full
- Cap MAX_FRAME_SIZE strictly below half the ring (ring/2 − 4) so every accepted frame is placeable at any pointer position; the only remaining drop cause is a genuinely full queue (consumer behind), which is the honest lossy-logger contract
- Regression test parks the ring exactly at the historical dead spot, pushes a max-size frame (the case the old half-ring grant failed forever), then sweeps 200 mixed-size frames through wraps and odd offsets asserting zero drops on a drained ring

Testing: verified on hardware end-to-end (STM32F405, USB transport) — defmt lines arrive at the full log rate from boot, together with a host-side stream-decoder fix in the consuming project.