### PR TITLE
Broadcast to no audience is a successful no-op; document the delivery model

### DIFF
--- a/crates/ergot/src/book/_04_delivery_and_reliability.rs
+++ b/crates/ergot/src/book/_04_delivery_and_reliability.rs
@@ -1,0 +1,165 @@
+//! # Delivery and Reliability
+//!
+//! Ergot makes a deliberate, narrow promise about delivery, and leaves
+//! everything stronger to the application. Understanding exactly what a `send`
+//! does — and does not — guarantee is the key to building something reliable on
+//! top of it.
+//!
+//! ## Ergot is at-most-once
+//!
+//! A send in Ergot is **at-most-once**: the message is delivered immediately, or
+//! it is dropped. There is no automatic retransmission, no acknowledgement, no
+//! background worker holding messages for later, and no built-in priority or
+//! quality-of-service. This follows directly from the "drop, don't block" choice
+//! described in [Major Concepts](super::_02_major_concepts): buffers are bounded
+//! and there is no hidden place to stash a deferred message, so when a
+//! destination is full or absent the message is dropped rather than queued
+//! indefinitely.
+//!
+//! This is a feature, not a limitation to apologize for: bounded buffers,
+//! demand-driven sending, and no hidden retransmission state are what make Ergot
+//! suitable for the smallest devices. It does mean that **reliability is the
+//! application's responsibility**, built from the primitives below.
+//!
+//! ## What a `send` result tells you
+//!
+//! The `Result` returned by a send describes the *local* send attempt, never the
+//! eventual fate of the message:
+//!
+//! * `Ok(())` means the message was accepted for immediate, best-effort delivery
+//!   — handed to a matching local socket and/or enqueued on an outgoing
+//!   interface. It does **not** mean the message was received or processed by the
+//!   peer. An accepted message can still be dropped downstream: a full queue on a
+//!   later hop, a stale frame shed under backpressure, or a peer that has gone
+//!   away.
+//! * `Err(..)` means the send could not even begin — for a unicast, there was no
+//!   route to the requested destination and no matching local socket.
+//!
+//! Because `Ok` already carries no delivery guarantee, the meaningful question is
+//! never "did anyone receive this?" (you cannot learn that from the return value)
+//! but "was this message accepted for sending?".
+//!
+//! ### Broadcast is best-effort with no single destination
+//!
+//! A broadcast (topic message, destination port `255`) is addressed to
+//! *everyone*, not to a specific node. It is delivered to every matching local
+//! socket and flooded outward on every interface. Two consequences follow:
+//!
+//! * Reaching **at least one** recipient is success; a partial broadcast (some
+//!   interfaces took it, others did not) still returns `Ok`.
+//! * Reaching **no one** — no local subscriber and no interface to flood to — is
+//!   a successful no-op, not an error. Under the at-most-once model, "nobody is
+//!   listening right now" is the same expected, lossy outcome as a message
+//!   dropped one hop later. A device that publishes telemetry whether or not a
+//!   host is attached is the normal case, and it is not a failure.
+//!
+//! A genuine failure to an interface that *does* exist (for example, its outgoing
+//! queue is full) is still reported as an error.
+//!
+//! ## The delivery-semantics ladder
+//!
+//! Stronger guarantees are built on top of at-most-once, rung by rung:
+//!
+//! * **At-most-once** — send and forget. Ergot's raw behaviour. The message may
+//!   be lost.
+//! * **At-least-once** — retry until acknowledged. This is just "wrap the request
+//!   in a timeout and a bounded number of retries." Because a message may now be
+//!   delivered more than once, the receiver must tolerate duplicates — that is,
+//!   the operation must be **idempotent**.
+//! * **Effectively-once** — at-least-once delivery plus de-duplication on the
+//!   receiver (an idempotency key / request id the server remembers). True
+//!   exactly-once is not achievable over an unreliable transport; this is the
+//!   practical substitute.
+//!
+//! Note that the `seq_no` field in the header does **not** give you
+//! de-duplication today: an application-level retry is a fresh send with a fresh
+//! `seq_no`, so the receiver cannot use it to recognise a duplicate.
+//! Effectively-once therefore needs an application-level request id carried in the
+//! message body.
+//!
+//! ## Idempotency by design
+//!
+//! Because at-least-once retry is the workhorse of reliability, the cheapest way
+//! to make a system robust is to make its operations idempotent from the start.
+//! The most effective discipline is to prefer **declarative, level-triggered**
+//! commands over **imperative, edge-triggered** ones:
+//!
+//! * Declarative / level-triggered: an absolute desired state — `set mode = Run`,
+//!   `set current limit = 10 A`. Re-applying it changes nothing, so retrying is
+//!   always safe, and absence of a fresh command fails toward a known state.
+//! * Imperative / edge-triggered: a delta or one-shot action — `toggle`, `step
+//!   +5`, `start calibration`. Re-applying it does something *again*, so a
+//!   duplicate from a retry is a bug.
+//!
+//! This is the same distinction as HTTP `PUT` versus `POST`, or a reconcile loop
+//! that drives toward a target rather than emitting edits. Declarative setpoints
+//! are idempotent by construction and fail safe naturally. For the genuine
+//! actions that remain, either make them no-ops when already done, or de-duplicate
+//! them by request id.
+//!
+//! ## Liveness and interface state
+//!
+//! Ergot will not ping or retry for you, but it provides two optional hooks on a
+//! transport's receive worker that the application-level reliability loop is built
+//! from. Both default to `None`.
+//!
+//! * `LivenessConfig { timeout_ms }` is a **receive-side watchdog**. The worker
+//!   arms a timer that is reset on every received frame; if nothing arrives within
+//!   `timeout_ms` it declares the link dead and transitions the interface state.
+//!   For a connectionless transport (UDP) the interface goes `Down` and the worker
+//!   exits, so you re-register for the next session; for a COBS stream (TCP,
+//!   serial, RTT) it goes `Inactive` and the workers keep running and recover when
+//!   frames resume, while a real transport error goes `Down`. With no liveness
+//!   configured, silence alone never changes the interface state.
+//! * A `state_notify` wait-queue is woken on **every interface state change**:
+//!   `Inactive → Active` on the first frame, `→ Inactive`/`Down` on a liveness
+//!   timeout, and on (de)registration. You `wait()` on it and react.
+//!
+//! Each interface carries an `InterfaceState`:
+//!
+//! * `Active { net_id, node_id }` — up and addressable.
+//! * `Inactive` — temporarily not delivering (a COBS-stream liveness timeout); the
+//!   workers keep running and recover when frames resume.
+//! * `Down` — gone (a UDP liveness timeout, or a transport error); for UDP the
+//!   worker exits and you re-register.
+//!
+//! The canonical reliability loop is therefore: register the interface with
+//! `liveness` and `state_notify`, `wait()` on the notify, and on each transition
+//! react — on `Active` mark the link up (and run any handshake), on `Inactive`
+//! wait a recovery window, on `Down` (or once the recovery window expires) tear
+//! down and reconnect.
+//!
+//! ## Backpressure, lossiness, and the absence of QoS
+//!
+//! There is no priority within an interface: a high-rate telemetry stream and a
+//! command response share one bounded outgoing queue. So the answer to "what
+//! happens when the buffer fills and an important packet is lost?" is not a QoS
+//! policy — it is to make the *high-volume, low-value* traffic the part that is
+//! shed:
+//!
+//! * Make bulk streams (telemetry, logs) **lossy and rate-limited**: drop samples
+//!   at the source when the queue is full, batch several samples per message, and
+//!   make streaming opt-in (the consumer asks for a rate) so nothing is produced
+//!   when no one is listening.
+//! * Let the **low-volume, important** traffic (commands and their responses) ride
+//!   the timeout-and-retry path from the ladder above.
+//!
+//! Combined with a transmit worker that drops stale frames and bounds the time
+//! spent on any single frame, this keeps a slow or congested link from
+//! head-of-line-blocking the command path: under pressure, telemetry is what is
+//! lost, not commands.
+//!
+//! ## Safety-critical systems: fail safe by absence
+//!
+//! The corollary of at-most-once is sharp for anything that can hurt someone: a
+//! "stop" command is **not** a safety guarantee, because it can be lost. Safety
+//! must instead be **fail-safe by absence** — a deadman. The actuator runs only
+//! while it receives continuous, positive affirmation, and the *loss* of that
+//! affirmation drives it to a safe state. The `liveness` → `state_notify` chain is
+//! exactly the "the controller went away" detector for this pattern.
+//!
+//! A subtlety worth internalizing: a link-loss gate that lives in the async
+//! executor only fires while the executor is running. The strongest layer is a
+//! command-staleness deadman that does not depend on the executor at all — for
+//! example, checked in the control interrupt and backed by a hardware watchdog —
+//! so that even a stalled executor still fails safe.

