### PR TITLE
Guard edge net_id (re)discovery against transit frames on a bridge upstream

### DIFF
--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -291,6 +291,22 @@ pub trait Profile {
             || node_id == crate::interface_manager::edge_port::EDGE_NODE_ID
     }
 
+    /// Check whether `net_id` names a segment this profile already routes to —
+    /// i.e., a frame addressed there that arrives on one of our interfaces is
+    /// *transit* traffic passing through, not traffic addressed to this
+    /// device's own segment.
+    ///
+    /// Used by [`EdgeFrameProcessor`] to guard net_id (re)discovery on a
+    /// bridge upstream: the dst of a transit frame names some downstream
+    /// segment and must never be adopted as the upstream's own net_id.
+    /// Profiles without transit (a single interface, nothing to route) keep
+    /// the default `false`, which preserves plain first-frame discovery.
+    ///
+    /// [`EdgeFrameProcessor`]: crate::interface_manager::profiles::direct_edge::EdgeFrameProcessor
+    fn is_transit_net(&mut self, _net_id: u16) -> bool {
+        false
+    }
+
     /// Request the refresh of a Net ID assignment from this profile
     ///
     /// For Profiles that are not (currently acting as) a Seed Router, this method will always return

--- a/crates/ergot/src/interface_manager/profiles/direct_edge.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge.rs
@@ -139,23 +139,52 @@ impl<I: Interface> Profile for DirectEdge<I> {
 
 /// Frame processor for `DirectEdge` profile.
 ///
-/// Discovers `net_id` from the first incoming frame and transitions the
-/// interface to [`InterfaceState::Active`]. Subsequent frames reuse the
-/// discovered net_id unless it changes (e.g., after reassignment).
+/// Discovers `net_id` from incoming frames and transitions the interface to
+/// [`InterfaceState::Active`]. Discovery only runs while the *window* is
+/// open — after construction or [`reset()`](crate::interface_manager::FrameProcessor::reset)
+/// (liveness timeout), while the interface is not yet Active — and only from
+/// a frame that is plausibly addressed to this device: `dst.node_id` matches
+/// our role's node_id AND the profile does not already route
+/// `dst.network_id` somewhere else ([`Profile::is_transit_net`]).
+///
+/// The guard exists for the bridge-upstream use of this processor: transit
+/// frames pass through an upstream with the dst nets of *other* segments,
+/// and a blind first-frame latch after a liveness reset could adopt a
+/// downstream segment's net_id as the upstream's own — the bridge would then
+/// emit frames src-addressed as some other device until the next lucky
+/// re-discovery. A discovered net is therefore also kept across `reset()` as
+/// a sticky hint, so the first frame after a liveness timeout — transit or
+/// not — reactivates the interface with the known net, while a frame that
+/// passes the guard may still update it (e.g. the root renumbered the
+/// segment after a reboot).
 pub struct EdgeFrameProcessor {
     net_id: Option<u16>,
+    /// Our node_id on this link: [`EDGE_NODE_ID`] in target mode,
+    /// [`CENTRAL_NODE_ID`] in controller mode. Used both to filter which
+    /// frames may donate a net_id and as the node to (re)activate with.
+    own_node: u8,
+    /// Closed (`true`) once an Active interface has been observed or
+    /// produced; while closed, frames are processed with zero profile
+    /// queries. Cleared by `reset()`.
+    activated: bool,
 }
 
 impl EdgeFrameProcessor {
     /// Create a new processor with no discovered net_id (target mode).
     pub fn new() -> Self {
-        Self { net_id: None }
+        Self {
+            net_id: None,
+            own_node: EDGE_NODE_ID,
+            activated: false,
+        }
     }
 
     /// Create a new processor with a pre-set net_id (controller mode).
     pub fn new_controller(net_id: u16) -> Self {
         Self {
             net_id: Some(net_id),
+            own_node: CENTRAL_NODE_ID,
+            activated: false,
         }
     }
 }
@@ -176,58 +205,116 @@ where
         nsh: &N,
         ident: <<N as crate::net_stack::NetStackHandle>::Profile as crate::interface_manager::Profile>::InterfaceIdent,
     ) -> bool {
-        let prev = self.net_id;
-        process_frame(&mut self.net_id, data, nsh, ident);
-        self.net_id != prev
+        process_frame(self, data, nsh, ident)
     }
 
     fn reset(&mut self) {
-        self.net_id = None;
+        // Keep net_id as a sticky hint: after a liveness timeout the next
+        // frame reactivates the interface with the known net even if it is
+        // transit, and only a frame passing the discovery guard may replace
+        // the net with a different one.
+        self.activated = false;
     }
 }
 