--- a/crates/ergot/src/book/mod.rs
+++ b/crates/ergot/src/book/mod.rs
@@ -101,3 +101,4 @@
 pub mod _01_what_can_you_do;
 pub mod _02_major_concepts;
 pub mod _03_feature_overview;
+pub mod _04_delivery_and_reliability;

--- a/crates/ergot/src/conformance/net_stack.rs
+++ b/crates/ergot/src/conformance/net_stack.rs
@@ -88,6 +88,29 @@
 //!    * If a matching socket is found, the Net Stack SHALL off the message to the socket.
 //!
 //! If a matching Socket is found, the Net Stack SHALL return the result of the socket send.
+//!
+//! #### Broadcast Messages
+//!
+//! A broadcast (destination port `255`) is addressed to *everyone*, not to a
+//! single destination, and is delivered best-effort: it is offered to all
+//! matching local sockets (find all) AND offered to the Profile to be flooded
+//! outward on all interfaces. See the book's
+//! [Delivery and Reliability](crate::book::_04_delivery_and_reliability) chapter
+//! for the model.
+//!
+//! * If the message DOES NOT include the Any/All appendix, the Net Stack SHALL
+//!   return an "All Port Missing Key" error.
+//! * If at least one local socket OR the Profile accepts the message, the Net
+//!   Stack SHALL return success.
+//! * A Profile result of "No Route to Destination" or "Routing Loop" SHALL be
+//!   treated as *no external recipient* — a successful best-effort no-op, NOT a
+//!   delivery error. Because a broadcast has no single destination, "nobody is
+//!   listening" is an expected outcome under at-most-once delivery, not a
+//!   failure. (This is why the flowchart's "profile Accepted" branch covers the
+//!   no-route case for broadcasts.)
+//! * If there is no local recipient AND the Profile reports a genuine delivery
+//!   failure to an interface that exists (e.g. its outgoing queue is full), the
+//!   Net Stack SHALL return a "No Route" error.
 #![cfg_attr(not(test), allow(dead_code, unused_imports, unused_macros))]
 
 use mocks::{ExpectedSend, test_stack};