-/// Process one rx worker frame for direct edge workers
+/// Process one rx worker frame for direct edge workers.
+///
+/// Returns `true` if the interface state changed (activation or a net_id
+/// update) — callers use this to notify state watchers.
 pub fn process_frame<N>(
-    net_id: &mut Option<u16>,
+    state: &mut EdgeFrameProcessor,
     data: &[u8],
     nsh: &N,
     ident: <<N as NetStackHandle>::Profile as Profile>::InterfaceIdent,
-) where
+) -> bool
+where
     N: NetStackHandle,
 {
     let Some(mut frame) = de_frame(data) else {
         warn!(
             "Decode error! Ignoring frame on net_id {}",
-            net_id.unwrap_or(0)
+            state.net_id.unwrap_or(0)
         );
-        return;
+        return false;
     };
 
     debug!("{}: Got Frame!", frame.hdr);
 
-    // Discover net_id from the first incoming frame only. Once discovered,
-    // don't update — on a bridge upstream, transit frames pass through with
-    // various dst.network_ids that don't reflect this interface's net_id.
-    // After a liveness timeout, reset() clears net_id to None, allowing
-    // re-discovery on the next frame.
-    let take_net = net_id.is_none() && frame.hdr.dst.network_id != 0;
+    let mut state_changed = false;
 
-    if take_net {
-        let ok = nsh.stack().manage_profile(|im| {
-            im.set_interface_state(
-                ident.clone(),
-                InterfaceState::Active {
-                    net_id: frame.hdr.dst.network_id,
-                    node_id: EDGE_NODE_ID,
-                },
+    // Discovery / reactivation window: open after construction or reset()
+    // (liveness timeout). In steady state (`activated`) frames are processed
+    // with no profile queries at all.
+    if !state.activated {
+        let dst = frame.hdr.dst;
+        let (if_state, dst_is_transit) = nsh.stack().manage_profile(|im| {
+            (
+                im.interface_state(ident.clone()),
+                im.is_transit_net(dst.network_id),
             )
-            .is_ok()
         });
-        if ok {
-            *net_id = Some(frame.hdr.dst.network_id);
-        } else {
-            warn!("Failed to set interface state from frame (wrong node_id?), dropping");
-            return;
+
+        match if_state {
+            // Already Active with a real net (pre-activated by registration
+            // code or reassigned by a seed router): adopt it, close the window.
+            Some(InterfaceState::Active { net_id, .. }) if net_id != 0 => {
+                state.net_id = Some(net_id);
+                state.activated = true;
+            }
+            // Not yet fully active: Inactive/Down after a liveness timeout or
+            // at boot, or the link-local placeholder `Active{net_id: 0}` a
+            // bridge upstream starts with.
+            Some(
+                InterfaceState::Active { .. } | InterfaceState::Inactive | InterfaceState::Down,
+            ) => {
+                // A frame may donate its dst as our net_id only if it is
+                // plausibly addressed to us: a real net, our own node, and
+                // not a segment the profile already routes (transit traffic
+                // on a bridge upstream carries downstream dst nets).
+                let donates =
+                    dst.network_id != 0 && dst.node_id == state.own_node && !dst_is_transit;
+
+                let new_net = if donates {
+                    Some(dst.network_id)
+                } else {
+                    // Sticky reactivation: a non-donating frame (e.g.
+                    // transit) still proves the link is alive, so bring the
+                    // interface back up with the previously known net.
+                    state.net_id
+                };
+
+                if let Some(net) = new_net {
+                    let ok = nsh.stack().manage_profile(|im| {
+                        im.set_interface_state(
+                            ident.clone(),
+                            InterfaceState::Active {
+                                net_id: net,
+                                node_id: state.own_node,
+                            },
+                        )
+                        .is_ok()
+                    });
+                    if ok {
+                        state.net_id = Some(net);
+                        state.activated = true;
+                        state_changed = true;
+                    } else {
+                        warn!("Failed to set interface state from frame, dropping");
+                        return state_changed;
+                    }
+                }
+                // No net known and the frame doesn't qualify: keep the window
+                // open and process the frame with link-local addressing.
+            }
+            // Bus-style local-only state is managed by the claim protocol;
+            // close the window and leave it alone.
+            Some(InterfaceState::ActiveLocal { .. }) => {
+                state.activated = true;
+            }
+            None => {
+                warn!("Frame for unknown interface, dropping");
+                return state_changed;
+            }
         }
     }
 
@@ -236,19 +323,19 @@ pub fn process_frame<N>(
     // local packet.
     //
     // TODO: accept any packet if we don't have a net_id yet?
-    if let Some(net) = net_id.as_ref()
+    if let Some(net) = state.net_id.as_ref()
         && frame.hdr.src.network_id == 0
     {
         if frame.hdr.src.node_id == 0 {
             warn!("Dropping frame with src node_id 0 (stale or local packet received remotely)");
-            return;
+            return state_changed;
         }
-        if frame.hdr.src.node_id == EDGE_NODE_ID {
+        if frame.hdr.src.node_id == state.own_node {
             warn!(
                 "Dropping frame with src node_id {} (spoofed as us)",
-                EDGE_NODE_ID
+                state.own_node
             );
-            return;
+            return state_changed;
         }
 
         frame.hdr.src.network_id = *net;
@@ -276,4 +363,6 @@ pub fn process_frame<N>(
             warn!("send error: {:?}", e);
         }
     }
+
+    state_changed
 }

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -953,6 +953,17 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             .get(node_id, net_id)
             .is_some_and(|e| e.kind.is_active(Instant::now()))
     }
+
+    fn is_transit_net(&mut self, net_id: u16) -> bool {
+        if net_id == 0 {
+            return false;
+        }
+        // Direct downstream segments (pending slots hold net_id=0 and are
+        // excluded by the check above) and seed-assigned routes. Tombstoned
+        // seed routes count too: a recently expired downstream net is still
+        // known-not-ours and must not be adopted as the upstream's own.
+        self.slots.iter().any(|s| s.net_id == net_id) || self.seed_routes.contains_key(net_id)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -958,6 +958,12 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         if net_id == 0 {
             return false;
         }
+        // `LeaseTable` GC is lazy. Without collecting here, a tombstone whose
+        // grace period has already elapsed can still make a newly renumbered
+        // upstream look like transit traffic. `EdgeFrameProcessor` would then
+        // reactivate with its sticky old net_id and close the discovery window
+        // before the later routing lookup gets a chance to collect the entry.
+        self.seed_routes.gc(Instant::now());
         // Direct downstream segments (pending slots hold net_id=0 and are
         // excluded by the check above) and seed-assigned routes. Tombstoned
         // seed routes count too: a recently expired downstream net is still
@@ -1016,6 +1022,42 @@ impl RouterFrameProcessor {
             net_id,
             activated: false,
         }
+    }
+}
+
+#[cfg(all(test, feature = "tokio-std"))]
+mod tests {
+    use super::*;
+    use crate::interface_manager::interface_impls::tokio_stream::TokioStreamInterface;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    #[test]
+    fn transit_check_collects_seed_tombstones_after_grace() {
+        const NET_ID: u16 = 42;
+        let mut router: Router<TokioStreamInterface, StdRng, 1, 1> =
+            Router::new(StdRng::seed_from_u64(0));
+
+        assert!(router.seed_routes.push(
+            NET_ID,
+            1,
+            0,
+            LeaseKind::Tombstone {
+                clear_time: Instant::now() + Duration::from_secs(60),
+            },
+        ));
+        assert!(
+            router.is_transit_net(NET_ID),
+            "a tombstone inside its grace period must remain transit"
+        );
+
+        router.seed_routes.entries[0].kind = LeaseKind::Tombstone {
+            clear_time: Instant::now(),
+        };
+        assert!(
+            !router.is_transit_net(NET_ID),
+            "a tombstone past its grace period must not block upstream rediscovery"
+        );
+        assert!(router.seed_routes.entries.is_empty());
     }
 }
 

--- a/crates/ergot/tests/edge_rediscovery.rs
+++ b/crates/ergot/tests/edge_rediscovery.rs
@@ -1,0 +1,324 @@
+//! EdgeFrameProcessor net_id (re)discovery guards.
+//!
+//! On a bridge upstream, the first frame after a liveness reset used to be
+//! trusted blindly: a transit frame (root → some downstream segment) could
+//! donate its dst net, and the upstream adopted another segment's net_id as
+//! its own ("mislatch") — the bridge then emitted frames src-addressed as a
+//! device on that segment, misrouting replies (including seed lease refresh
+//! responses) until the next lucky re-discovery. Discovery is now guarded by
+//! `Profile::is_transit_net` + a node match, and a known net is sticky
+//! across `reset()` so transit frames reactivate the interface instead of
+//! hijacking its identity.
+
+#![cfg(feature = "tokio-std")]
+#![cfg(not(miri))]
+
+use ergot::{
+    Address, FrameKind, HeaderSeq,
+    interface_manager::{
+        FrameProcessor, Interface, InterfaceSink, InterfaceState, Profile,
+        profiles::{
+            direct_edge::{CENTRAL_NODE_ID, DirectEdge, EDGE_NODE_ID, EdgeFrameProcessor},
+            router::{Router, UPSTREAM_IDENT},
+        },
+    },
+    net_stack::ArcNetStack,
+    wire_frames,
+};
+use mutex::raw_impls::cs::CriticalSectionRawMutex;
+use rand::SeedableRng;
+use serde::Serialize;
+
+// --- Sink that accepts everything ---
+
+#[derive(Clone)]
+struct NullSink;
+
+impl InterfaceSink for NullSink {
+    fn mtu(&self) -> u16 {
+        2048
+    }
+    fn send_ty<T: Serialize>(&mut self, _hdr: &HeaderSeq, _body: &T) -> Result<(), ()> {
+        Ok(())
+    }
+    fn send_raw(&mut self, _hdr: &HeaderSeq, _body: &[u8]) -> Result<(), ()> {
+        Ok(())
+    }
+    fn send_err(&mut self, _hdr: &HeaderSeq, _err: ergot::ProtocolError) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
+struct MockInterface;
+impl Interface for MockInterface {
+    type Sink = NullSink;
+}
+
+type BridgeRouter = Router<MockInterface, rand::rngs::StdRng, 4, 8>;
+type BridgeStack = ArcNetStack<CriticalSectionRawMutex, BridgeRouter>;
+
+type EdgeProfile = DirectEdge<MockInterface>;
+type EdgeStack = ArcNetStack<CriticalSectionRawMutex, EdgeProfile>;
+
+/// A frame from the root (net 10, CENTRAL) to `dst`, as seen by an upstream
+/// RX worker.
+fn frame_to(dst_net: u16, dst_node: u8) -> Vec<u8> {
+    let hdr = HeaderSeq {
+        src: Address {
+            network_id: 10,
+            node_id: CENTRAL_NODE_ID,
+            port_id: 1,
+        },
+        dst: Address {
+            network_id: dst_net,
+            node_id: dst_node,
+            port_id: 5,
+        },
+        any_all: None,
+        seq_no: 0,
+        kind: FrameKind::ENDPOINT_REQ,
+        ttl: 16,
+    };
+    wire_frames::encode_frame_ty(postcard::ser_flavors::StdVec::new(), &hdr, &42u32).unwrap()
+}
+
+/// Bridge stack with one downstream slot (net 1) and one seed route (net 2).
+/// The upstream's "real" net, as the root would assign it, is 7 in these
+/// tests — deliberately absent from the bridge's own tables.
+fn bridge_stack() -> BridgeStack {
+    let stack: BridgeStack = BridgeStack::new_with_profile(Router::new_bridge(
+        rand::rngs::StdRng::from_seed([0u8; 32]),
+        NullSink,
+    ));
+    let slot_ident = stack
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let slot_net = stack.manage_profile(|im| im.net_id_of(slot_ident)).unwrap();
+    assert_eq!(slot_net, 1);
+    let seed = stack
+        .manage_profile(|im| im.request_seed_net_assign(slot_net))
+        .unwrap();
+    assert_eq!(seed.net_id, 2);
+    stack
+}
+
+fn upstream_state(stack: &BridgeStack) -> InterfaceState {
+    stack
+        .manage_profile(|im| im.interface_state(UPSTREAM_IDENT))
+        .unwrap()
+}
+
+/// `FrameProcessor::reset` is generic over the stack handle, so a bare
+/// `proc.reset()` can't infer `N` — qualify it.
+fn reset_bridge_proc(p: &mut EdgeFrameProcessor) {
+    <EdgeFrameProcessor as FrameProcessor<BridgeStack>>::reset(p);
+}
+
+fn reset_edge_proc(p: &mut EdgeFrameProcessor) {
+    <EdgeFrameProcessor as FrameProcessor<EdgeStack>>::reset(p);
+}
+
+#[test]
+fn router_transit_nets_are_slots_and_seed_routes() {
+    let stack = bridge_stack();
+    stack.manage_profile(|im| {
+        assert!(im.is_transit_net(1), "downstream slot net is transit");
+        assert!(im.is_transit_net(2), "seed-assigned net is transit");
+        assert!(!im.is_transit_net(7), "the upstream's own net is not");
+        assert!(!im.is_transit_net(0), "link-local is never transit");
+    });
+}
+
+#[test]
+fn boot_discovery_latches_only_from_bridge_addressed_frames() {
+    let stack = bridge_stack();
+    // Canonical upstream boot state: link-local placeholder.
+    stack
+        .manage_profile(|im| {
+            im.set_interface_state(
+                UPSTREAM_IDENT,
+                InterfaceState::Active {
+                    net_id: 0,
+                    node_id: EDGE_NODE_ID,
+                },
+            )
+        })
+        .unwrap();
+    let mut proc = EdgeFrameProcessor::new();
+
+    // A transit frame arriving first at boot must NOT latch.
+    let changed = proc.process_frame(&frame_to(1, EDGE_NODE_ID), &stack, UPSTREAM_IDENT);
+    assert!(!changed);
+    assert!(
+        matches!(
+            upstream_state(&stack),
+            InterfaceState::Active { net_id: 0, .. }
+        ),
+        "transit frame at boot must not donate a net_id"
+    );
+
+    // A bridge-addressed frame latches the real upstream net.
+    let changed = proc.process_frame(&frame_to(7, EDGE_NODE_ID), &stack, UPSTREAM_IDENT);
+    assert!(changed);
+    assert!(matches!(
+        upstream_state(&stack),
+        InterfaceState::Active { net_id: 7, .. }
+    ));
+
+    // Steady state: later transit frames change nothing.
+    let changed = proc.process_frame(&frame_to(2, EDGE_NODE_ID), &stack, UPSTREAM_IDENT);
+    assert!(!changed);
+    assert!(matches!(
+        upstream_state(&stack),
+        InterfaceState::Active { net_id: 7, .. }
+    ));
+}
+
+/// The mislatch regression: after a liveness reset, a transit frame arriving
+/// first must reactivate the upstream with its OLD net, not hijack it.
+#[test]
+fn transit_frame_after_reset_reactivates_instead_of_hijacking() {
+    let stack = bridge_stack();
+    stack
+        .manage_profile(|im| {
+            im.set_interface_state(
+                UPSTREAM_IDENT,
+                InterfaceState::Active {
+                    net_id: 0,
+                    node_id: EDGE_NODE_ID,
+                },
+            )
+        })
+        .unwrap();
+    let mut proc = EdgeFrameProcessor::new();
+    proc.process_frame(&frame_to(7, EDGE_NODE_ID), &stack, UPSTREAM_IDENT);
+    assert!(matches!(
+        upstream_state(&stack),
+        InterfaceState::Active { net_id: 7, .. }
+    ));
+
+    for transit_net in [1u16, 2] {
+        // Liveness timeout: the RX worker marks the interface Inactive and
+        // resets the processor.
+        stack
+            .manage_profile(|im| im.set_interface_state(UPSTREAM_IDENT, InterfaceState::Inactive))
+            .unwrap();
+        reset_bridge_proc(&mut proc);
+
+        // First frame after the quiet period is transit (root → downstream
+        // segment). The old blind latch adopted `transit_net` here.
+        let changed =
+            proc.process_frame(&frame_to(transit_net, EDGE_NODE_ID), &stack, UPSTREAM_IDENT);
+        assert!(changed, "reactivation is a state change");
+        assert!(
+            matches!(
+                upstream_state(&stack),
+                InterfaceState::Active { net_id: 7, .. }
+            ),
+            "upstream must keep its own net_id, not adopt transit net {transit_net}"
+        );
+    }
+}
+
+/// Renumbering: after a reset, a bridge-addressed frame with a DIFFERENT
+/// (non-transit) net updates the upstream — e.g. the root rebooted and
+/// assigned this segment a new net_id.
+#[test]
+fn rediscovery_accepts_renumbered_upstream_net() {
+    let stack = bridge_stack();
+    stack
+        .manage_profile(|im| {
+            im.set_interface_state(
+                UPSTREAM_IDENT,
+                InterfaceState::Active {
+                    net_id: 0,
+                    node_id: EDGE_NODE_ID,
+                },
+            )
+        })
+        .unwrap();
+    let mut proc = EdgeFrameProcessor::new();
+    proc.process_frame(&frame_to(7, EDGE_NODE_ID), &stack, UPSTREAM_IDENT);
+
+    stack
+        .manage_profile(|im| im.set_interface_state(UPSTREAM_IDENT, InterfaceState::Inactive))
+        .unwrap();
+    reset_bridge_proc(&mut proc);
+
+    let changed = proc.process_frame(&frame_to(9, EDGE_NODE_ID), &stack, UPSTREAM_IDENT);
+    assert!(changed);
+    assert!(matches!(
+        upstream_state(&stack),
+        InterfaceState::Active { net_id: 9, .. }
+    ));
+}
+
+/// Frames addressed to the far side's node (CENTRAL, from an edge's point of
+/// view) never donate a net — only frames addressed to us do.
+#[test]
+fn frames_to_other_nodes_do_not_donate_a_net() {
+    let stack = bridge_stack();
+    stack
+        .manage_profile(|im| im.set_interface_state(UPSTREAM_IDENT, InterfaceState::Inactive))
+        .unwrap();
+    let mut proc = EdgeFrameProcessor::new();
+
+    let changed = proc.process_frame(&frame_to(7, CENTRAL_NODE_ID), &stack, UPSTREAM_IDENT);
+    assert!(!changed);
+    assert!(matches!(upstream_state(&stack), InterfaceState::Inactive));
+}
+
+/// A controller-mode edge must reactivate as CENTRAL after a liveness reset.
+/// The old code cleared the net on reset and re-latched from the next frame
+/// with `node_id: EDGE`, silently corrupting the controller's own node.
+#[test]
+fn controller_reactivates_as_central() {
+    let stack: EdgeStack = EdgeStack::new_with_profile(DirectEdge::new_controller(
+        NullSink,
+        InterfaceState::Active {
+            net_id: 5,
+            node_id: CENTRAL_NODE_ID,
+        },
+    ));
+    let mut proc = EdgeFrameProcessor::new_controller(5);
+
+    // Liveness timeout on the controller side.
+    stack
+        .manage_profile(|im| im.set_interface_state((), InterfaceState::Inactive))
+        .unwrap();
+    reset_edge_proc(&mut proc);
+
+    // Frame from the target (addressed to us, the controller).
+    let hdr = HeaderSeq {
+        src: Address {
+            network_id: 5,
+            node_id: EDGE_NODE_ID,
+            port_id: 1,
+        },
+        dst: Address {
+            network_id: 5,
+            node_id: CENTRAL_NODE_ID,
+            port_id: 5,
+        },
+        any_all: None,
+        seq_no: 0,
+        kind: FrameKind::ENDPOINT_REQ,
+        ttl: 16,
+    };
+    let frame =
+        wire_frames::encode_frame_ty(postcard::ser_flavors::StdVec::new(), &hdr, &42u32).unwrap();
+
+    let changed = proc.process_frame(&frame, &stack, ());
+    assert!(changed);
+    let state = stack.manage_profile(|im| im.interface_state(())).unwrap();
+    assert!(
+        matches!(
+            state,
+            InterfaceState::Active {
+                net_id: 5,
+                node_id: CENTRAL_NODE_ID,
+            }
+        ),
+        "controller must come back as CENTRAL, got {state:?}"
+    );
+}


### PR DESCRIPTION
`EdgeFrameProcessor` discovers its net_id from the dst of the first incoming frame, and a liveness-timeout `reset()` clears the net to allow re-discovery. On a leaf that is sound — every frame a leaf receives is addressed to it. On a bridge upstream (the processor `register_bridge_upstream` uses) it is not: transit frames pass through carrying the dst nets of *downstream* segments, and if the first frame after a quiet period is transit — root → a downstream device, the dominant traffic pattern — the upstream adopts that segment's net_id as its own. The bridge then emits frames src-addressed as a device on its own downstream segment; replies to the bridge, including seed lease refresh responses, get routed back down to that device, the lease expires, and the whole downstream segment goes unroutable until a lucky re-discovery. Boot is protected by protocol ordering (no seed routes exist before the bridge itself gets addressed), so the hole is specifically post-reset re-discovery; the existing e2e tests all run with `liveness: None` and bootstrap with a root→bridge ping, so the case was never exercised.

- Discovery now runs only inside an explicit window — after construction or `reset()`, while the interface is not Active with a real net — and only accepts a donor frame plausibly addressed to us: nonzero dst net, our own node_id, and not a segment the profile already routes
- New `Profile::is_transit_net()` hook with a `false` default, so single-interface profiles keep plain first-frame discovery; `Router` implements it over its direct slots and seed routes. Lazy lease GC runs before classification, so live tombstones remain known-not-ours while tombstones past their grace period cannot block a legitimately renumbered upstream
- A discovered net is sticky across `reset()`: the first frame after a liveness timeout reactivates the interface with the known net even when that frame is transit, while a frame passing the guard may still update the net (e.g. the root rebooted and renumbered the segment)
- Fixes a latent controller-mode bug on the way: the processor records its role's node_id (EDGE for `new()`, CENTRAL for `new_controller()`), where the old post-reset re-latch would have reactivated a controller edge as node EDGE, corrupting its own address
- In steady state the window is closed and frames are processed with zero profile queries, same as before
- Tests pin the whole matrix on real profiles: boot latch ignores transit, post-reset transit reactivates instead of hijacking (slot and seed nets), renumbering is accepted, frames to other nodes never donate, controller comes back as CENTRAL, and `Router::is_transit_net` preserves in-grace tombstones while collecting elapsed ones

Breaking changes: the free `direct_edge::process_frame()` now takes `&mut EdgeFrameProcessor` instead of `&mut Option<u16>` and returns `bool` (state changed); the `FrameProcessor` impl is unchanged in shape, so transports and profiles are unaffected.