--- a/crates/ergot/src/conformance/net_stack.rs
+++ b/crates/ergot/src/conformance/net_stack.rs
@@ -93,7 +93,7 @@
 use mocks::{ExpectedSend, test_stack};
 
 use crate::{
-    Address, DEFAULT_TTL, FrameKind, Header, NetStackSendError,
+    Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, Key, NetStackSendError,
     interface_manager::InterfaceSendError,
 };
 
@@ -254,6 +254,26 @@ fn unicast_specific_port() -> Header {
     }
 }
 
+/// A broadcast header (`*:*.255`) carrying the Any/All appendix that broadcast
+/// delivery requires.
+fn broadcast_hdr() -> Header {
+    Header {
+        src: Address::unknown(),
+        dst: Address {
+            network_id: 10,
+            node_id: 10,
+            port_id: 255,
+        },
+        any_all: Some(AnyAllAppendix {
+            key: Key(*b"TESTTEST"),
+            nash: None,
+        }),
+        seq_no: None,
+        kind: FrameKind::TOPIC_MSG,
+        ttl: DEFAULT_TTL,
+    }
+}
+
 /// Returns an Ok(())
 fn ok<E>() -> Result<(), E> {
     Ok(())
@@ -303,6 +323,12 @@ fn snoroute() -> Result<(), NetStackSendError> {
     stack_err(NetStackSendError::NoRoute)
 }
 
+/// Interface reports a routing loop (a broadcast whose only route is back to its
+/// source — i.e. no external recipient).
+fn iroutingloop() -> Result<(), InterfaceSendError> {
+    interface_err(InterfaceSendError::RoutingLoop)
+}
+
 send_testa! {
     | Case                          | Header                | Val     | ProfileReturns  | StackReturns  |
     | ----                          | ------                | ---     | --------------  | ------------  |
@@ -310,4 +336,18 @@ send_testa! {
     | no_sockets_no_iroute          | unicast_specific_port | 1234u64 | inoroute        | sinoroute     |
     | no_sockets_interface_full     | unicast_specific_port | 1234u64 | ifull           | sifull        |
     | no_sockets_interface_local    | unicast_specific_port | 1234u64 | ilocal          | snoroute      |
+}
+
+// Broadcast (`*:*.255`) has no single destination: it is best-effort to all
+// current recipients. "No route to dest" and "routing loop" both mean "no
+// external recipient", which is a successful no-op — not a delivery error.
+// A genuine failure to an *existing* interface (e.g. `InterfaceFull`) still
+// surfaces as an error. (See the book's delivery-model chapter.)
+send_testa! {
+    | Case                           | Header        | Val     | ProfileReturns  | StackReturns  |
+    | ----                           | ------        | ---     | --------------  | ------------  |
+    | bcast_interface_takes          | broadcast_hdr | 1234u64 | ok              | ok            |
+    | bcast_no_audience_no_iroute    | broadcast_hdr | 1234u64 | inoroute        | ok            |
+    | bcast_no_audience_routing_loop | broadcast_hdr | 1234u64 | iroutingloop    | ok            |
+    | bcast_genuine_failure_errors   | broadcast_hdr | 1234u64 | ifull           | snoroute      |
 }

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -592,6 +592,31 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize>
 // Profile implementation
 // ---------------------------------------------------------------------------
 
+/// Fold one broadcast-leg send result into the loop accumulators.
+///
+/// The benign class — down/inactive interface (`NoRouteToDest`), the frame's
+/// own source (`RoutingLoop`), a self-addressed leg (`DestinationLocal`) —
+/// just means "no recipient here" and is not remembered. Anything else (e.g.
+/// `InterfaceFull`, `PacketTooBig`) is a *genuine* failure on an interface
+/// that exists and was attempted; the caller reports it if no leg succeeded,
+/// so a broadcast that failed everywhere is distinguishable from a broadcast
+/// with no audience (see the conformance spec's "Broadcast Messages").
+fn fold_broadcast_leg(
+    res: Result<(), InterfaceSendError>,
+    any_good: &mut bool,
+    genuine: &mut Option<InterfaceSendError>,
+) {
+    match res {
+        Ok(()) => *any_good = true,
+        Err(
+            InterfaceSendError::NoRouteToDest
+            | InterfaceSendError::RoutingLoop
+            | InterfaceSendError::DestinationLocal,
+        ) => {}
+        Err(e) => *genuine = Some(e),
+    }
+}
+
 impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> Profile
     for Router<I, R, N, S, C>
 {
@@ -609,6 +634,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             }
 
             let mut any_good = false;
+            let mut genuine = None;
             for slot in self.slots.iter_mut() {
                 if hdr.dst.network_id == slot.net_id {
                     continue;
@@ -616,14 +642,16 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
                 let mut bhdr = hdr.clone();
                 bhdr.dst.network_id = slot.net_id;
                 bhdr.dst.node_id = EDGE_NODE_ID;
-                any_good |= slot.port.send(&bhdr, data).is_ok();
+                fold_broadcast_leg(slot.port.send(&bhdr, data), &mut any_good, &mut genuine);
             }
             // Also broadcast to upstream (bridge mode)
             if let Some(up) = self.upstream.as_mut() {
-                any_good |= up.port.send(&hdr, data).is_ok();
+                fold_broadcast_leg(up.port.send(&hdr, data), &mut any_good, &mut genuine);
             }
             if any_good {
                 Ok(())
+            } else if let Some(e) = genuine {
+                Err(e)
             } else {
                 Err(InterfaceSendError::NoRouteToDest)
             }
@@ -669,6 +697,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
 
             let mut default_error = InterfaceSendError::RoutingLoop;
             let mut any_good = false;
+            let mut genuine = None;
 
             for slot in self.slots.iter_mut() {
                 if source == slot.ident {
@@ -678,16 +707,22 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
 
                 hdr.dst.network_id = slot.net_id;
                 hdr.dst.node_id = EDGE_NODE_ID;
-                any_good |= slot.port.send_raw(&hdr, data).is_ok();
+                fold_broadcast_leg(slot.port.send_raw(&hdr, data), &mut any_good, &mut genuine);
             }
             // Also broadcast to upstream (bridge mode), unless source is upstream
             if let Some(up) = self.upstream.as_mut()
                 && source != UPSTREAM_IDENT
             {
                 default_error = InterfaceSendError::NoRouteToDest;
-                any_good |= up.port.send_raw(&hdr, data).is_ok();
+                fold_broadcast_leg(up.port.send_raw(&hdr, data), &mut any_good, &mut genuine);
             }
-            if any_good { Ok(()) } else { Err(default_error) }
+            if any_good {
+                Ok(())
+            } else if let Some(e) = genuine {
+                Err(e)
+            } else {
+                Err(default_error)
+            }
         } else {
             let nshdr: Header = hdr.clone().into();
             let port = self.find(&nshdr, Some(source))?;

--- a/crates/ergot/src/net_stack/discovery.rs
+++ b/crates/ergot/src/net_stack/discovery.rs
@@ -40,10 +40,15 @@ impl<NS: NetStackHandle> Discovery<NS> {
         // is at-most-once and to an empty network it is a successful no-op (no
         // error to short-circuit on), so just listen for whatever responds
         // within the timeout — with no interface the listener simply times out
-        // and returns an empty result.
-        let _ = topics
+        // and returns an empty result. A genuine send failure (e.g. a full
+        // interface queue) also just waits out the timeout, but keep it
+        // observable.
+        if let Err(e) = topics
             .clone()
-            .broadcast_with_src_port::<ErgotDeviceInfoInterrogationTopic>(&(), None, port);
+            .broadcast_with_src_port::<ErgotDeviceInfoInterrogationTopic>(&(), None, port)
+        {
+            crate::logging::debug!("discovery interrogation broadcast failed: {:?}", e);
+        }
 
         let fut = async {
             loop {
@@ -90,10 +95,13 @@ impl<NS: NetStackHandle> Discovery<NS> {
         let mut rxd = vec![];
 
         // AFTER creating the subscription, send the query. Best-effort
-        // broadcast — see `discover_devices` for the at-most-once rationale.
-        let _ = topics
+        // broadcast — see `discover` for the at-most-once rationale.
+        if let Err(e) = topics
             .clone()
-            .broadcast_with_src_port::<ErgotSocketQueryTopic>(query, None, port);
+            .broadcast_with_src_port::<ErgotSocketQueryTopic>(query, None, port)
+        {
+            crate::logging::debug!("socket query broadcast failed: {:?}", e);
+        }
 
         let fut = async {
             loop {

--- a/crates/ergot/src/net_stack/discovery.rs
+++ b/crates/ergot/src/net_stack/discovery.rs
@@ -36,13 +36,14 @@ impl<NS: NetStackHandle> Discovery<NS> {
         let port = hdl.port();
         let mut rxd = vec![];
 
-        // AFTER creating the subscription, send the interrogation
-        let res = topics
+        // AFTER creating the subscription, send the interrogation. Broadcasting
+        // is at-most-once and to an empty network it is a successful no-op (no
+        // error to short-circuit on), so just listen for whatever responds
+        // within the timeout — with no interface the listener simply times out
+        // and returns an empty result.
+        let _ = topics
             .clone()
             .broadcast_with_src_port::<ErgotDeviceInfoInterrogationTopic>(&(), None, port);
-        if res.is_err() {
-            return vec![];
-        }
 
         let fut = async {
             loop {
@@ -88,13 +89,11 @@ impl<NS: NetStackHandle> Discovery<NS> {
         let port = hdl.port();
         let mut rxd = vec![];
 
-        // AFTER creating the subscription, send the interrogation
-        let res = topics
+        // AFTER creating the subscription, send the query. Best-effort
+        // broadcast — see `discover_devices` for the at-most-once rationale.
+        let _ = topics
             .clone()
             .broadcast_with_src_port::<ErgotSocketQueryTopic>(query, None, port);
-        if res.is_err() {
-            return vec![];
-        }
 
         let fut = async {
             loop {

--- a/crates/ergot/src/net_stack/inner.rs
+++ b/crates/ergot/src/net_stack/inner.rs
@@ -103,11 +103,18 @@ where
                 debug!("{}: delivered broadcast message remotely", hdr);
                 true
             }
-            Err(InterfaceSendError::RoutingLoop) => {
-                // no need to report /errors/ on routing loops
+            // A broadcast has no single destination (dst port 255 = "everyone"),
+            // so "routing loop" and "no route to dest" both mean the same benign
+            // thing: there is no external recipient for this message. Under the
+            // at-most-once delivery model a broadcast with no audience is a
+            // successful no-op, not a delivery error — consistent with the way a
+            // delivered broadcast can still be dropped downstream. (`NoRouteToDest`
+            // is a unicast-shaped error; for `255` it just means "nobody here".)
+            Err(InterfaceSendError::RoutingLoop | InterfaceSendError::NoRouteToDest) => {
                 debug!("{}: No external interest in msg broadcast", hdr);
                 true
             }
+            // A genuine delivery failure to an existing interface (e.g. full).
             // `e` is only used in the logging macro (no-op when internal logging is disabled)
             #[allow(unused_variables)]
             Err(e) => {

--- a/crates/ergot/src/net_stack/mod.rs
+++ b/crates/ergot/src/net_stack/mod.rs
@@ -69,6 +69,14 @@ where
 pub enum NetStackSendError {
     SocketSend(SocketSendError),
     InterfaceSend(InterfaceSendError),
+    /// The message could not be delivered: for a unicast, there was no route to
+    /// the destination and no matching local socket; for a broadcast, there was
+    /// no local recipient and the profile reported a genuine delivery failure.
+    ///
+    /// Note that a broadcast reaching *no one* (no subscribers, no interface) is
+    /// NOT this error — it is a successful best-effort no-op. See the book's
+    /// [Delivery and Reliability](crate::book::_04_delivery_and_reliability)
+    /// chapter.
     NoRoute,
     AnyPortMissingKey,
     /// The message and the socket don't agree on the port kind

--- a/crates/ergot/src/net_stack/topics.rs
+++ b/crates/ergot/src/net_stack/topics.rs
@@ -91,6 +91,13 @@ impl<NS: NetStackHandle> Topics<NS> {
     ///
     /// This message will be sent to all matching local socket listeners, as well
     /// as on all interfaces, to be repeated outwards, in a "flood" style.
+    ///
+    /// Broadcast delivery is best-effort (at-most-once): `Ok(())` means the
+    /// message was accepted for sending, not that anyone received it, and a
+    /// broadcast with no recipients at all (no subscribers, no interface) is a
+    /// successful no-op rather than an error. See the book's
+    /// [Delivery and Reliability](crate::book::_04_delivery_and_reliability)
+    /// chapter.
     pub fn broadcast<T>(self, msg: &T::Message, name: Option<&str>) -> Result<(), NetStackSendError>
     where
         T: Topic,

--- a/crates/ergot/tests/bridge_router.rs
+++ b/crates/ergot/tests/bridge_router.rs
@@ -19,11 +19,30 @@ use std::sync::{Arc, Mutex};
 struct RecordingSink {
     log: Arc<Mutex<Vec<String>>>,
     label: &'static str,
+    fail: bool,
 }
 
 impl RecordingSink {
     fn new(label: &'static str, log: Arc<Mutex<Vec<String>>>) -> Self {
-        Self { log, label }
+        Self {
+            log,
+            label,
+            fail: false,
+        }
+    }
+
+    /// A sink whose queue is permanently "full": every send is recorded and
+    /// then refused, which `EdgePort` surfaces as `InterfaceFull`.
+    fn new_failing(label: &'static str, log: Arc<Mutex<Vec<String>>>) -> Self {
+        Self {
+            log,
+            label,
+            fail: true,
+        }
+    }
+
+    fn result(&self) -> Result<(), ()> {
+        if self.fail { Err(()) } else { Ok(()) }
     }
 }
 
@@ -36,21 +55,21 @@ impl InterfaceSink for RecordingSink {
             .lock()
             .unwrap()
             .push(format!("{}:send_ty:{}", self.label, hdr.dst));
-        Ok(())
+        self.result()
     }
     fn send_raw(&mut self, hdr: &HeaderSeq, _body: &[u8]) -> Result<(), ()> {
         self.log
             .lock()
             .unwrap()
             .push(format!("{}:send_raw:{}", self.label, hdr.dst));
-        Ok(())
+        self.result()
     }
     fn send_err(&mut self, hdr: &HeaderSeq, _err: ProtocolError) -> Result<(), ()> {
         self.log
             .lock()
             .unwrap()
             .push(format!("{}:send_err:{}", self.label, hdr.dst));
-        Ok(())
+        self.result()
     }
 }
 
@@ -483,4 +502,85 @@ fn bridge_send_err_forwards_upstream() {
     let entries = log.lock().unwrap();
     assert_eq!(entries.len(), 1);
     assert!(entries[0].starts_with("upstream:"));
+}
+
+// --- Broadcast: genuine failures vs no audience ---
+//
+// Conformance ("Broadcast Messages"): a broadcast reaching nobody is the
+// benign NoRouteToDest/RoutingLoop class (the net stack maps it to a
+// successful no-op), but a genuine delivery failure to an interface that
+// exists and was attempted (full queue) must surface as that failure.
+
+#[test]
+fn broadcast_full_everywhere_reports_genuine_failure() {
+    // Down upstream (benign: no recipient) + one Active downstream whose
+    // queue is "full": nobody got the message AND an existing interface
+    // genuinely failed — the failure must win over the benign default.
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut router = make_bridge(&log);
+    router
+        .register_interface(RecordingSink::new_failing("down0", log.clone()))
+        .unwrap();
+
+    let res = router.send(&make_broadcast_hdr(), &1234u64);
+    assert_eq!(res, Err(InterfaceSendError::InterfaceFull));
+}
+
+#[test]
+fn broadcast_partial_success_is_ok() {
+    // One full interface + one healthy one: reaching at least one recipient
+    // is success.
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut router = make_bridge(&log);
+    router
+        .register_interface(RecordingSink::new_failing("down0", log.clone()))
+        .unwrap();
+    router
+        .register_interface(RecordingSink::new("down1", log.clone()))
+        .unwrap();
+
+    router.send(&make_broadcast_hdr(), &1234u64).unwrap();
+}
+
+#[test]
+fn broadcast_no_interfaces_is_benign_no_route() {
+    // Root router with no interfaces at all: nobody to deliver to — the
+    // benign class, NOT a genuine failure.
+    let mut router: TestRouter = Router::new(rand::rngs::StdRng::from_seed([0u8; 32]));
+    let res = router.send(&make_broadcast_hdr(), &1234u64);
+    assert_eq!(res, Err(InterfaceSendError::NoRouteToDest));
+}
+
+#[test]
+fn broadcast_raw_full_everywhere_reports_genuine_failure() {
+    // Same rule on the forwarded-broadcast (send_raw) leg: a broadcast from
+    // upstream that fails on every downstream queue reports the failure.
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut router = make_bridge(&log);
+    router
+        .register_interface(RecordingSink::new_failing("down0", log.clone()))
+        .unwrap();
+
+    let hdr = HeaderSeq {
+        src: Address {
+            network_id: 10,
+            node_id: 1,
+            port_id: 0,
+        },
+        dst: Address {
+            network_id: 0,
+            node_id: 0,
+            port_id: 255,
+        },
+        any_all: Some(AnyAllAppendix {
+            key: Key(*b"TESTTEST"),
+            nash: None,
+        }),
+        seq_no: 0,
+        kind: FrameKind::TOPIC_MSG,
+        ttl: 16,
+    };
+
+    let res = router.send_raw(&hdr, &[1, 2, 3], UPSTREAM_IDENT);
+    assert_eq!(res, Err(InterfaceSendError::InterfaceFull));
 }

--- a/notes/2026-06-13-broadcast-delivery.md
+++ b/notes/2026-06-13-broadcast-delivery.md
@@ -1,0 +1,68 @@
+# Broadcast Delivery — No Audience Is Success
+
+Status: Implemented (`net_stack::inner::broadcast`)
+
+This note records a deliberate change to what a **broadcast** send returns when
+it reaches no one, and the reasoning behind it. The narrative model lives in the
+book ([`book/_04_delivery_and_reliability.rs`](../crates/ergot/src/book/_04_delivery_and_reliability.rs));
+the normative rules live in the conformance spec
+([`conformance/net_stack.rs`](../crates/ergot/src/conformance/net_stack.rs), the
+`Broadcast Messages` section). This note is the "why".
+
+## The change
+
+A topic broadcast (destination port `255`) to a stack with no local subscriber
+and no interface used to return `Err(NetStackSendError::NoRoute)` and log two
+errors. It now returns `Ok(())`.
+
+Concretely: in `inner::broadcast`, the external leg now treats a profile
+`NoRouteToDest` the same as `RoutingLoop` — a benign "no external recipient" —
+instead of an error. A genuine delivery failure to an interface that *exists*
+(e.g. `InterfaceFull`) is unchanged: it still errors and logs.
+
+## Why
+
+A broadcast is addressed to *everyone*, not to a single node, so the
+unicast-shaped error `NoRouteToDest` ("no route to *the* destination") does not
+apply to it — there is no specific destination to fail to route to. The only
+meaningful outcomes are "delivered to ≥1 recipient" and "nobody was listening".
+
+Three things make "nobody was listening = success" the right call:
+
+1. **Consistency.** `RoutingLoop` (the only interface is the source) was already
+   treated as a benign success on the same leg. "No interface at all" is the same
+   situation — no external recipient — and was inconsistently treated as an error.
+2. **At-most-once.** `Ok` from a send never meant "delivered" anyway — an accepted
+   broadcast can be dropped one hop later, and a *partial* broadcast (some
+   interfaces took it, others did not) already returned `Ok`. Singling out
+   "zero recipients" as an error draws the line at "zero vs non-zero recipients",
+   which is not the same as "delivered vs not" (which cannot be expressed).
+3. **It is the normal case.** A device that publishes telemetry whether or not a
+   host is attached broadcasts into the void constantly; that is by design, not a
+   fault worth an error and two log lines on every frame.
+
+## Impact on existing callers
+
+Audited every broadcast call-site (ergot + demos):
+
+- `net_stack::discovery` was the only place that *used* the error: an
+  `if broadcast().is_err() { return vec![] }` fast-fail. With the change that
+  short-circuit is dead, so it is removed; discovery now always listens for the
+  timeout and returns an empty result when no one answers. Same result, slightly
+  slower only in the degenerate "no interface at all" case.
+- A few demos `.unwrap()` the broadcast and would panic when broadcasting before
+  a peer connected; they now no-op silently (an improvement).
+- Every other caller (defmt logging, telemetry streams, etc.) already ignored the
+  result.
+
+No external user can reliably depend on the old behaviour, since a partial
+broadcast never reported "nobody got it" in the first place.
+
+## Tests / docs touched
+
+- `conformance/net_stack.rs`: added broadcast send cases (the table was
+  unicast-only) and the normative `Broadcast Messages` prose.
+- `book/_04_delivery_and_reliability.rs`: new chapter documenting the
+  at-most-once delivery model, the reliability ladder, idempotency-by-design,
+  liveness/`state_notify`, lossy streams, and fail-safe-by-absence.
+- Doc comments on `NetStackSendError::NoRoute` and `Topics::broadcast`.


### PR DESCRIPTION
A topic broadcast (dst port 255) has no single destination, so a profile returning NoRouteToDest — no interface, or no external recipient — is the same benign situation as RoutingLoop: there is simply nobody to deliver to. Under ergot's at-most-once delivery model that is a successful no-op, consistent with the fact that even a delivered broadcast can be dropped downstream. Previously `inner::broadcast()` logged two errors and returned `Err(NoRoute)` for it, while RoutingLoop was already treated as benign. The delivery model this rule falls out of was folklore until now, so this PR also writes it down.

- net_stack: `inner::broadcast()` treats `NoRouteToDest` on the remote leg like RoutingLoop — a successful no-op; genuine delivery failures to an existing interface (e.g. `InterfaceFull`) still error
- Router: the broadcast legs of `send()`/`send_raw()` now uphold that distinction instead of collapsing every all-legs-failed broadcast into `NoRouteToDest` — a broadcast that failed everywhere because every existing interface's queue was full reports the genuine failure (previously it would have become a silent "success" under the new no-op rule); benign no-recipient legs (down/inactive interface, routing loop, self-addressed) are still not errors. Tests pin all four cases on the real Router profile, not just the conformance mock
- conformance: fill in the missing normative "Broadcast Messages" section (the prose only covered unicast) with tests for both the no-op and the genuine-failure cases
- book: new "Delivery and Reliability" chapter — at-most-once model, what a send result does and does not mean, the at-most/at-least/effectively-once ladder, idempotency-by-design, liveness + state_notify and the interface-state reliability loop, fail-safe-by-absence for safety-critical consumers
- document `NetStackSendError::NoRoute` (previously undocumented) and the best-effort contract on `Topics::broadcast`; add a design note recording the decision and its rationale

Breaking changes: `Topics::broadcast` to zero subscribers/interfaces now returns `Ok` instead of `Err(NoRoute)`. Code that used the error to detect "nobody listening" should use discovery instead; the conformance spec now documents the no-op as normative.