### PR TITLE
Delegate hierarchical seed leases through bridge routers

### DIFF
--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -115,6 +115,16 @@ pub struct SeedLease {
     pub min_refresh_seconds: u16,
 }
 
+/// Result of validating a delegated refresh request.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DelegatedRefreshPreparation {
+    /// Contact the parent seed router with the stored lease.
+    Forward(SeedLease),
+    /// The caller retried the immediately previous token after losing the
+    /// response; replay the already-committed assignment without upstream I/O.
+    Replay(SeedNetAssignment),
+}
+
 /// An error occurred when assigning a net ID
 #[derive(Serialize, Deserialize, Schema, Debug, PartialEq, Clone)]
 pub enum SeedAssignmentError {
@@ -124,6 +134,10 @@ pub enum SeedAssignmentError {
     NetIdsExhausted,
     /// The source ID requesting the Net ID is unknown to this seed router
     UnknownSource,
+    /// An upstream seed router required for delegation is temporarily unavailable
+    UpstreamUnavailable,
+    /// Another delegation hop would exhaust the refresh timing margin
+    DelegationDepthExceeded,
 }
 
 /// A successful node_id claim assignment from a router on a bus-style interface
@@ -193,6 +207,10 @@ pub enum SeedRefreshError {
     BadRequest,
     /// The request to refresh violated the min_refresh_seconds time
     TooSoon,
+    /// An upstream seed router required for delegation is temporarily unavailable
+    UpstreamUnavailable,
+    /// The refreshed parent lease no longer leaves room for another safe hop
+    DelegationDepthExceeded,
 }
 
 // An interface send is very similar to a socket send, with the exception
@@ -367,15 +385,16 @@ pub trait Profile {
         Err(SeedAssignmentError::ProfileCantSeed)
     }
 
-    /// Validate a delegated refresh request and return the stored parent
-    /// lease without changing either lease. Called before upstream I/O, so a
-    /// bad requester or token cannot trigger traffic to the parent seed router.
+    /// Validate a delegated refresh request. A current token returns the stored
+    /// parent lease for forwarding; the immediately previous token replays the
+    /// last committed response after response loss. Called before upstream I/O,
+    /// so a bad requester or token cannot trigger traffic to the parent router.
     fn prepare_delegated_refresh(
         &mut self,
         source_net: u16,
         refresh_net: u16,
         refresh_token: [u8; 8],
-    ) -> Result<SeedLease, SeedRefreshError> {
+    ) -> Result<DelegatedRefreshPreparation, SeedRefreshError> {
         _ = source_net;
         _ = refresh_net;
         _ = refresh_token;

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -321,6 +321,18 @@ pub trait Profile {
         None
     }
 
+    /// Pre-flight check, run *before* a net_id is leased from the upstream
+    /// seed router: verify `source_net` is a known direct downstream and
+    /// there is room to register a delegated route. Returns the same error
+    /// [`register_delegated_seed_net`] would, so a doomed request is rejected
+    /// without stranding an upstream lease (which only frees on expiry).
+    ///
+    /// [`register_delegated_seed_net`]: Profile::register_delegated_seed_net
+    fn can_delegate_seed(&mut self, source_net: u16) -> Result<(), SeedAssignmentError> {
+        _ = source_net;
+        Err(SeedAssignmentError::ProfileCantSeed)
+    }
+
     /// Register a seed route for `net_id`, which was leased from the
     /// upstream seed router on behalf of the requester reachable via the
     /// interface serving `source_net`. `granted` is the upstream lease;

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -105,6 +105,8 @@ pub struct SeedLease {
     pub net_id: u16,
     /// Address to send refresh requests to.
     pub refresh_addr: crate::Address,
+    /// Address to send an explicit release request to.
+    pub release_addr: crate::Address,
     /// Current refresh token issued by the parent seed router.
     pub refresh_token: [u8; 8],
     /// Lease duration in seconds.
@@ -138,6 +140,8 @@ pub enum SeedAssignmentError {
     UpstreamUnavailable,
     /// Another delegation hop would exhaust the refresh timing margin
     DelegationDepthExceeded,
+    /// The parent assigned a net_id already used by this bridge
+    NetIdCollision,
 }
 
 /// A successful node_id claim assignment from a router on a bus-style interface
@@ -416,6 +420,46 @@ pub trait Profile {
         Err(SeedRefreshError::ProfileCantSeed)
     }
 
+    /// Validate a delegated release and return the parent lease that must be
+    /// released before the local route is removed.
+    fn prepare_delegated_release(
+        &mut self,
+        source_net: u16,
+        release_net: u16,
+        refresh_token: [u8; 8],
+    ) -> Result<SeedLease, SeedRefreshError> {
+        _ = source_net;
+        _ = release_net;
+        _ = refresh_token;
+        Err(SeedRefreshError::ProfileCantSeed)
+    }
+
+    /// Remove a delegated route after its parent lease was released.
+    fn commit_delegated_release(
+        &mut self,
+        source_net: u16,
+        release_net: u16,
+        refresh_token: [u8; 8],
+    ) -> Result<(), SeedRefreshError> {
+        _ = source_net;
+        _ = release_net;
+        _ = refresh_token;
+        Err(SeedRefreshError::ProfileCantSeed)
+    }
+
+    /// Explicitly release a root-owned seed assignment.
+    fn release_seed_net_assignment(
+        &mut self,
+        source_net: u16,
+        release_net: u16,
+        refresh_token: [u8; 8],
+    ) -> Result<(), SeedRefreshError> {
+        _ = source_net;
+        _ = release_net;
+        _ = refresh_token;
+        Err(SeedRefreshError::ProfileCantSeed)
+    }
+
     fn refresh_seed_net_assignment(
         &mut self,
         source_net: u16,
@@ -526,6 +570,7 @@ pub enum RegisterSinkError {
 pub enum SetStateError {
     InterfaceNotFound,
     InvalidNodeId,
+    NetIdInUse,
 }
 
 impl InterfaceSendError {

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -97,6 +97,24 @@ pub struct SeedNetAssignment {
     pub refresh_token: [u8; 8],
 }
 
+/// A seed lease held by a bridge, including the address of the parent seed
+/// router that must be contacted to refresh it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SeedLease {
+    /// The assigned net_id.
+    pub net_id: u16,
+    /// Address to send refresh requests to.
+    pub refresh_addr: crate::Address,
+    /// Current refresh token issued by the parent seed router.
+    pub refresh_token: [u8; 8],
+    /// Lease duration in seconds.
+    pub expires_seconds: u16,
+    /// Maximum refresh interval in seconds.
+    pub max_refresh_seconds: u16,
+    /// Minimum time before expiration to refresh.
+    pub min_refresh_seconds: u16,
+}
+
 /// An error occurred when assigning a net ID
 #[derive(Serialize, Deserialize, Schema, Debug, PartialEq, Clone)]
 pub enum SeedAssignmentError {
@@ -333,51 +351,49 @@ pub trait Profile {
         Err(SeedAssignmentError::ProfileCantSeed)
     }
 
-    /// Register a seed route for `net_id`, which was leased from the
-    /// upstream seed router on behalf of the requester reachable via the
-    /// interface serving `source_net`. `granted` is the upstream lease;
+    /// Register a seed route leased from the upstream seed router on behalf
+    /// of the requester reachable via the interface serving `source_net`.
+    /// `parent` is the complete upstream lease and is stored with the route;
     /// implementations return their own assignment (fresh local token, and
     /// a `min_refresh_seconds` reduced by a margin so the downstream
     /// refresh always lands inside the upstream refresh window).
     fn register_delegated_seed_net(
         &mut self,
-        net_id: u16,
         source_net: u16,
-        granted: &SeedNetAssignment,
+        parent: &SeedLease,
     ) -> Result<SeedNetAssignment, SeedAssignmentError> {
-        _ = net_id;
         _ = source_net;
-        _ = granted;
+        _ = parent;
         Err(SeedAssignmentError::ProfileCantSeed)
     }
 
-    /// Validate a refresh request for a delegated seed route (existence,
-    /// requester net, token) *without* refreshing it — called before the
-    /// upstream lease is refreshed, so bad requests cannot trigger
-    /// upstream traffic.
-    fn validate_delegated_refresh(
+    /// Validate a delegated refresh request and return the stored parent
+    /// lease without changing either lease. Called before upstream I/O, so a
+    /// bad requester or token cannot trigger traffic to the parent seed router.
+    fn prepare_delegated_refresh(
         &mut self,
         source_net: u16,
         refresh_net: u16,
         refresh_token: [u8; 8],
-    ) -> Result<(), SeedRefreshError> {
+    ) -> Result<SeedLease, SeedRefreshError> {
         _ = source_net;
         _ = refresh_net;
         _ = refresh_token;
         Err(SeedRefreshError::ProfileCantSeed)
     }
 
-    /// Extend a delegated seed route after its upstream lease was
-    /// successfully refreshed. `granted` is the refreshed upstream lease.
-    fn refresh_delegated_seed_net(
+    /// Commit an upstream refresh: replace the stored parent lease, extend
+    /// the delegated route, and rotate the downstream token. The old token is
+    /// checked again so an async refresh cannot commit into a changed route.
+    fn commit_delegated_refresh(
         &mut self,
         source_net: u16,
         refresh_token: [u8; 8],
-        granted: &SeedNetAssignment,
+        refreshed_parent: &SeedLease,
     ) -> Result<SeedNetAssignment, SeedRefreshError> {
         _ = source_net;
         _ = refresh_token;
-        _ = granted;
+        _ = refreshed_parent;
         Err(SeedRefreshError::ProfileCantSeed)
     }
 

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -311,6 +311,64 @@ pub trait Profile {
     ///
     /// For Profiles that are not (currently acting as) a Seed Router, this method will always return
     /// an error.
+    /// If this profile should *delegate* seed assignments to an upstream
+    /// seed router (i.e. it is a bridge), returns the upstream interface.
+    ///
+    /// When this returns `Some`, the seed handler forwards assignment and
+    /// refresh requests up the tree instead of allocating from a local pool,
+    /// so the root remains the single owner of the net-id space.
+    fn seed_delegation_upstream(&self) -> Option<Self::InterfaceIdent> {
+        None
+    }
+
+    /// Register a seed route for `net_id`, which was leased from the
+    /// upstream seed router on behalf of the requester reachable via the
+    /// interface serving `source_net`. `granted` is the upstream lease;
+    /// implementations return their own assignment (fresh local token, and
+    /// a `min_refresh_seconds` reduced by a margin so the downstream
+    /// refresh always lands inside the upstream refresh window).
+    fn register_delegated_seed_net(
+        &mut self,
+        net_id: u16,
+        source_net: u16,
+        granted: &SeedNetAssignment,
+    ) -> Result<SeedNetAssignment, SeedAssignmentError> {
+        _ = net_id;
+        _ = source_net;
+        _ = granted;
+        Err(SeedAssignmentError::ProfileCantSeed)
+    }
+
+    /// Validate a refresh request for a delegated seed route (existence,
+    /// requester net, token) *without* refreshing it — called before the
+    /// upstream lease is refreshed, so bad requests cannot trigger
+    /// upstream traffic.
+    fn validate_delegated_refresh(
+        &mut self,
+        source_net: u16,
+        refresh_net: u16,
+        refresh_token: [u8; 8],
+    ) -> Result<(), SeedRefreshError> {
+        _ = source_net;
+        _ = refresh_net;
+        _ = refresh_token;
+        Err(SeedRefreshError::ProfileCantSeed)
+    }
+
+    /// Extend a delegated seed route after its upstream lease was
+    /// successfully refreshed. `granted` is the refreshed upstream lease.
+    fn refresh_delegated_seed_net(
+        &mut self,
+        source_net: u16,
+        refresh_token: [u8; 8],
+        granted: &SeedNetAssignment,
+    ) -> Result<SeedNetAssignment, SeedRefreshError> {
+        _ = source_net;
+        _ = refresh_token;
+        _ = granted;
+        Err(SeedRefreshError::ProfileCantSeed)
+    }
+
     fn refresh_seed_net_assignment(
         &mut self,
         source_net: u16,

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -48,14 +48,27 @@ const MIN_REFRESH_SECS: u16 = 62;
 /// the parent's own upstream refresh is accepted.
 const SEED_DELEGATION_REFRESH_MARGIN: u16 = 5;
 
-fn delegated_assignment(parent: &SeedLease, refresh_token: u64) -> SeedNetAssignment {
+fn delegated_assignment(
+    parent: &SeedLease,
+    refresh_token: u64,
+    expires_seconds: u16,
+) -> SeedNetAssignment {
     SeedNetAssignment {
         net_id: parent.net_id,
-        expires_seconds: parent.expires_seconds,
+        expires_seconds,
         max_refresh_seconds: parent.max_refresh_seconds,
         min_refresh_seconds: parent.min_refresh_seconds - SEED_DELEGATION_REFRESH_MARGIN,
         refresh_token: refresh_token.to_le_bytes(),
     }
+}
+
+fn remaining_lease_seconds(expiration: Instant, now: Instant) -> u16 {
+    let remaining = expiration - now;
+    let whole_seconds = remaining.as_secs();
+    let rounded_up = whole_seconds.saturating_add(u64::from(
+        remaining > Duration::from_secs(whole_seconds),
+    ));
+    rounded_up.min(u16::MAX as u64) as u16
 }
 
 /// Tombstone duration — how long a revoked net_id/node_id stays reserved,
@@ -144,14 +157,15 @@ impl LeaseKind {
 
     /// Refresh an active lease: verify the token, reject if expired (tombstoning
     /// it) or too soon, otherwise extend to `MAX_LEASE_SECS` and rotate
-    /// the token to `new_token`. Returns the renewed lease.
+    /// the token to `new_token`. Returns the renewed lease and whether this
+    /// was an idempotent replay rather than a new extension.
     fn refresh(
         &mut self,
         req_token: u64,
         now: Instant,
         new_token: u64,
         allow_replay: bool,
-    ) -> Result<Lease, RefreshDenied> {
+    ) -> Result<(Lease, bool), RefreshDenied> {
         match self {
             LeaseKind::Tombstone { .. } => Err(RefreshDenied::Expired),
             LeaseKind::Active(lease) => {
@@ -169,7 +183,7 @@ impl LeaseKind {
                     return Err(RefreshDenied::Expired);
                 }
                 if is_replay {
-                    return Ok(*lease);
+                    return Ok((*lease, true));
                 }
                 if lease.expiration - now > Duration::from_secs(MIN_REFRESH_SECS as u64) {
                     return Err(RefreshDenied::TooSoon);
@@ -177,7 +191,7 @@ impl LeaseKind {
                 lease.expiration = now + Duration::from_secs(MAX_LEASE_SECS as u64);
                 lease.previous_refresh_token = allow_replay.then_some(lease.refresh_token);
                 lease.refresh_token = new_token;
-                Ok(*lease)
+                Ok((*lease, false))
             }
         }
     }
@@ -258,6 +272,13 @@ impl<K: Copy + Eq, X, const N: usize> LeaseTable<K, X, N> {
         self.entries.retain(|e| e.key != key);
     }
 
+    fn remove(&mut self, key: K, scope: u16) -> bool {
+        let old_len = self.entries.len();
+        self.entries
+            .retain(|entry| entry.key != key || entry.scope != scope);
+        self.entries.len() != old_len
+    }
+
     /// Push a new entry. Returns `false` if the table is full.
     fn push(&mut self, key: K, scope: u16, extra: X, kind: LeaseKind) -> bool {
         self.entries
@@ -329,6 +350,8 @@ pub enum RegisterError {
     Full,
     /// No free net_id is available (every net_id in `1..u16::MAX` is in use).
     NetIdsExhausted,
+    /// Bridge downlinks must start pending and receive a root-issued net_id.
+    BridgeRequiresSeedAssignment,
 }
 
 /// Errors from [`Router::deregister_interface`].
@@ -409,6 +432,9 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize>
     ///
     /// Returns the assigned ident on success.
     pub fn register_interface(&mut self, sink: I::Sink) -> Result<u8, RegisterError> {
+        if self.has_upstream() {
+            return Err(RegisterError::BridgeRequiresSeedAssignment);
+        }
         // Reclaim net_ids from cleared seed-route tombstones before allocating.
         self.seed_routes.gc(Instant::now());
         if self.slots.is_full() {
@@ -808,6 +834,19 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         ident: Self::InterfaceIdent,
         new_net_id: u16,
     ) -> Result<(), SetStateError> {
+        if new_net_id == 0
+            || self
+                .slots
+                .iter()
+                .any(|slot| slot.ident != ident && slot.net_id == new_net_id)
+            || self.seed_routes.contains_key(new_net_id)
+            || self
+                .upstream
+                .as_ref()
+                .is_some_and(|up| up.port.net_id() == Some(new_net_id))
+        {
+            return Err(SetStateError::NetIdInUse);
+        }
         let slot = self
             .slots
             .iter_mut()
@@ -824,6 +863,9 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         &mut self,
         source_net: u16,
     ) -> Result<SeedNetAssignment, SeedAssignmentError> {
+        if self.has_upstream() {
+            return Err(SeedAssignmentError::ProfileCantSeed);
+        }
         let now = Instant::now();
         self.seed_routes.gc(now);
 
@@ -872,7 +914,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
 
     fn can_delegate_seed(&mut self, source_net: u16) -> Result<(), SeedAssignmentError> {
         self.seed_routes.gc(Instant::now());
-        if !self.slots.iter().any(|s| s.net_id == source_net) {
+        if source_net == 0 || !self.slots.iter().any(|s| s.net_id == source_net) {
             return Err(SeedAssignmentError::UnknownSource);
         }
         if self.seed_routes.is_full() {
@@ -889,6 +931,10 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         let now = Instant::now();
         self.seed_routes.gc(now);
 
+        if source_net == 0 {
+            return Err(SeedAssignmentError::UnknownSource);
+        }
+
         let via_ident = self
             .slots
             .iter()
@@ -896,12 +942,30 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             .map(|s| s.ident)
             .ok_or(SeedAssignmentError::UnknownSource)?;
 
+        if self.slots.iter().any(|s| s.net_id == parent.net_id)
+            || self
+                .upstream
+                .as_ref()
+                .is_some_and(|up| up.port.net_id() == Some(parent.net_id))
+        {
+            return Err(SeedAssignmentError::NetIdCollision);
+        }
+
         if parent.min_refresh_seconds <= SEED_DELEGATION_REFRESH_MARGIN {
             return Err(SeedAssignmentError::DelegationDepthExceeded);
         }
 
         // Re-delegation of a net we already route is idempotent: drop the
         // stale entry and re-register. (net_id is the table's unique key.)
+        if let Some(existing) = self.seed_routes.by_key(parent.net_id)
+            && existing.scope != source_net
+            && existing.kind.is_active(now)
+        {
+            warn!(
+                "Replacing active seed route net_id {} owned by source net {} with source net {}",
+                parent.net_id, existing.scope, source_net
+            );
+        }
         self.seed_routes.remove_key(parent.net_id);
         if self.seed_routes.is_full() {
             return Err(SeedAssignmentError::NetIdsExhausted);
@@ -920,7 +984,11 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             LeaseKind::active(now, parent.expires_seconds, refresh_token),
         );
 
-        Ok(delegated_assignment(parent, refresh_token))
+        Ok(delegated_assignment(
+            parent,
+            refresh_token,
+            parent.expires_seconds,
+        ))
     }
 
     fn prepare_delegated_refresh(
@@ -929,7 +997,8 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         refresh_net: u16,
         refresh_token: [u8; 8],
     ) -> Result<DelegatedRefreshPreparation, SeedRefreshError> {
-        self.seed_routes.gc(Instant::now());
+        let now = Instant::now();
+        self.seed_routes.gc(now);
         let req_token = u64::from_le_bytes(refresh_token);
         // net_id is the unique key; the requester (source_net) is the scope.
         let entry = self
@@ -950,6 +1019,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
                     Ok(DelegatedRefreshPreparation::Replay(delegated_assignment(
                         parent,
                         lease.refresh_token,
+                        remaining_lease_seconds(lease.expiration, now),
                     )))
                 } else if lease.refresh_token != req_token {
                     Err(SeedRefreshError::BadRequest)
@@ -1002,9 +1072,85 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
                     now + Duration::from_secs(refreshed_parent.expires_seconds as u64);
                 lease.previous_refresh_token = Some(lease.refresh_token);
                 lease.refresh_token = new_token;
-                Ok(delegated_assignment(refreshed_parent, new_token))
+                Ok(delegated_assignment(
+                    refreshed_parent,
+                    new_token,
+                    refreshed_parent.expires_seconds,
+                ))
             }
         }
+    }
+
+    fn prepare_delegated_release(
+        &mut self,
+        source_net: u16,
+        release_net: u16,
+        refresh_token: [u8; 8],
+    ) -> Result<SeedLease, SeedRefreshError> {
+        let now = Instant::now();
+        self.seed_routes.gc(now);
+        let req_token = u64::from_le_bytes(refresh_token);
+        let entry = self
+            .seed_routes
+            .get(release_net, source_net)
+            .ok_or(SeedRefreshError::UnknownNetId)?;
+        match entry.kind {
+            LeaseKind::Tombstone { .. } => Err(SeedRefreshError::AlreadyExpired),
+            LeaseKind::Active(lease) if lease.refresh_token != req_token => {
+                Err(SeedRefreshError::BadRequest)
+            }
+            LeaseKind::Active(_) => entry
+                .extra
+                .parent
+                .clone()
+                .ok_or(SeedRefreshError::NotAssigned),
+        }
+    }
+
+    fn commit_delegated_release(
+        &mut self,
+        source_net: u16,
+        release_net: u16,
+        refresh_token: [u8; 8],
+    ) -> Result<(), SeedRefreshError> {
+        let req_token = u64::from_le_bytes(refresh_token);
+        let entry = self
+            .seed_routes
+            .get(release_net, source_net)
+            .ok_or(SeedRefreshError::UnknownNetId)?;
+        match entry.kind {
+            LeaseKind::Tombstone { .. } => return Err(SeedRefreshError::AlreadyExpired),
+            LeaseKind::Active(lease) if lease.refresh_token != req_token => {
+                return Err(SeedRefreshError::BadRequest);
+            }
+            LeaseKind::Active(_) => {}
+        }
+        self.seed_routes.remove(release_net, source_net);
+        Ok(())
+    }
+
+    fn release_seed_net_assignment(
+        &mut self,
+        source_net: u16,
+        release_net: u16,
+        refresh_token: [u8; 8],
+    ) -> Result<(), SeedRefreshError> {
+        let now = Instant::now();
+        self.seed_routes.gc(now);
+        let req_token = u64::from_le_bytes(refresh_token);
+        let entry = self
+            .seed_routes
+            .get(release_net, source_net)
+            .ok_or(SeedRefreshError::UnknownNetId)?;
+        match entry.kind {
+            LeaseKind::Tombstone { .. } => return Err(SeedRefreshError::AlreadyExpired),
+            LeaseKind::Active(lease) if lease.refresh_token != req_token => {
+                return Err(SeedRefreshError::BadRequest);
+            }
+            LeaseKind::Active(_) => {}
+        }
+        self.seed_routes.remove(release_net, source_net);
+        Ok(())
     }
 
     fn refresh_seed_net_assignment(
@@ -1026,9 +1172,13 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             .ok_or(SeedRefreshError::UnknownNetId)?;
 
         match entry.kind.refresh(req_token, now, new_token, true) {
-            Ok(lease) => Ok(SeedNetAssignment {
+            Ok((lease, replayed)) => Ok(SeedNetAssignment {
                 net_id: refresh_net,
-                expires_seconds: MAX_LEASE_SECS,
+                expires_seconds: if replayed {
+                    remaining_lease_seconds(lease.expiration, now)
+                } else {
+                    MAX_LEASE_SECS
+                },
                 max_refresh_seconds: MAX_LEASE_SECS,
                 min_refresh_seconds: MIN_REFRESH_SECS,
                 refresh_token: lease.refresh_token.to_le_bytes(),
@@ -1117,7 +1267,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             .ok_or(AddressRefreshError::UnknownNodeId)?;
 
         match entry.kind.refresh(req_token, now, new_token, false) {
-            Ok(lease) => Ok(NodeClaimAssignment {
+            Ok((lease, _)) => Ok(NodeClaimAssignment {
                 node_id,
                 net_id: source_net,
                 expires_seconds: MAX_LEASE_SECS,

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -837,6 +837,17 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         }
     }
 
+    fn can_delegate_seed(&mut self, source_net: u16) -> Result<(), SeedAssignmentError> {
+        self.seed_routes.gc(Instant::now());
+        if !self.slots.iter().any(|s| s.net_id == source_net) {
+            return Err(SeedAssignmentError::UnknownSource);
+        }
+        if self.seed_routes.is_full() {
+            return Err(SeedAssignmentError::NetIdsExhausted);
+        }
+        Ok(())
+    }
+
     fn register_delegated_seed_net(
         &mut self,
         net_id: u16,

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -25,8 +25,8 @@ use crate::{
     Header, HeaderSeq, ProtocolError,
     interface_manager::{
         AddressClaimError, AddressRefreshError, Interface, InterfaceSendError, InterfaceState,
-        NodeClaimAssignment, Profile, SeedAssignmentError, SeedNetAssignment, SeedRefreshError,
-        SetStateError,
+        NodeClaimAssignment, Profile, SeedAssignmentError, SeedLease, SeedNetAssignment,
+        SeedRefreshError, SetStateError,
         edge_port::{CENTRAL_NODE_ID, EDGE_NODE_ID, EdgePort},
     },
     logging::{debug, trace, warn},
@@ -257,6 +257,15 @@ struct UpstreamPort<I: Interface> {
     closer: Option<std::sync::Arc<maitake_sync::WaitQueue>>,
 }
 
+/// Routing metadata for one seed-assigned network.
+struct SeedRoute {
+    /// Direct downstream interface through which this network is reachable.
+    via_ident: u8,
+    /// Parent lease for delegated routes. Root-allocated routes have no
+    /// parent because this router is their lease authority.
+    parent: Option<SeedLease>,
+}
+
 /// Reserved ident for the upstream interface (bridge mode).
 ///
 /// This is `u8::MAX` (255), which means a router can have at most 255
@@ -283,8 +292,8 @@ pub const UPSTREAM_IDENT: u8 = u8::MAX;
 pub struct Router<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize = 0> {
     slots: heapless::Vec<Slot<I>, N>,
     /// Seed-assigned routes. Key = assigned net_id, scope = requesting
-    /// source net_id, extra = via_ident (the direct ident to reach it).
-    seed_routes: LeaseTable<u16, u8, S>,
+    /// source net_id, extra = routing metadata and optional parent lease.
+    seed_routes: LeaseTable<u16, SeedRoute, S>,
     /// Bus node_id claims. Key = node_id, scope = bus net_id, extra = nonce.
     node_claims: LeaseTable<u8, u64, C>,
     rng: R,
@@ -467,7 +476,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize>
         // gone now, so the grace is anchored to now (no lease expiration).
         let clear_time = Instant::now() + Duration::from_secs(TOMBSTONE_DURATION_SECS);
         for e in self.seed_routes.iter_mut() {
-            if e.extra == ident {
+            if e.extra.via_ident == ident {
                 e.kind = LeaseKind::Tombstone { clear_time };
             }
         }
@@ -559,7 +568,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize>
         let via_ident = match self.seed_routes.by_key(hdr.dst.network_id) {
             // 3. Upstream fallback (bridge mode)
             None => return self.find_upstream(source),
-            Some(entry) if entry.kind.is_active(Instant::now()) => entry.extra,
+            Some(entry) if entry.kind.is_active(Instant::now()) => entry.extra.via_ident,
             Some(_) => return Err(InterfaceSendError::NoRouteToDest),
         };
 
@@ -816,7 +825,10 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         self.seed_routes.push(
             net_id,
             source_net,
-            via_ident,
+            SeedRoute {
+                via_ident,
+                parent: None,
+            },
             LeaseKind::active(now, INITIAL_LEASE_SECS, refresh_token),
         );
 
@@ -850,9 +862,8 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
 
     fn register_delegated_seed_net(
         &mut self,
-        net_id: u16,
         source_net: u16,
-        granted: &SeedNetAssignment,
+        parent: &SeedLease,
     ) -> Result<SeedNetAssignment, SeedAssignmentError> {
         let now = Instant::now();
         self.seed_routes.gc(now);
@@ -866,7 +877,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
 
         // Re-delegation of a net we already route is idempotent: drop the
         // stale entry and re-register. (net_id is the table's unique key.)
-        self.seed_routes.remove_key(net_id);
+        self.seed_routes.remove_key(parent.net_id);
         if self.seed_routes.is_full() {
             return Err(SeedAssignmentError::NetIdsExhausted);
         }
@@ -875,17 +886,20 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         // expires when the upstream lease does.
         let refresh_token = self.rng.next_u64();
         self.seed_routes.push(
-            net_id,
+            parent.net_id,
             source_net,
-            via_ident,
-            LeaseKind::active(now, granted.expires_seconds, refresh_token),
+            SeedRoute {
+                via_ident,
+                parent: Some(parent.clone()),
+            },
+            LeaseKind::active(now, parent.expires_seconds, refresh_token),
         );
 
         Ok(SeedNetAssignment {
-            net_id,
-            expires_seconds: granted.expires_seconds,
-            max_refresh_seconds: granted.max_refresh_seconds,
-            min_refresh_seconds: granted
+            net_id: parent.net_id,
+            expires_seconds: parent.expires_seconds,
+            max_refresh_seconds: parent.max_refresh_seconds,
+            min_refresh_seconds: parent
                 .min_refresh_seconds
                 .saturating_sub(SEED_DELEGATION_REFRESH_MARGIN)
                 .max(1),
@@ -893,12 +907,13 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         })
     }
 
-    fn validate_delegated_refresh(
+    fn prepare_delegated_refresh(
         &mut self,
         source_net: u16,
         refresh_net: u16,
         refresh_token: [u8; 8],
-    ) -> Result<(), SeedRefreshError> {
+    ) -> Result<SeedLease, SeedRefreshError> {
+        self.seed_routes.gc(Instant::now());
         let req_token = u64::from_le_bytes(refresh_token);
         // net_id is the unique key; the requester (source_net) is the scope.
         let entry = self
@@ -911,17 +926,21 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
                 if entry.scope != source_net || lease.refresh_token != req_token {
                     Err(SeedRefreshError::BadRequest)
                 } else {
-                    Ok(())
+                    entry
+                        .extra
+                        .parent
+                        .clone()
+                        .ok_or(SeedRefreshError::NotAssigned)
                 }
             }
         }
     }
 
-    fn refresh_delegated_seed_net(
+    fn commit_delegated_refresh(
         &mut self,
         source_net: u16,
         refresh_token: [u8; 8],
-        granted: &SeedNetAssignment,
+        refreshed_parent: &SeedLease,
     ) -> Result<SeedNetAssignment, SeedRefreshError> {
         let req_token = u64::from_le_bytes(refresh_token);
         let new_token = self.rng.next_u64();
@@ -929,7 +948,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
 
         let entry = self
             .seed_routes
-            .get_mut(granted.net_id, source_net)
+            .get_mut(refreshed_parent.net_id, source_net)
             .ok_or(SeedRefreshError::UnknownNetId)?;
 
         match &mut entry.kind {
@@ -941,13 +960,20 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
                 // No TooSoon check here: pacing is enforced by the upstream
                 // seed router, whose refresh has already succeeded. Extend to
                 // track the upstream lease and rotate the local token.
-                lease.expiration = now + Duration::from_secs(granted.expires_seconds as u64);
+                let parent = entry
+                    .extra
+                    .parent
+                    .as_mut()
+                    .ok_or(SeedRefreshError::NotAssigned)?;
+                *parent = refreshed_parent.clone();
+                lease.expiration =
+                    now + Duration::from_secs(refreshed_parent.expires_seconds as u64);
                 lease.refresh_token = new_token;
                 Ok(SeedNetAssignment {
-                    net_id: granted.net_id,
-                    expires_seconds: granted.expires_seconds,
-                    max_refresh_seconds: granted.max_refresh_seconds,
-                    min_refresh_seconds: granted
+                    net_id: refreshed_parent.net_id,
+                    expires_seconds: refreshed_parent.expires_seconds,
+                    max_refresh_seconds: refreshed_parent.max_refresh_seconds,
+                    min_refresh_seconds: refreshed_parent
                         .min_refresh_seconds
                         .saturating_sub(SEED_DELEGATION_REFRESH_MARGIN)
                         .max(1),
@@ -1180,7 +1206,10 @@ mod tests {
         assert!(router.seed_routes.push(
             NET_ID,
             1,
-            0,
+            SeedRoute {
+                via_ident: 0,
+                parent: None,
+            },
             LeaseKind::Tombstone {
                 clear_time: Instant::now() + Duration::from_secs(60),
             },

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -42,6 +42,11 @@ const INITIAL_LEASE_SECS: u16 = 30;
 const MAX_LEASE_SECS: u16 = 120;
 /// Refresh is allowed only when remaining time is less than this (seconds).
 const MIN_REFRESH_SECS: u16 = 62;
+
+/// Each delegation hop hands its downstream a `min_refresh_seconds` smaller
+/// by this margin, so a child's refresh always lands inside the window where
+/// the parent's own upstream refresh is accepted.
+const SEED_DELEGATION_REFRESH_MARGIN: u16 = 5;
 /// Tombstone duration — how long a revoked net_id/node_id stays reserved,
 /// measured from its lease expiration, before it can be reused (seconds).
 const TOMBSTONE_DURATION_SECS: u64 = 30;
@@ -223,6 +228,13 @@ impl<K: Copy + Eq, X, const N: usize> LeaseTable<K, X, N> {
     /// once the net_id is reused.
     fn drop_scope(&mut self, scope: u16) {
         self.entries.retain(|e| e.scope != scope);
+    }
+
+    /// Remove every entry with the given `key`. Used for idempotent
+    /// re-registration of a globally-unique key (e.g. re-delegating a seed
+    /// net_id this router already routes).
+    fn remove_key(&mut self, key: K) {
+        self.entries.retain(|e| e.key != key);
     }
 
     /// Push a new entry. Returns `false` if the table is full.
@@ -815,6 +827,123 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             min_refresh_seconds: MIN_REFRESH_SECS,
             refresh_token: refresh_token.to_le_bytes(),
         })
+    }
+
+    fn seed_delegation_upstream(&self) -> Option<Self::InterfaceIdent> {
+        if self.has_upstream() {
+            Some(UPSTREAM_IDENT)
+        } else {
+            None
+        }
+    }
+
+    fn register_delegated_seed_net(
+        &mut self,
+        net_id: u16,
+        source_net: u16,
+        granted: &SeedNetAssignment,
+    ) -> Result<SeedNetAssignment, SeedAssignmentError> {
+        let now = Instant::now();
+        self.seed_routes.gc(now);
+
+        let via_ident = self
+            .slots
+            .iter()
+            .find(|s| s.net_id == source_net)
+            .map(|s| s.ident)
+            .ok_or(SeedAssignmentError::UnknownSource)?;
+
+        // Re-delegation of a net we already route is idempotent: drop the
+        // stale entry and re-register. (net_id is the table's unique key.)
+        self.seed_routes.remove_key(net_id);
+        if self.seed_routes.is_full() {
+            return Err(SeedAssignmentError::NetIdsExhausted);
+        }
+
+        // The delegated route's lease tracks the upstream lease we hold, so it
+        // expires when the upstream lease does.
+        let refresh_token = self.rng.next_u64();
+        self.seed_routes.push(
+            net_id,
+            source_net,
+            via_ident,
+            LeaseKind::active(now, granted.expires_seconds, refresh_token),
+        );
+
+        Ok(SeedNetAssignment {
+            net_id,
+            expires_seconds: granted.expires_seconds,
+            max_refresh_seconds: granted.max_refresh_seconds,
+            min_refresh_seconds: granted
+                .min_refresh_seconds
+                .saturating_sub(SEED_DELEGATION_REFRESH_MARGIN)
+                .max(1),
+            refresh_token: refresh_token.to_le_bytes(),
+        })
+    }
+
+    fn validate_delegated_refresh(
+        &mut self,
+        source_net: u16,
+        refresh_net: u16,
+        refresh_token: [u8; 8],
+    ) -> Result<(), SeedRefreshError> {
+        let req_token = u64::from_le_bytes(refresh_token);
+        // net_id is the unique key; the requester (source_net) is the scope.
+        let entry = self
+            .seed_routes
+            .by_key(refresh_net)
+            .ok_or(SeedRefreshError::UnknownNetId)?;
+        match entry.kind {
+            LeaseKind::Tombstone { .. } => Err(SeedRefreshError::AlreadyExpired),
+            LeaseKind::Active(lease) => {
+                if entry.scope != source_net || lease.refresh_token != req_token {
+                    Err(SeedRefreshError::BadRequest)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn refresh_delegated_seed_net(
+        &mut self,
+        source_net: u16,
+        refresh_token: [u8; 8],
+        granted: &SeedNetAssignment,
+    ) -> Result<SeedNetAssignment, SeedRefreshError> {
+        let req_token = u64::from_le_bytes(refresh_token);
+        let new_token = self.rng.next_u64();
+        let now = Instant::now();
+
+        let entry = self
+            .seed_routes
+            .get_mut(granted.net_id, source_net)
+            .ok_or(SeedRefreshError::UnknownNetId)?;
+
+        match &mut entry.kind {
+            LeaseKind::Tombstone { .. } => Err(SeedRefreshError::AlreadyExpired),
+            LeaseKind::Active(lease) => {
+                if lease.refresh_token != req_token {
+                    return Err(SeedRefreshError::BadRequest);
+                }
+                // No TooSoon check here: pacing is enforced by the upstream
+                // seed router, whose refresh has already succeeded. Extend to
+                // track the upstream lease and rotate the local token.
+                lease.expiration = now + Duration::from_secs(granted.expires_seconds as u64);
+                lease.refresh_token = new_token;
+                Ok(SeedNetAssignment {
+                    net_id: granted.net_id,
+                    expires_seconds: granted.expires_seconds,
+                    max_refresh_seconds: granted.max_refresh_seconds,
+                    min_refresh_seconds: granted
+                        .min_refresh_seconds
+                        .saturating_sub(SEED_DELEGATION_REFRESH_MARGIN)
+                        .max(1),
+                    refresh_token: new_token.to_le_bytes(),
+                })
+            }
+        }
     }
 
     fn refresh_seed_net_assignment(

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -24,9 +24,9 @@ use serde::Serialize;
 use crate::{
     Header, HeaderSeq, ProtocolError,
     interface_manager::{
-        AddressClaimError, AddressRefreshError, Interface, InterfaceSendError, InterfaceState,
-        NodeClaimAssignment, Profile, SeedAssignmentError, SeedLease, SeedNetAssignment,
-        SeedRefreshError, SetStateError,
+        AddressClaimError, AddressRefreshError, DelegatedRefreshPreparation, Interface,
+        InterfaceSendError, InterfaceState, NodeClaimAssignment, Profile, SeedAssignmentError,
+        SeedLease, SeedNetAssignment, SeedRefreshError, SetStateError,
         edge_port::{CENTRAL_NODE_ID, EDGE_NODE_ID, EdgePort},
     },
     logging::{debug, trace, warn},
@@ -47,6 +47,17 @@ const MIN_REFRESH_SECS: u16 = 62;
 /// by this margin, so a child's refresh always lands inside the window where
 /// the parent's own upstream refresh is accepted.
 const SEED_DELEGATION_REFRESH_MARGIN: u16 = 5;
+
+fn delegated_assignment(parent: &SeedLease, refresh_token: u64) -> SeedNetAssignment {
+    SeedNetAssignment {
+        net_id: parent.net_id,
+        expires_seconds: parent.expires_seconds,
+        max_refresh_seconds: parent.max_refresh_seconds,
+        min_refresh_seconds: parent.min_refresh_seconds - SEED_DELEGATION_REFRESH_MARGIN,
+        refresh_token: refresh_token.to_le_bytes(),
+    }
+}
+
 /// Tombstone duration — how long a revoked net_id/node_id stays reserved,
 /// measured from its lease expiration, before it can be reused (seconds).
 const TOMBSTONE_DURATION_SECS: u64 = 30;
@@ -69,6 +80,9 @@ struct Slot<I: Interface> {
 struct Lease {
     expiration: Instant,
     refresh_token: u64,
+    /// The immediately previous token remains valid only for replaying a lost
+    /// refresh response. A successful refresh replaces this replay slot.
+    previous_refresh_token: Option<u64>,
 }
 
 /// The state of a leased resource.
@@ -97,6 +111,7 @@ impl LeaseKind {
         LeaseKind::Active(Lease {
             expiration: now + Duration::from_secs(secs as u64),
             refresh_token: token,
+            previous_refresh_token: None,
         })
     }
 
@@ -135,6 +150,7 @@ impl LeaseKind {
         req_token: u64,
         now: Instant,
         new_token: u64,
+        allow_replay: bool,
     ) -> Result<Lease, RefreshDenied> {
         match self {
             LeaseKind::Tombstone { .. } => Err(RefreshDenied::Expired),
@@ -142,7 +158,8 @@ impl LeaseKind {
                 // Token is checked before expiry on purpose: a caller with the
                 // wrong token learns nothing about whether the lease exists or
                 // has already expired (it always sees BadToken).
-                if lease.refresh_token != req_token {
+                let is_replay = allow_replay && lease.previous_refresh_token == Some(req_token);
+                if lease.refresh_token != req_token && !is_replay {
                     return Err(RefreshDenied::BadToken);
                 }
                 if now >= lease.expiration {
@@ -151,10 +168,14 @@ impl LeaseKind {
                     };
                     return Err(RefreshDenied::Expired);
                 }
+                if is_replay {
+                    return Ok(*lease);
+                }
                 if lease.expiration - now > Duration::from_secs(MIN_REFRESH_SECS as u64) {
                     return Err(RefreshDenied::TooSoon);
                 }
                 lease.expiration = now + Duration::from_secs(MAX_LEASE_SECS as u64);
+                lease.previous_refresh_token = allow_replay.then_some(lease.refresh_token);
                 lease.refresh_token = new_token;
                 Ok(*lease)
             }
@@ -875,6 +896,10 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             .map(|s| s.ident)
             .ok_or(SeedAssignmentError::UnknownSource)?;
 
+        if parent.min_refresh_seconds <= SEED_DELEGATION_REFRESH_MARGIN {
+            return Err(SeedAssignmentError::DelegationDepthExceeded);
+        }
+
         // Re-delegation of a net we already route is idempotent: drop the
         // stale entry and re-register. (net_id is the table's unique key.)
         self.seed_routes.remove_key(parent.net_id);
@@ -895,16 +920,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             LeaseKind::active(now, parent.expires_seconds, refresh_token),
         );
 
-        Ok(SeedNetAssignment {
-            net_id: parent.net_id,
-            expires_seconds: parent.expires_seconds,
-            max_refresh_seconds: parent.max_refresh_seconds,
-            min_refresh_seconds: parent
-                .min_refresh_seconds
-                .saturating_sub(SEED_DELEGATION_REFRESH_MARGIN)
-                .max(1),
-            refresh_token: refresh_token.to_le_bytes(),
-        })
+        Ok(delegated_assignment(parent, refresh_token))
     }
 
     fn prepare_delegated_refresh(
@@ -912,7 +928,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         source_net: u16,
         refresh_net: u16,
         refresh_token: [u8; 8],
-    ) -> Result<SeedLease, SeedRefreshError> {
+    ) -> Result<DelegatedRefreshPreparation, SeedRefreshError> {
         self.seed_routes.gc(Instant::now());
         let req_token = u64::from_le_bytes(refresh_token);
         // net_id is the unique key; the requester (source_net) is the scope.
@@ -923,13 +939,26 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         match entry.kind {
             LeaseKind::Tombstone { .. } => Err(SeedRefreshError::AlreadyExpired),
             LeaseKind::Active(lease) => {
-                if entry.scope != source_net || lease.refresh_token != req_token {
+                if entry.scope != source_net {
+                    Err(SeedRefreshError::BadRequest)
+                } else if lease.previous_refresh_token == Some(req_token) {
+                    let parent = entry
+                        .extra
+                        .parent
+                        .as_ref()
+                        .ok_or(SeedRefreshError::NotAssigned)?;
+                    Ok(DelegatedRefreshPreparation::Replay(delegated_assignment(
+                        parent,
+                        lease.refresh_token,
+                    )))
+                } else if lease.refresh_token != req_token {
                     Err(SeedRefreshError::BadRequest)
                 } else {
                     entry
                         .extra
                         .parent
                         .clone()
+                        .map(DelegatedRefreshPreparation::Forward)
                         .ok_or(SeedRefreshError::NotAssigned)
                 }
             }
@@ -942,6 +971,9 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         refresh_token: [u8; 8],
         refreshed_parent: &SeedLease,
     ) -> Result<SeedNetAssignment, SeedRefreshError> {
+        if refreshed_parent.min_refresh_seconds <= SEED_DELEGATION_REFRESH_MARGIN {
+            return Err(SeedRefreshError::DelegationDepthExceeded);
+        }
         let req_token = u64::from_le_bytes(refresh_token);
         let new_token = self.rng.next_u64();
         let now = Instant::now();
@@ -968,17 +1000,9 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
                 *parent = refreshed_parent.clone();
                 lease.expiration =
                     now + Duration::from_secs(refreshed_parent.expires_seconds as u64);
+                lease.previous_refresh_token = Some(lease.refresh_token);
                 lease.refresh_token = new_token;
-                Ok(SeedNetAssignment {
-                    net_id: refreshed_parent.net_id,
-                    expires_seconds: refreshed_parent.expires_seconds,
-                    max_refresh_seconds: refreshed_parent.max_refresh_seconds,
-                    min_refresh_seconds: refreshed_parent
-                        .min_refresh_seconds
-                        .saturating_sub(SEED_DELEGATION_REFRESH_MARGIN)
-                        .max(1),
-                    refresh_token: new_token.to_le_bytes(),
-                })
+                Ok(delegated_assignment(refreshed_parent, new_token))
             }
         }
     }
@@ -1001,7 +1025,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             .get_mut(refresh_net, source_net)
             .ok_or(SeedRefreshError::UnknownNetId)?;
 
-        match entry.kind.refresh(req_token, now, new_token) {
+        match entry.kind.refresh(req_token, now, new_token, true) {
             Ok(lease) => Ok(SeedNetAssignment {
                 net_id: refresh_net,
                 expires_seconds: MAX_LEASE_SECS,
@@ -1092,7 +1116,7 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             .get_mut(node_id, source_net)
             .ok_or(AddressRefreshError::UnknownNodeId)?;
 
-        match entry.kind.refresh(req_token, now, new_token) {
+        match entry.kind.refresh(req_token, now, new_token, false) {
             Ok(lease) => Ok(NodeClaimAssignment {
                 node_id,
                 net_id: source_net,

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -193,7 +193,10 @@ impl<NS: NetStackHandle> Services<NS> {
         let mut assign_svr = assign.attach();
 
         // Upstream leases held on behalf of downstream requesters, keyed by
-        // the delegated net id (bridges only; empty on root routers).
+        // the delegated net id (bridges only; empty on root routers). The
+        // capacity caps how many delegations a single bridge holds at once;
+        // it is intentionally independent of the profile's `S` (route table
+        // size), since this handler is not generic over the profile's consts.
         let mut parent_leases: heapless::Vec<SeedLease, 32> = heapless::Vec::new();
 
         loop {
@@ -423,6 +426,12 @@ async fn handle_assign_delegated<NS: NetStackHandle + Clone>(
         if parent_leases.is_full() {
             return Err(SeedAssignmentError::NetIdsExhausted);
         }
+        // Reject before leasing a net_id from upstream: if the source is
+        // unknown or the route table is full, registration would fail *after*
+        // the lease was acquired, stranding it until expiry. The handler is a
+        // single-task loop, so nothing fills the table during the await below.
+        nsh.stack()
+            .manage_profile(|p| p.can_delegate_seed(assign_req.hdr.src.network_id))?;
         let lease = request_seed_lease(nsh, upstream)
             .await
             .map_err(|_| SeedAssignmentError::NetIdsExhausted)?;

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -17,6 +17,8 @@ use crate::{
 };
 use core::pin::pin;
 
+pub use crate::interface_manager::SeedLease;
+
 use super::SocketHeaderIter;
 
 /// A proxy type usable for creating helper services
@@ -192,13 +194,6 @@ impl<NS: NetStackHandle> Services<NS> {
         let assign = pin!(assign);
         let mut assign_svr = assign.attach();
 
-        // Upstream leases held on behalf of downstream requesters, keyed by
-        // the delegated net id (bridges only; empty on root routers). The
-        // capacity caps how many delegations a single bridge holds at once;
-        // it is intentionally independent of the profile's `S` (route table
-        // size), since this handler is not generic over the profile's consts.
-        let mut parent_leases: heapless::Vec<SeedLease, 32> = heapless::Vec::new();
-
         loop {
             let res = embassy_futures::select::select(
                 assign_svr.recv_manual(),
@@ -218,14 +213,7 @@ impl<NS: NetStackHandle> Services<NS> {
                     };
                     match upstream {
                         Some(up) => {
-                            handle_assign_delegated(
-                                &nsh,
-                                refresh_port,
-                                &assign_req,
-                                up,
-                                &mut parent_leases,
-                            )
-                            .await
+                            handle_assign_delegated(&nsh, refresh_port, &assign_req, up).await
                         }
                         None => handle_assign(&nsh, refresh_port, &assign_req),
                     }
@@ -235,9 +223,7 @@ impl<NS: NetStackHandle> Services<NS> {
                         continue;
                     };
                     match upstream {
-                        Some(_) => {
-                            handle_refresh_delegated(&nsh, &refresh_req, &mut parent_leases).await
-                        }
+                        Some(_) => handle_refresh_delegated(&nsh, &refresh_req).await,
                         None => handle_refresh(&nsh, &refresh_req),
                     }
                 }
@@ -410,7 +396,7 @@ fn handle_refresh<NS: NetStackHandle>(
         .respond_owned::<ErgotSeedRouterRefreshEndpoint>(&refresh_req.hdr, &res);
 }
 
-use crate::interface_manager::{SeedAssignmentError, SeedNetAssignment, SeedRefreshError};
+use crate::interface_manager::{SeedAssignmentError, SeedRefreshError};
 
 /// Handle an Assign request on a bridge: lease a net id from our own
 /// upstream seed router, register it as a delegated seed route, and answer
@@ -420,12 +406,8 @@ async fn handle_assign_delegated<NS: NetStackHandle + Clone>(
     refresh_port: u8,
     assign_req: &HeaderMessage<()>,
     upstream: <NS::Profile as crate::interface_manager::Profile>::InterfaceIdent,
-    parent_leases: &mut heapless::Vec<SeedLease, 32>,
 ) {
     let res = async {
-        if parent_leases.is_full() {
-            return Err(SeedAssignmentError::NetIdsExhausted);
-        }
         // Reject before leasing a net_id from upstream: if the source is
         // unknown or the route table is full, registration would fail *after*
         // the lease was acquired, stranding it until expiry. The handler is a
@@ -435,22 +417,9 @@ async fn handle_assign_delegated<NS: NetStackHandle + Clone>(
         let lease = request_seed_lease(nsh, upstream)
             .await
             .map_err(|_| SeedAssignmentError::NetIdsExhausted)?;
-        let granted = SeedNetAssignment {
-            net_id: lease.net_id,
-            expires_seconds: lease.expires_seconds,
-            max_refresh_seconds: lease.max_refresh_seconds,
-            min_refresh_seconds: lease.min_refresh_seconds,
-            refresh_token: lease.refresh_token,
-        };
         let assignment = nsh.stack().manage_profile(|p| {
-            p.register_delegated_seed_net(
-                lease.net_id,
-                assign_req.hdr.src.network_id,
-                &granted,
-            )
+            p.register_delegated_seed_net(assign_req.hdr.src.network_id, &lease)
         })?;
-        parent_leases.retain(|l| l.net_id != lease.net_id);
-        _ = parent_leases.push(lease);
         Ok(assignment)
     }
     .await;
@@ -469,39 +438,26 @@ async fn handle_assign_delegated<NS: NetStackHandle + Clone>(
 async fn handle_refresh_delegated<NS: NetStackHandle + Clone>(
     nsh: &NS,
     refresh_req: &HeaderMessage<SeedRouterRefreshRequest>,
-    parent_leases: &mut heapless::Vec<SeedLease, 32>,
 ) {
     let res = async {
-        // Validate before touching the upstream so bad tokens cannot
-        // trigger upstream traffic.
-        nsh.stack().manage_profile(|p| {
-            p.validate_delegated_refresh(
+        // Validate and clone the profile-owned parent lease before touching
+        // the upstream so bad tokens cannot trigger upstream traffic.
+        let parent = nsh.stack().manage_profile(|p| {
+            p.prepare_delegated_refresh(
                 refresh_req.hdr.src.network_id,
                 refresh_req.t.refresh_net,
                 refresh_req.t.refresh_token,
             )
         })?;
-        let lease = parent_leases
-            .iter_mut()
-            .find(|l| l.net_id == refresh_req.t.refresh_net)
-            .ok_or(SeedRefreshError::UnknownNetId)?;
-        let refreshed = bridge_seed_refresh(nsh, lease).await.map_err(|e| match e {
+        let refreshed = bridge_seed_refresh(nsh, &parent).await.map_err(|e| match e {
             SeedClientError::RefreshDenied(denied) => denied,
             _ => SeedRefreshError::BadRequest,
         })?;
-        *lease = refreshed.clone();
-        let granted = SeedNetAssignment {
-            net_id: refreshed.net_id,
-            expires_seconds: refreshed.expires_seconds,
-            max_refresh_seconds: refreshed.max_refresh_seconds,
-            min_refresh_seconds: refreshed.min_refresh_seconds,
-            refresh_token: refreshed.refresh_token,
-        };
         nsh.stack().manage_profile(|p| {
-            p.refresh_delegated_seed_net(
+            p.commit_delegated_refresh(
                 refresh_req.hdr.src.network_id,
                 refresh_req.t.refresh_token,
-                &granted,
+                &refreshed,
             )
         })
     }
@@ -515,25 +471,6 @@ async fn handle_refresh_delegated<NS: NetStackHandle + Clone>(
 // ---------------------------------------------------------------------------
 // Bridge seed routing client
 // ---------------------------------------------------------------------------
-
-/// Result of a successful seed net_id assignment.
-///
-/// Contains all information needed to refresh the lease later.
-#[derive(Debug, Clone)]
-pub struct SeedLease {
-    /// The assigned net_id for the downstream interface.
-    pub net_id: u16,
-    /// Address to send refresh requests to.
-    pub refresh_addr: crate::Address,
-    /// Current refresh token.
-    pub refresh_token: [u8; 8],
-    /// Lease duration in seconds.
-    pub expires_seconds: u16,
-    /// Maximum refresh interval in seconds.
-    pub max_refresh_seconds: u16,
-    /// Minimum time before expiration to refresh.
-    pub min_refresh_seconds: u16,
-}
 
 /// Errors from bridge seed client operations.
 #[derive(Debug)]

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -1,4 +1,4 @@
-use embassy_futures::select::Either;
+use embassy_futures::select::{Either, Either3, select3};
 
 #[cfg(feature = "std")]
 use crate::fmtlog::ErgotFmtRxOwned;
@@ -11,8 +11,10 @@ use crate::{
         ErgotAddressClaimEndpoint, ErgotAddressRefreshEndpoint,
         ErgotDeviceInfoInterrogationTopic, ErgotDeviceInfoTopic, ErgotPingEndpoint,
         ErgotSeedRouterAssignmentEndpoint, ErgotSeedRouterRefreshEndpoint,
+        ErgotSeedRouterReleaseEndpoint,
         ErgotSocketQueryResponseTopic, ErgotSocketQueryTopic, NameRequirement,
-        SeedRouterAssignment, SeedRouterRefreshRequest, SocketQuery, SocketQueryResponse,
+        SeedRouterAssignment, SeedRouterRefreshRequest, SeedRouterReleaseRequest, SocketQuery,
+        SocketQueryResponse,
     },
 };
 use core::{future::Future, pin::pin};
@@ -177,7 +179,35 @@ impl<NS: NetStackHandle> Services<NS> {
     ///
     /// Should only be used by Profiles that are capable of acting as Seed Routers, otherwise
     /// all requests will fail.
+    #[cfg(any(feature = "tokio-std", feature = "nostd-seed-router"))]
     pub async fn seed_router_request_handler<const D: usize>(self) {
+        #[cfg(feature = "tokio-std")]
+        self.seed_router_request_handler_with_timeout::<D, _, _>(|| {
+            tokio::time::sleep(core::time::Duration::from_secs(
+                DELEGATED_SEED_RPC_TIMEOUT_SECS,
+            ))
+        })
+        .await;
+
+        #[cfg(all(not(feature = "tokio-std"), feature = "nostd-seed-router"))]
+        self.seed_router_request_handler_with_timeout::<D, _, _>(|| {
+            embassy_time::Timer::after(embassy_time::Duration::from_secs(
+                DELEGATED_SEED_RPC_TIMEOUT_SECS,
+            ))
+        })
+        .await;
+    }
+
+    /// Handle seed-router requests using a caller-provided timeout future for
+    /// delegated upstream RPCs. Plain `std`/WASM executors must use this API
+    /// because the crate cannot choose their timer implementation safely.
+    pub async fn seed_router_request_handler_with_timeout<const D: usize, T, F>(
+        self,
+        timeout: T,
+    ) where
+        T: Fn() -> F,
+        F: Future<Output = ()>,
+    {
         let nsh = self.inner.clone();
         let endpoints = Endpoints { inner: self.inner };
 
@@ -188,6 +218,13 @@ impl<NS: NetStackHandle> Services<NS> {
         let mut refresh_svr = refresh.attach();
         let refresh_port = refresh_svr.port();
 
+        let release = endpoints
+            .clone()
+            .bounded_server::<ErgotSeedRouterReleaseEndpoint, D>(None);
+        let release = pin!(release);
+        let mut release_svr = release.attach();
+        let release_port = release_svr.port();
+
         let assign = endpoints
             .clone()
             .bounded_server::<ErgotSeedRouterAssignmentEndpoint, D>(None);
@@ -195,9 +232,10 @@ impl<NS: NetStackHandle> Services<NS> {
         let mut assign_svr = assign.attach();
 
         loop {
-            let res = embassy_futures::select::select(
+            let res = select3(
                 assign_svr.recv_manual(),
                 refresh_svr.recv_manual(),
+                release_svr.recv_manual(),
             )
             .await;
             // Bridges delegate to the upstream seed router instead of
@@ -207,24 +245,41 @@ impl<NS: NetStackHandle> Services<NS> {
                 .stack()
                 .manage_profile(|p| p.seed_delegation_upstream());
             match res {
-                Either::First(assign_req) => {
+                Either3::First(assign_req) => {
                     let Ok(assign_req) = assign_req else {
                         continue;
                     };
                     match upstream {
                         Some(up) => {
-                            handle_assign_delegated(&nsh, refresh_port, &assign_req, up).await
+                            handle_assign_delegated(
+                                &nsh,
+                                refresh_port,
+                                release_port,
+                                &assign_req,
+                                up,
+                                &timeout,
+                            )
+                            .await
                         }
-                        None => handle_assign(&nsh, refresh_port, &assign_req),
+                        None => handle_assign(&nsh, refresh_port, release_port, &assign_req),
                     }
                 }
-                Either::Second(refresh_req) => {
+                Either3::Second(refresh_req) => {
                     let Ok(refresh_req) = refresh_req else {
                         continue;
                     };
                     match upstream {
-                        Some(_) => handle_refresh_delegated(&nsh, &refresh_req).await,
+                        Some(_) => handle_refresh_delegated(&nsh, &refresh_req, &timeout).await,
                         None => handle_refresh(&nsh, &refresh_req),
+                    }
+                }
+                Either3::Third(release_req) => {
+                    let Ok(release_req) = release_req else {
+                        continue;
+                    };
+                    match upstream {
+                        Some(_) => handle_release_delegated(&nsh, &release_req, &timeout).await,
+                        None => handle_release(&nsh, &release_req),
                     }
                 }
             }
@@ -364,18 +419,41 @@ fn log_fmtlog(msg: HeaderMessage<ErgotFmtRxOwned>) {
 }
 
 /// Helper function for handling an Assign request
-fn handle_assign<NS: NetStackHandle>(nsh: &NS, refresh_port: u8, assign_req: &HeaderMessage<()>) {
+fn handle_assign<NS: NetStackHandle>(
+    nsh: &NS,
+    refresh_port: u8,
+    release_port: u8,
+    assign_req: &HeaderMessage<()>,
+) {
     let res = nsh
         .stack()
         .manage_profile(|p| p.request_seed_net_assign(assign_req.hdr.src.network_id));
     let res = res.map(|assignment| SeedRouterAssignment {
         assignment,
         refresh_port,
+        release_port,
     });
     _ = nsh
         .stack()
         .endpoints()
         .respond_owned::<ErgotSeedRouterAssignmentEndpoint>(&assign_req.hdr, &res);
+}
+
+fn handle_release<NS: NetStackHandle>(
+    nsh: &NS,
+    release_req: &HeaderMessage<SeedRouterReleaseRequest>,
+) {
+    let res = nsh.stack().manage_profile(|p| {
+        p.release_seed_net_assignment(
+            release_req.hdr.src.network_id,
+            release_req.t.release_net,
+            release_req.t.refresh_token,
+        )
+    });
+    _ = nsh
+        .stack()
+        .endpoints()
+        .respond_owned::<ErgotSeedRouterReleaseEndpoint>(&release_req.hdr, &res);
 }
 
 /// Helper function for handling a Refresh request
@@ -403,28 +481,13 @@ use crate::interface_manager::{
 #[cfg(any(feature = "tokio-std", feature = "nostd-seed-router"))]
 const DELEGATED_SEED_RPC_TIMEOUT_SECS: u64 = 1;
 
-async fn delegated_seed_rpc_timeout<F: Future>(future: F) -> Result<F::Output, ()> {
-    #[cfg(feature = "tokio-std")]
-    {
-        tokio::time::timeout(
-            core::time::Duration::from_secs(DELEGATED_SEED_RPC_TIMEOUT_SECS),
-            future,
-        )
-        .await
-        .map_err(|_| ())
-    }
-    #[cfg(all(not(feature = "tokio-std"), feature = "nostd-seed-router"))]
-    {
-        embassy_time::with_timeout(
-            embassy_time::Duration::from_secs(DELEGATED_SEED_RPC_TIMEOUT_SECS),
-            future,
-        )
-        .await
-        .map_err(|_| ())
-    }
-    #[cfg(not(any(feature = "tokio-std", feature = "nostd-seed-router")))]
-    {
-        Ok(future.await)
+async fn delegated_seed_rpc_timeout<F: Future, T: Future<Output = ()>>(
+    future: F,
+    timeout: T,
+) -> Result<F::Output, ()> {
+    match embassy_futures::select::select(future, timeout).await {
+        Either::First(output) => Ok(output),
+        Either::Second(()) => Err(()),
     }
 }
 
@@ -445,12 +508,18 @@ fn refresh_client_error(err: SeedClientError) -> SeedRefreshError {
 /// Handle an Assign request on a bridge: lease a net id from our own
 /// upstream seed router, register it as a delegated seed route, and answer
 /// downstream with a locally-issued assignment.
-async fn handle_assign_delegated<NS: NetStackHandle + Clone>(
+async fn handle_assign_delegated<NS, T, F>(
     nsh: &NS,
     refresh_port: u8,
+    release_port: u8,
     assign_req: &HeaderMessage<()>,
     upstream: <NS::Profile as crate::interface_manager::Profile>::InterfaceIdent,
-) {
+    timeout: &T,
+) where
+    NS: NetStackHandle + Clone,
+    T: Fn() -> F,
+    F: Future<Output = ()>,
+{
     let res = async {
         // Reject before leasing a net_id from upstream: if the source is
         // unknown or the route table is full, registration would fail *after*
@@ -458,19 +527,27 @@ async fn handle_assign_delegated<NS: NetStackHandle + Clone>(
         // single-task loop, so nothing fills the table during the await below.
         nsh.stack()
             .manage_profile(|p| p.can_delegate_seed(assign_req.hdr.src.network_id))?;
-        let lease = delegated_seed_rpc_timeout(request_seed_lease(nsh, upstream))
+        let lease = delegated_seed_rpc_timeout(request_seed_lease(nsh, upstream), timeout())
             .await
             .map_err(|_| SeedAssignmentError::UpstreamUnavailable)?
             .map_err(assignment_client_error)?;
         let assignment = nsh.stack().manage_profile(|p| {
             p.register_delegated_seed_net(assign_req.hdr.src.network_id, &lease)
-        })?;
+        });
+        let assignment = match assignment {
+            Ok(assignment) => assignment,
+            Err(error) => {
+                _ = delegated_seed_rpc_timeout(release_seed_lease(nsh, &lease), timeout()).await;
+                return Err(error);
+            }
+        };
         Ok(assignment)
     }
     .await;
     let res = res.map(|assignment| SeedRouterAssignment {
         assignment,
         refresh_port,
+        release_port,
     });
     _ = nsh
         .stack()
@@ -478,12 +555,53 @@ async fn handle_assign_delegated<NS: NetStackHandle + Clone>(
         .respond_owned::<ErgotSeedRouterAssignmentEndpoint>(&assign_req.hdr, &res);
 }
 
+async fn handle_release_delegated<NS, T, F>(
+    nsh: &NS,
+    release_req: &HeaderMessage<SeedRouterReleaseRequest>,
+    timeout: &T,
+) where
+    NS: NetStackHandle + Clone,
+    T: Fn() -> F,
+    F: Future<Output = ()>,
+{
+    let res = async {
+        let parent = nsh.stack().manage_profile(|p| {
+            p.prepare_delegated_release(
+                release_req.hdr.src.network_id,
+                release_req.t.release_net,
+                release_req.t.refresh_token,
+            )
+        })?;
+        delegated_seed_rpc_timeout(release_seed_lease(nsh, &parent), timeout())
+            .await
+            .map_err(|_| SeedRefreshError::UpstreamUnavailable)?
+            .map_err(refresh_client_error)?;
+        nsh.stack().manage_profile(|p| {
+            p.commit_delegated_release(
+                release_req.hdr.src.network_id,
+                release_req.t.release_net,
+                release_req.t.refresh_token,
+            )
+        })
+    }
+    .await;
+    _ = nsh
+        .stack()
+        .endpoints()
+        .respond_owned::<ErgotSeedRouterReleaseEndpoint>(&release_req.hdr, &res);
+}
+
 /// Handle a Refresh request on a bridge: validate the downstream token,
 /// refresh our own upstream lease, then extend the delegated route.
-async fn handle_refresh_delegated<NS: NetStackHandle + Clone>(
+async fn handle_refresh_delegated<NS, T, F>(
     nsh: &NS,
     refresh_req: &HeaderMessage<SeedRouterRefreshRequest>,
-) {
+    timeout: &T,
+) where
+    NS: NetStackHandle + Clone,
+    T: Fn() -> F,
+    F: Future<Output = ()>,
+{
     let res = async {
         // Validate and clone the profile-owned parent lease before touching
         // the upstream so bad tokens cannot trigger upstream traffic.
@@ -498,7 +616,7 @@ async fn handle_refresh_delegated<NS: NetStackHandle + Clone>(
             DelegatedRefreshPreparation::Forward(parent) => parent,
             DelegatedRefreshPreparation::Replay(assignment) => return Ok(assignment),
         };
-        let refreshed = delegated_seed_rpc_timeout(bridge_seed_refresh(nsh, &parent))
+        let refreshed = delegated_seed_rpc_timeout(bridge_seed_refresh(nsh, &parent), timeout())
             .await
             .map_err(|_| SeedRefreshError::UpstreamUnavailable)?
             .map_err(refresh_client_error)?;
@@ -548,9 +666,14 @@ pub async fn bridge_seed_assign<NS: NetStackHandle + Clone>(
     let lease = request_seed_lease(nsh, upstream_ident).await?;
 
     // Reassign downstream interface net_id
-    nsh.stack()
+    if nsh
+        .stack()
         .manage_profile(|im| im.reassign_interface_net_id(downstream_ident, lease.net_id))
-        .map_err(|_| SeedClientError::ReassignFailed)?;
+        .is_err()
+    {
+        _ = release_seed_lease(nsh, &lease).await;
+        return Err(SeedClientError::ReassignFailed);
+    }
 
     Ok(lease)
 }
@@ -568,7 +691,11 @@ pub async fn request_seed_lease<NS: NetStackHandle + Clone>(
     let upstream_net_id = nsh
         .stack()
         .manage_profile(|im| match im.interface_state(upstream_ident.clone()) {
-            Some(crate::interface_manager::InterfaceState::Active { net_id, .. }) => Some(net_id),
+            Some(crate::interface_manager::InterfaceState::Active { net_id, .. })
+                if net_id != 0 =>
+            {
+                Some(net_id)
+            }
             _ => None,
         })
         .ok_or(SeedClientError::UpstreamNotActive)?;
@@ -596,10 +723,16 @@ pub async fn request_seed_lease<NS: NetStackHandle + Clone>(
         node_id: crate::interface_manager::edge_port::CENTRAL_NODE_ID,
         port_id: assignment.refresh_port,
     };
+    let release_addr = crate::Address {
+        network_id: upstream_net_id,
+        node_id: crate::interface_manager::edge_port::CENTRAL_NODE_ID,
+        port_id: assignment.release_port,
+    };
 
     Ok(SeedLease {
         net_id: seed_net_id,
         refresh_addr,
+        release_addr,
         refresh_token: assignment.assignment.refresh_token,
         expires_seconds: assignment.assignment.expires_seconds,
         max_refresh_seconds: assignment.assignment.max_refresh_seconds,
@@ -631,11 +764,31 @@ pub async fn bridge_seed_refresh<NS: NetStackHandle + Clone>(
     Ok(SeedLease {
         net_id: refreshed.net_id,
         refresh_addr: lease.refresh_addr,
+        release_addr: lease.release_addr,
         refresh_token: refreshed.refresh_token,
         expires_seconds: refreshed.expires_seconds,
         max_refresh_seconds: refreshed.max_refresh_seconds,
         min_refresh_seconds: refreshed.min_refresh_seconds,
     })
+}
+
+/// Explicitly release an upstream seed lease.
+pub async fn release_seed_lease<NS: NetStackHandle + Clone>(
+    nsh: &NS,
+    lease: &SeedLease,
+) -> Result<(), SeedClientError> {
+    Endpoints { inner: nsh.clone() }
+        .request::<ErgotSeedRouterReleaseEndpoint>(
+            lease.release_addr,
+            &SeedRouterReleaseRequest {
+                release_net: lease.net_id,
+                refresh_token: lease.refresh_token,
+            },
+            None,
+        )
+        .await
+        .map_err(SeedClientError::RequestFailed)?
+        .map_err(SeedClientError::RefreshDenied)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -15,7 +15,7 @@ use crate::{
         SeedRouterAssignment, SeedRouterRefreshRequest, SocketQuery, SocketQueryResponse,
     },
 };
-use core::pin::pin;
+use core::{future::Future, pin::pin};
 
 pub use crate::interface_manager::SeedLease;
 
@@ -396,7 +396,51 @@ fn handle_refresh<NS: NetStackHandle>(
         .respond_owned::<ErgotSeedRouterRefreshEndpoint>(&refresh_req.hdr, &res);
 }
 
-use crate::interface_manager::{SeedAssignmentError, SeedRefreshError};
+use crate::interface_manager::{
+    DelegatedRefreshPreparation, SeedAssignmentError, SeedRefreshError,
+};
+
+#[cfg(any(feature = "tokio-std", feature = "nostd-seed-router"))]
+const DELEGATED_SEED_RPC_TIMEOUT_SECS: u64 = 1;
+
+async fn delegated_seed_rpc_timeout<F: Future>(future: F) -> Result<F::Output, ()> {
+    #[cfg(feature = "tokio-std")]
+    {
+        tokio::time::timeout(
+            core::time::Duration::from_secs(DELEGATED_SEED_RPC_TIMEOUT_SECS),
+            future,
+        )
+        .await
+        .map_err(|_| ())
+    }
+    #[cfg(all(not(feature = "tokio-std"), feature = "nostd-seed-router"))]
+    {
+        embassy_time::with_timeout(
+            embassy_time::Duration::from_secs(DELEGATED_SEED_RPC_TIMEOUT_SECS),
+            future,
+        )
+        .await
+        .map_err(|_| ())
+    }
+    #[cfg(not(any(feature = "tokio-std", feature = "nostd-seed-router")))]
+    {
+        Ok(future.await)
+    }
+}
+
+fn assignment_client_error(err: SeedClientError) -> SeedAssignmentError {
+    match err {
+        SeedClientError::AssignmentDenied(denied) => denied,
+        _ => SeedAssignmentError::UpstreamUnavailable,
+    }
+}
+
+fn refresh_client_error(err: SeedClientError) -> SeedRefreshError {
+    match err {
+        SeedClientError::RefreshDenied(denied) => denied,
+        _ => SeedRefreshError::UpstreamUnavailable,
+    }
+}
 
 /// Handle an Assign request on a bridge: lease a net id from our own
 /// upstream seed router, register it as a delegated seed route, and answer
@@ -414,9 +458,10 @@ async fn handle_assign_delegated<NS: NetStackHandle + Clone>(
         // single-task loop, so nothing fills the table during the await below.
         nsh.stack()
             .manage_profile(|p| p.can_delegate_seed(assign_req.hdr.src.network_id))?;
-        let lease = request_seed_lease(nsh, upstream)
+        let lease = delegated_seed_rpc_timeout(request_seed_lease(nsh, upstream))
             .await
-            .map_err(|_| SeedAssignmentError::NetIdsExhausted)?;
+            .map_err(|_| SeedAssignmentError::UpstreamUnavailable)?
+            .map_err(assignment_client_error)?;
         let assignment = nsh.stack().manage_profile(|p| {
             p.register_delegated_seed_net(assign_req.hdr.src.network_id, &lease)
         })?;
@@ -442,17 +487,21 @@ async fn handle_refresh_delegated<NS: NetStackHandle + Clone>(
     let res = async {
         // Validate and clone the profile-owned parent lease before touching
         // the upstream so bad tokens cannot trigger upstream traffic.
-        let parent = nsh.stack().manage_profile(|p| {
+        let prepared = nsh.stack().manage_profile(|p| {
             p.prepare_delegated_refresh(
                 refresh_req.hdr.src.network_id,
                 refresh_req.t.refresh_net,
                 refresh_req.t.refresh_token,
             )
         })?;
-        let refreshed = bridge_seed_refresh(nsh, &parent).await.map_err(|e| match e {
-            SeedClientError::RefreshDenied(denied) => denied,
-            _ => SeedRefreshError::BadRequest,
-        })?;
+        let parent = match prepared {
+            DelegatedRefreshPreparation::Forward(parent) => parent,
+            DelegatedRefreshPreparation::Replay(assignment) => return Ok(assignment),
+        };
+        let refreshed = delegated_seed_rpc_timeout(bridge_seed_refresh(nsh, &parent))
+            .await
+            .map_err(|_| SeedRefreshError::UpstreamUnavailable)?
+            .map_err(refresh_client_error)?;
         nsh.stack().manage_profile(|p| {
             p.commit_delegated_refresh(
                 refresh_req.hdr.src.network_id,

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -192,24 +192,51 @@ impl<NS: NetStackHandle> Services<NS> {
         let assign = pin!(assign);
         let mut assign_svr = assign.attach();
 
+        // Upstream leases held on behalf of downstream requesters, keyed by
+        // the delegated net id (bridges only; empty on root routers).
+        let mut parent_leases: heapless::Vec<SeedLease, 32> = heapless::Vec::new();
+
         loop {
             let res = embassy_futures::select::select(
                 assign_svr.recv_manual(),
                 refresh_svr.recv_manual(),
             )
             .await;
+            // Bridges delegate to the upstream seed router instead of
+            // allocating locally: the root must stay the single owner of
+            // the net-id space or nested assignments collide.
+            let upstream = nsh
+                .stack()
+                .manage_profile(|p| p.seed_delegation_upstream());
             match res {
                 Either::First(assign_req) => {
                     let Ok(assign_req) = assign_req else {
                         continue;
                     };
-                    handle_assign(&nsh, refresh_port, &assign_req)
+                    match upstream {
+                        Some(up) => {
+                            handle_assign_delegated(
+                                &nsh,
+                                refresh_port,
+                                &assign_req,
+                                up,
+                                &mut parent_leases,
+                            )
+                            .await
+                        }
+                        None => handle_assign(&nsh, refresh_port, &assign_req),
+                    }
                 }
                 Either::Second(refresh_req) => {
                     let Ok(refresh_req) = refresh_req else {
                         continue;
                     };
-                    handle_refresh(&nsh, &refresh_req);
+                    match upstream {
+                        Some(_) => {
+                            handle_refresh_delegated(&nsh, &refresh_req, &mut parent_leases).await
+                        }
+                        None => handle_refresh(&nsh, &refresh_req),
+                    }
                 }
             }
         }
@@ -380,6 +407,102 @@ fn handle_refresh<NS: NetStackHandle>(
         .respond_owned::<ErgotSeedRouterRefreshEndpoint>(&refresh_req.hdr, &res);
 }
 
+use crate::interface_manager::{SeedAssignmentError, SeedNetAssignment, SeedRefreshError};
+
+/// Handle an Assign request on a bridge: lease a net id from our own
+/// upstream seed router, register it as a delegated seed route, and answer
+/// downstream with a locally-issued assignment.
+async fn handle_assign_delegated<NS: NetStackHandle + Clone>(
+    nsh: &NS,
+    refresh_port: u8,
+    assign_req: &HeaderMessage<()>,
+    upstream: <NS::Profile as crate::interface_manager::Profile>::InterfaceIdent,
+    parent_leases: &mut heapless::Vec<SeedLease, 32>,
+) {
+    let res = async {
+        if parent_leases.is_full() {
+            return Err(SeedAssignmentError::NetIdsExhausted);
+        }
+        let lease = request_seed_lease(nsh, upstream)
+            .await
+            .map_err(|_| SeedAssignmentError::NetIdsExhausted)?;
+        let granted = SeedNetAssignment {
+            net_id: lease.net_id,
+            expires_seconds: lease.expires_seconds,
+            max_refresh_seconds: lease.max_refresh_seconds,
+            min_refresh_seconds: lease.min_refresh_seconds,
+            refresh_token: lease.refresh_token,
+        };
+        let assignment = nsh.stack().manage_profile(|p| {
+            p.register_delegated_seed_net(
+                lease.net_id,
+                assign_req.hdr.src.network_id,
+                &granted,
+            )
+        })?;
+        parent_leases.retain(|l| l.net_id != lease.net_id);
+        _ = parent_leases.push(lease);
+        Ok(assignment)
+    }
+    .await;
+    let res = res.map(|assignment| SeedRouterAssignment {
+        assignment,
+        refresh_port,
+    });
+    _ = nsh
+        .stack()
+        .endpoints()
+        .respond_owned::<ErgotSeedRouterAssignmentEndpoint>(&assign_req.hdr, &res);
+}
+
+/// Handle a Refresh request on a bridge: validate the downstream token,
+/// refresh our own upstream lease, then extend the delegated route.
+async fn handle_refresh_delegated<NS: NetStackHandle + Clone>(
+    nsh: &NS,
+    refresh_req: &HeaderMessage<SeedRouterRefreshRequest>,
+    parent_leases: &mut heapless::Vec<SeedLease, 32>,
+) {
+    let res = async {
+        // Validate before touching the upstream so bad tokens cannot
+        // trigger upstream traffic.
+        nsh.stack().manage_profile(|p| {
+            p.validate_delegated_refresh(
+                refresh_req.hdr.src.network_id,
+                refresh_req.t.refresh_net,
+                refresh_req.t.refresh_token,
+            )
+        })?;
+        let lease = parent_leases
+            .iter_mut()
+            .find(|l| l.net_id == refresh_req.t.refresh_net)
+            .ok_or(SeedRefreshError::UnknownNetId)?;
+        let refreshed = bridge_seed_refresh(nsh, lease).await.map_err(|e| match e {
+            SeedClientError::RefreshDenied(denied) => denied,
+            _ => SeedRefreshError::BadRequest,
+        })?;
+        *lease = refreshed.clone();
+        let granted = SeedNetAssignment {
+            net_id: refreshed.net_id,
+            expires_seconds: refreshed.expires_seconds,
+            max_refresh_seconds: refreshed.max_refresh_seconds,
+            min_refresh_seconds: refreshed.min_refresh_seconds,
+            refresh_token: refreshed.refresh_token,
+        };
+        nsh.stack().manage_profile(|p| {
+            p.refresh_delegated_seed_net(
+                refresh_req.hdr.src.network_id,
+                refresh_req.t.refresh_token,
+                &granted,
+            )
+        })
+    }
+    .await;
+    _ = nsh
+        .stack()
+        .endpoints()
+        .respond_owned::<ErgotSeedRouterRefreshEndpoint>(&refresh_req.hdr, &res);
+}
+
 // ---------------------------------------------------------------------------
 // Bridge seed routing client
 // ---------------------------------------------------------------------------
@@ -427,6 +550,23 @@ pub async fn bridge_seed_assign<NS: NetStackHandle + Clone>(
     upstream_ident: <NS::Profile as crate::interface_manager::Profile>::InterfaceIdent,
     downstream_ident: <NS::Profile as crate::interface_manager::Profile>::InterfaceIdent,
 ) -> Result<SeedLease, SeedClientError> {
+    let lease = request_seed_lease(nsh, upstream_ident).await?;
+
+    // Reassign downstream interface net_id
+    nsh.stack()
+        .manage_profile(|im| im.reassign_interface_net_id(downstream_ident, lease.net_id))
+        .map_err(|_| SeedClientError::ReassignFailed)?;
+
+    Ok(lease)
+}
+
+/// Request a seed net-id lease from the upstream seed router, without
+/// binding it to a local interface. Used directly when delegating a
+/// downstream requester's assignment up the tree.
+pub async fn request_seed_lease<NS: NetStackHandle + Clone>(
+    nsh: &NS,
+    upstream_ident: <NS::Profile as crate::interface_manager::Profile>::InterfaceIdent,
+) -> Result<SeedLease, SeedClientError> {
     use crate::interface_manager::Profile;
 
     // 1. Get upstream net_id
@@ -455,12 +595,7 @@ pub async fn bridge_seed_assign<NS: NetStackHandle + Clone>(
 
     let seed_net_id = assignment.assignment.net_id;
 
-    // 3. Reassign downstream interface net_id
-    nsh.stack()
-        .manage_profile(|im| im.reassign_interface_net_id(downstream_ident, seed_net_id))
-        .map_err(|_| SeedClientError::ReassignFailed)?;
-
-    // 4. Build refresh address
+    // 3. Build refresh address
     let refresh_addr = crate::Address {
         network_id: upstream_net_id,
         node_id: crate::interface_manager::edge_port::CENTRAL_NODE_ID,

--- a/crates/ergot/src/well_known.rs
+++ b/crates/ergot/src/well_known.rs
@@ -76,6 +76,7 @@ topic!(
 
 pub type SeedRouterAssignmentResponse = Result<SeedRouterAssignment, SeedAssignmentError>;
 pub type SeedRouterRefreshResponse = Result<SeedNetAssignment, SeedRefreshError>;
+pub type SeedRouterReleaseResponse = Result<(), SeedRefreshError>;
 endpoint!(
     ErgotSeedRouterAssignmentEndpoint,
     (),
@@ -87,6 +88,12 @@ endpoint!(
     SeedRouterRefreshRequest,
     SeedRouterRefreshResponse,
     "ergot/.well-known/seed-router/refresh"
+);
+endpoint!(
+    ErgotSeedRouterReleaseEndpoint,
+    SeedRouterReleaseRequest,
+    SeedRouterReleaseResponse,
+    "ergot/.well-known/seed-router/release"
 );
 
 #[derive(Debug, Serialize, Deserialize, Schema, Clone, Hash, PartialEq, Eq)]
@@ -133,12 +140,20 @@ pub struct SocketQueryResponse {
 pub struct SeedRouterAssignment {
     pub assignment: SeedNetAssignment,
     pub refresh_port: u8,
+    pub release_port: u8,
 }
 
 #[derive(Debug, Serialize, Deserialize, Schema, Clone, PartialEq)]
 #[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
 pub struct SeedRouterRefreshRequest {
     pub refresh_net: u16,
+    pub refresh_token: [u8; 8],
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
+pub struct SeedRouterReleaseRequest {
+    pub release_net: u16,
     pub refresh_token: [u8; 8],
 }
 

--- a/crates/ergot/tests/bridge_router.rs
+++ b/crates/ergot/tests/bridge_router.rs
@@ -87,6 +87,12 @@ fn make_bridge(log: &Arc<Mutex<Vec<String>>>) -> TestRouter {
     )
 }
 
+fn register_downstream(router: &mut TestRouter, sink: RecordingSink, net_id: u16) -> u8 {
+    let ident = router.register_interface_pending(sink).unwrap();
+    router.reassign_interface_net_id(ident, net_id).unwrap();
+    ident
+}
+
 fn make_hdr(src_net: u16, dst_net: u16, dst_node: u8, dst_port: u8) -> Header {
     Header {
         src: Address {
@@ -199,9 +205,7 @@ fn bridge_routes_known_downstream() {
         .unwrap();
 
     // Register downstream with net_id=1
-    router
-        .register_interface(RecordingSink::new("down0", log.clone()))
-        .unwrap();
+    register_downstream(&mut router, RecordingSink::new("down0", log.clone()), 1);
 
     // Send to net_id=1, node=2 — should go to downstream, NOT upstream
     let hdr = make_hdr(0, 1, 2, 5);
@@ -233,9 +237,7 @@ fn bridge_forwards_unknown_to_upstream() {
         .unwrap();
 
     // Register downstream
-    router
-        .register_interface(RecordingSink::new("down0", log.clone()))
-        .unwrap();
+    register_downstream(&mut router, RecordingSink::new("down0", log.clone()), 1);
 
     // Send to net_id=99 — unknown downstream, should go upstream
     let hdr = make_hdr(0, 99, 2, 5);
@@ -282,12 +284,8 @@ fn bridge_broadcast_includes_upstream() {
         )
         .unwrap();
 
-    router
-        .register_interface(RecordingSink::new("down0", log.clone()))
-        .unwrap();
-    router
-        .register_interface(RecordingSink::new("down1", log.clone()))
-        .unwrap();
+    register_downstream(&mut router, RecordingSink::new("down0", log.clone()), 1);
+    register_downstream(&mut router, RecordingSink::new("down1", log.clone()), 2);
 
     let hdr = make_broadcast_hdr();
     router.send(&hdr, &42u32).unwrap();
@@ -320,12 +318,8 @@ fn bridge_broadcast_from_upstream_skips_upstream() {
         )
         .unwrap();
 
-    router
-        .register_interface(RecordingSink::new("down0", log.clone()))
-        .unwrap();
-    router
-        .register_interface(RecordingSink::new("down1", log.clone()))
-        .unwrap();
+    register_downstream(&mut router, RecordingSink::new("down0", log.clone()), 1);
+    register_downstream(&mut router, RecordingSink::new("down1", log.clone()), 2);
 
     // Raw broadcast from upstream (source=UPSTREAM_IDENT)
     let hdr = HeaderSeq {
@@ -419,13 +413,13 @@ fn bridge_downstream_to_downstream_no_upstream() {
         )
         .unwrap();
 
-    let id0 = router
-        .register_interface(RecordingSink::new("down0", log.clone()))
-        .unwrap();
+    let id0 = register_downstream(
+        &mut router,
+        RecordingSink::new("down0", log.clone()),
+        1,
+    );
     // net_id=2
-    router
-        .register_interface(RecordingSink::new("down1", log.clone()))
-        .unwrap();
+    register_downstream(&mut router, RecordingSink::new("down1", log.clone()), 2);
 
     // Raw packet from down0 destined to net_id=2 (down1)
     let hdr = HeaderSeq {
@@ -473,9 +467,7 @@ fn bridge_send_err_forwards_upstream() {
         )
         .unwrap();
 
-    router
-        .register_interface(RecordingSink::new("down0", log.clone()))
-        .unwrap();
+    register_downstream(&mut router, RecordingSink::new("down0", log.clone()), 1);
 
     // Error to unknown net_id — should go upstream
     let hdr = Header {
@@ -518,9 +510,11 @@ fn broadcast_full_everywhere_reports_genuine_failure() {
     // genuinely failed — the failure must win over the benign default.
     let log = Arc::new(Mutex::new(Vec::new()));
     let mut router = make_bridge(&log);
-    router
-        .register_interface(RecordingSink::new_failing("down0", log.clone()))
-        .unwrap();
+    register_downstream(
+        &mut router,
+        RecordingSink::new_failing("down0", log.clone()),
+        1,
+    );
 
     let res = router.send(&make_broadcast_hdr(), &1234u64);
     assert_eq!(res, Err(InterfaceSendError::InterfaceFull));
@@ -532,12 +526,12 @@ fn broadcast_partial_success_is_ok() {
     // is success.
     let log = Arc::new(Mutex::new(Vec::new()));
     let mut router = make_bridge(&log);
-    router
-        .register_interface(RecordingSink::new_failing("down0", log.clone()))
-        .unwrap();
-    router
-        .register_interface(RecordingSink::new("down1", log.clone()))
-        .unwrap();
+    register_downstream(
+        &mut router,
+        RecordingSink::new_failing("down0", log.clone()),
+        1,
+    );
+    register_downstream(&mut router, RecordingSink::new("down1", log.clone()), 2);
 
     router.send(&make_broadcast_hdr(), &1234u64).unwrap();
 }
@@ -557,9 +551,11 @@ fn broadcast_raw_full_everywhere_reports_genuine_failure() {
     // upstream that fails on every downstream queue reports the failure.
     let log = Arc::new(Mutex::new(Vec::new()));
     let mut router = make_bridge(&log);
-    router
-        .register_interface(RecordingSink::new_failing("down0", log.clone()))
-        .unwrap();
+    register_downstream(
+        &mut router,
+        RecordingSink::new_failing("down0", log.clone()),
+        1,
+    );
 
     let hdr = HeaderSeq {
         src: Address {

--- a/crates/ergot/tests/e2e_bridge.rs
+++ b/crates/ergot/tests/e2e_bridge.rs
@@ -88,7 +88,7 @@ async fn bridge_forwards_ping_upstream() {
     .await
     .unwrap();
 
-    tokio_cobs_stream::register_router(
+    let bridge_down = tokio_cobs_stream::register_bridge_downstream(
         bridge_stack.clone(),
         bridge_d0_read,
         bridge_d0_write,
@@ -154,6 +154,15 @@ async fn bridge_forwards_ping_upstream() {
     .await;
 
     sleep(Duration::from_millis(200)).await;
+
+    let bridge_down_assignment = root_stack
+        .manage_profile(|im| im.request_seed_net_assign(1))
+        .unwrap();
+    bridge_stack
+        .manage_profile(|im| {
+            im.reassign_interface_net_id(bridge_down, bridge_down_assignment.net_id)
+        })
+        .unwrap();
 
     // Bootstrap edge1 through bridge
     let bridge_d0_net = bridge_stack

--- a/crates/ergot/tests/e2e_bridge_discovery.rs
+++ b/crates/ergot/tests/e2e_bridge_discovery.rs
@@ -156,6 +156,31 @@ async fn host_discovers_and_pings_through_bridge() {
     // Let services register sockets
     sleep(Duration::from_millis(50)).await;
 
+    // Bootstrap the upstream identity before asking for a lease. A source
+    // network of zero is deliberately rejected by the seed client.
+    let _ = timeout(
+        Duration::from_millis(500),
+        root_stack.endpoints().request::<ergot::well_known::ErgotPingEndpoint>(
+            Address {
+                network_id: 1,
+                node_id: 2,
+                port_id: 0,
+            },
+            &0u32,
+            Some("ping"),
+        ),
+    )
+    .await;
+    for _ in 0..20 {
+        if matches!(
+            bridge_stack.manage_profile(|im| im.interface_state(UPSTREAM_IDENT)),
+            Some(InterfaceState::Active { net_id: 1, .. })
+        ) {
+            break;
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+
     // ========== Bridge: seed assign via link-local upstream ==========
     let lease = timeout(
         Duration::from_secs(5),

--- a/crates/ergot/tests/e2e_seed_delegation.rs
+++ b/crates/ergot/tests/e2e_seed_delegation.rs
@@ -1,0 +1,189 @@
+//! E2E: hierarchical seed delegation.
+//!
+//! A bridge running `seed_router_request_handler` that has an upstream must
+//! **delegate** a downstream's seed request to the root, not allocate from its
+//! own pool — otherwise two allocators share one 16-bit space and nested
+//! assignments collide (the original "1.2" bug).
+//!
+//! ```text
+//!   Requester ──(cobs)── Bridge ──(cobs, upstream)── Root
+//! ```
+//!
+//! The test makes root's next-free net_id (5) differ from the bridge's (3) by
+//! pre-consuming net_ids on each, then asserts the requester's delegated net_id
+//! is the **root**-allocated 5. Local allocation (the bug) would hand out the
+//! bridge's 3.
+
+#![cfg(feature = "tokio-std")]
+#![cfg(not(miri))]
+
+mod common;
+
+use std::time::Duration;
+
+use ergot::{
+    Address,
+    interface_manager::{
+        InterfaceState, Profile,
+        interface_impls::tokio_stream::TokioStreamInterface,
+        profiles::router::{Router, UPSTREAM_IDENT},
+    },
+    net_stack::{ArcNetStack, services::request_seed_lease},
+    well_known::ErgotPingEndpoint,
+};
+use mutex::raw_impls::cs::CriticalSectionRawMutex;
+use tokio::time::{sleep, timeout};
+
+type RouterStack =
+    ArcNetStack<CriticalSectionRawMutex, Router<TokioStreamInterface, rand::rngs::StdRng, 64, 64>>;
+
+async fn wait_interface_active(stack: &RouterStack, ident: u8) -> u16 {
+    for _ in 0..60 {
+        if let Some(InterfaceState::Active { net_id, .. }) =
+            stack.manage_profile(|im| im.interface_state(ident))
+        {
+            return net_id;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    panic!("interface {ident} never became Active");
+}
+
+/// Register a downstream on `stack` whose far end is held alive but never
+/// written, so the interface stays registered (consuming a net_id) without
+/// carrying traffic.
+async fn consume_net_id(stack: &RouterStack, held: &mut Vec<tokio::io::DuplexStream>) {
+    let (near_read, far_write) = tokio::io::duplex(64);
+    let (far_read, near_write) = tokio::io::duplex(64);
+    ergot::interface_manager::transports::tokio_cobs_stream::register_router(
+        stack.clone(),
+        near_read,
+        near_write,
+        512,
+        4096,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    held.push(far_write);
+    held.push(far_read);
+}
+
+#[tokio::test]
+async fn bridge_delegates_downstream_request_to_root() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    use ergot::interface_manager::transports::tokio_cobs_stream as tcs;
+    use ergot::interface_manager::utils::{cobs_stream, std::new_std_queue};
+
+    // ---- Stacks ----
+    let root: RouterStack = RouterStack::new();
+
+    let bridge_up_queue = new_std_queue(4096);
+    let bridge: RouterStack = RouterStack::new_with_profile(Router::new_bridge_std(
+        cobs_stream::Sink::new_from_handle(bridge_up_queue.clone(), 512),
+    ));
+
+    let requester_up_queue = new_std_queue(4096);
+    let requester: RouterStack = RouterStack::new_with_profile(Router::new_bridge_std(
+        cobs_stream::Sink::new_from_handle(requester_up_queue.clone(), 512),
+    ));
+
+    // ---- Seed handlers on root AND bridge (bridge will delegate) ----
+    tokio::spawn({
+        let s = root.clone();
+        async move { s.services().seed_router_request_handler::<4>().await }
+    });
+    tokio::spawn({
+        let s = root.clone();
+        async move { s.services().ping_handler::<4>().await }
+    });
+    tokio::spawn({
+        let s = bridge.clone();
+        async move { s.services().seed_router_request_handler::<4>().await }
+    });
+
+    // ---- root ⟷ bridge upstream link (root assigns the bridge link net_id=1) ----
+    let (bridge_up_read, root_b_write) = tokio::io::duplex(8192);
+    let (root_b_read, bridge_up_write) = tokio::io::duplex(8192);
+    tcs::register_router(root.clone(), root_b_read, root_b_write, 512, 4096, None, None)
+        .await
+        .unwrap();
+    tcs::register_bridge_upstream(
+        bridge.clone(),
+        bridge_up_read,
+        bridge_up_write,
+        bridge_up_queue,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Pre-consume net_ids so root's next-free (5) differs from the bridge's (3):
+    // root holds nets 2,3,4 in addition to the bridge link (1).
+    let mut held = Vec::new();
+    consume_net_id(&root, &mut held).await; // net 2
+    consume_net_id(&root, &mut held).await; // net 3
+    consume_net_id(&root, &mut held).await; // net 4
+
+    // Bootstrap the bridge upstream: a frame from root makes it discover net 1.
+    let _ = timeout(
+        Duration::from_millis(500),
+        root.endpoints()
+            .request::<ErgotPingEndpoint>(Address { network_id: 1, node_id: 2, port_id: 0 }, &0u32, Some("ping")),
+    )
+    .await;
+    let bridge_up_net = wait_interface_active(&bridge, UPSTREAM_IDENT).await;
+    assert_eq!(bridge_up_net, 1, "bridge upstream should be root-assigned net 1");
+
+    // ---- bridge ⟷ requester link. Registered now (after the bridge upstream
+    // is net 1), so it gets the bridge's net 2; the bridge's next-free is 3. ----
+    let (req_up_read, bridge_r_write) = tokio::io::duplex(8192);
+    let (bridge_r_read, req_up_write) = tokio::io::duplex(8192);
+    let bridge_down = tcs::register_router(
+        bridge.clone(),
+        bridge_r_read,
+        bridge_r_write,
+        512,
+        4096,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        bridge.manage_profile(|im| im.net_id_of(bridge_down)),
+        Some(2),
+        "bridge's requester link should be net 2 (next-free is then 3)"
+    );
+    tcs::register_bridge_upstream(
+        requester.clone(),
+        req_up_read,
+        req_up_write,
+        requester_up_queue,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // ---- The requester asks the bridge for a seed net_id ----
+    let lease = timeout(
+        Duration::from_secs(5),
+        request_seed_lease(&requester, UPSTREAM_IDENT),
+    )
+    .await
+    .expect("seed lease timed out — the bridge did not answer")
+    .expect("seed lease request failed");
+
+    // Delegation => root allocated it (root's next-free is 5).
+    // The local-allocation bug would have handed out the bridge's next-free, 3.
+    assert_eq!(
+        lease.net_id, 5,
+        "delegated net_id must come from the root's pool (5), not the bridge's local pool (3)"
+    );
+
+    drop(held);
+}

--- a/crates/ergot/tests/e2e_seed_delegation.rs
+++ b/crates/ergot/tests/e2e_seed_delegation.rs
@@ -28,7 +28,10 @@ use ergot::{
         interface_impls::tokio_stream::TokioStreamInterface,
         profiles::router::{Router, UPSTREAM_IDENT},
     },
-    net_stack::{ArcNetStack, services::request_seed_lease},
+    net_stack::{
+        ArcNetStack,
+        services::{bridge_seed_refresh, request_seed_lease},
+    },
     well_known::ErgotPingEndpoint,
 };
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
@@ -99,7 +102,7 @@ async fn bridge_delegates_downstream_request_to_root() {
         let s = root.clone();
         async move { s.services().ping_handler::<4>().await }
     });
-    tokio::spawn({
+    let bridge_seed_handler = tokio::spawn({
         let s = bridge.clone();
         async move { s.services().seed_router_request_handler::<4>().await }
     });
@@ -184,6 +187,25 @@ async fn bridge_delegates_downstream_request_to_root() {
         lease.net_id, 5,
         "delegated net_id must come from the root's pool (5), not the bridge's local pool (3)"
     );
+
+    // The parent lease is profile-owned, not task-local: restarting the
+    // handler must not lose the upstream token needed to refresh this route.
+    bridge_seed_handler.abort();
+    let _ = bridge_seed_handler.await;
+    let replacement_handler = tokio::spawn({
+        let s = bridge.clone();
+        async move { s.services().seed_router_request_handler::<4>().await }
+    });
+    let refreshed = timeout(
+        Duration::from_secs(5),
+        bridge_seed_refresh(&requester, &lease),
+    )
+    .await
+    .expect("seed refresh timed out after handler restart")
+    .expect("seed refresh failed after handler restart");
+    assert_eq!(refreshed.net_id, lease.net_id);
+    assert_ne!(refreshed.refresh_token, lease.refresh_token);
+    replacement_handler.abort();
 
     drop(held);
 }

--- a/crates/ergot/tests/e2e_seed_delegation.rs
+++ b/crates/ergot/tests/e2e_seed_delegation.rs
@@ -187,3 +187,177 @@ async fn bridge_delegates_downstream_request_to_root() {
 
     drop(held);
 }
+
+/// The previous test proves the delegated net_id comes from the root's pool.
+/// This one proves the resulting route is actually *routable*: a ping from the
+/// root reaches an edge attached behind the requester, traversing both
+/// delegated seed-route hops (Root→Bridge→Requester→Edge).
+///
+/// ```text
+///   Edge ──(cobs)── Requester ──(cobs)── Bridge ──(cobs, upstream)── Root
+/// ```
+#[tokio::test]
+async fn delegated_route_is_routable_end_to_end() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    use common::{make_edge_stack, ping_with_retry, spawn_ping_server, wait_active};
+    use ergot::interface_manager::profiles::direct_edge::EdgeFrameProcessor;
+    use ergot::interface_manager::transports::tokio_cobs_stream as tcs;
+    use ergot::interface_manager::utils::{cobs_stream, std::new_std_queue};
+    use ergot::net_stack::services::bridge_seed_assign;
+
+    // ---- Stacks ----
+    let root: RouterStack = RouterStack::new();
+
+    let bridge_up_queue = new_std_queue(4096);
+    let bridge: RouterStack = RouterStack::new_with_profile(Router::new_bridge_std(
+        cobs_stream::Sink::new_from_handle(bridge_up_queue.clone(), 512),
+    ));
+
+    let requester_up_queue = new_std_queue(4096);
+    let requester: RouterStack = RouterStack::new_with_profile(Router::new_bridge_std(
+        cobs_stream::Sink::new_from_handle(requester_up_queue.clone(), 512),
+    ));
+
+    let (edge, edge_queue) = make_edge_stack();
+
+    // ---- Seed handlers on root AND bridge (bridge delegates) ----
+    tokio::spawn({
+        let s = root.clone();
+        async move { s.services().seed_router_request_handler::<4>().await }
+    });
+    tokio::spawn({
+        let s = bridge.clone();
+        async move { s.services().seed_router_request_handler::<4>().await }
+    });
+
+    // ---- root ⟷ bridge upstream (root assigns the bridge link net_id=1) ----
+    let (bridge_up_read, root_b_write) = tokio::io::duplex(8192);
+    let (root_b_read, bridge_up_write) = tokio::io::duplex(8192);
+    tcs::register_router(root.clone(), root_b_read, root_b_write, 512, 4096, None, None)
+        .await
+        .unwrap();
+    tcs::register_bridge_upstream(
+        bridge.clone(),
+        bridge_up_read,
+        bridge_up_write,
+        bridge_up_queue,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Pre-consume net_ids on root (it holds 2,3,4 besides the bridge link 1) so
+    // the delegated net (root's next-free, 5) cannot coincide with a
+    // bridge-local link net — the bridge↔requester link below is net 2.
+    let mut held = Vec::new();
+    consume_net_id(&root, &mut held).await; // net 2
+    consume_net_id(&root, &mut held).await; // net 3
+    consume_net_id(&root, &mut held).await; // net 4
+
+    // Bootstrap the bridge upstream.
+    let _ = timeout(
+        Duration::from_millis(500),
+        root.endpoints().request::<ErgotPingEndpoint>(
+            Address { network_id: 1, node_id: 2, port_id: 0 },
+            &0u32,
+            Some("ping"),
+        ),
+    )
+    .await;
+    assert_eq!(wait_interface_active(&bridge, UPSTREAM_IDENT).await, 1);
+
+    // ---- bridge ⟷ requester link (bridge-local net 2), registered after the
+    // bridge upstream is net 1 ----
+    let (req_up_read, bridge_r_write) = tokio::io::duplex(8192);
+    let (bridge_r_read, req_up_write) = tokio::io::duplex(8192);
+    let bridge_down =
+        tcs::register_router(bridge.clone(), bridge_r_read, bridge_r_write, 512, 4096, None, None)
+            .await
+            .unwrap();
+    assert_eq!(bridge.manage_profile(|im| im.net_id_of(bridge_down)), Some(2));
+    tcs::register_bridge_upstream(
+        requester.clone(),
+        req_up_read,
+        req_up_write,
+        requester_up_queue,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // ---- requester ⟷ edge link (pending; the seed assign gives it the
+    // delegated net) ----
+    let (edge_read, req_d_write) = tokio::io::duplex(8192);
+    let (req_d_read, edge_write) = tokio::io::duplex(8192);
+    let req_down = tcs::register_bridge_downstream(
+        requester.clone(),
+        req_d_read,
+        req_d_write,
+        512,
+        4096,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    tcs::register_edge::<_, TokioStreamInterface, _, _>(
+        edge.clone(),
+        edge_read,
+        edge_write,
+        edge_queue,
+        EdgeFrameProcessor::new(),
+        InterfaceState::Inactive,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    spawn_ping_server(&edge);
+
+    // Bootstrap the requester upstream: the bridge pings the requester's
+    // upstream node so it discovers net 2.
+    let _ = timeout(
+        Duration::from_millis(500),
+        bridge.endpoints().request::<ErgotPingEndpoint>(
+            Address { network_id: 2, node_id: 2, port_id: 0 },
+            &0u32,
+            Some("ping"),
+        ),
+    )
+    .await;
+    assert_eq!(wait_interface_active(&requester, UPSTREAM_IDENT).await, 2);
+
+    // ---- The requester asks the bridge for a seed net for its edge link; the
+    // bridge delegates to root → root allocates net 5 and the requester
+    // reassigns the edge link to it ----
+    let lease = timeout(
+        Duration::from_secs(5),
+        bridge_seed_assign(&requester, UPSTREAM_IDENT, req_down),
+    )
+    .await
+    .expect("seed assign timed out")
+    .expect("seed assign failed");
+    assert_eq!(lease.net_id, 5, "delegated net must come from the root's pool");
+    assert!(
+        matches!(
+            requester.manage_profile(|im| im.interface_state(req_down)),
+            Some(InterfaceState::Active { net_id: 5, .. })
+        ),
+        "the requester's edge link should be reassigned to the delegated net 5"
+    );
+
+    // ---- E2E: root pings the edge across both delegated hops ----
+    let edge_addr = Address { network_id: 5, node_id: 2, port_id: 0 };
+    ping_with_retry(&root, edge_addr, 0).await; // bootstrap the edge
+    wait_active(&edge).await;
+    let resp = ping_with_retry(&root, edge_addr, 42).await;
+    assert_eq!(
+        resp, 42,
+        "root must reach the edge Root→Bridge→Requester→Edge via the delegated seed routes"
+    );
+
+    drop(held);
+}

--- a/crates/ergot/tests/e2e_seed_delegation.rs
+++ b/crates/ergot/tests/e2e_seed_delegation.rs
@@ -9,10 +9,8 @@
 //!   Requester ──(cobs)── Bridge ──(cobs, upstream)── Root
 //! ```
 //!
-//! The test makes root's next-free net_id (5) differ from the bridge's (3) by
-//! pre-consuming net_ids on each, then asserts the requester's delegated net_id
-//! is the **root**-allocated 5. Local allocation (the bug) would hand out the
-//! bridge's 3.
+//! Every bridge downlink starts pending and receives its net_id from the root,
+//! so there is only one allocator for the whole hierarchy.
 
 #![cfg(feature = "tokio-std")]
 #![cfg(not(miri))]
@@ -50,27 +48,6 @@ async fn wait_interface_active(stack: &RouterStack, ident: u8) -> u16 {
         sleep(Duration::from_millis(50)).await;
     }
     panic!("interface {ident} never became Active");
-}
-
-/// Register a downstream on `stack` whose far end is held alive but never
-/// written, so the interface stays registered (consuming a net_id) without
-/// carrying traffic.
-async fn consume_net_id(stack: &RouterStack, held: &mut Vec<tokio::io::DuplexStream>) {
-    let (near_read, far_write) = tokio::io::duplex(64);
-    let (far_read, near_write) = tokio::io::duplex(64);
-    ergot::interface_manager::transports::tokio_cobs_stream::register_router(
-        stack.clone(),
-        near_read,
-        near_write,
-        512,
-        4096,
-        None,
-        None,
-    )
-    .await
-    .unwrap();
-    held.push(far_write);
-    held.push(far_read);
 }
 
 #[tokio::test]
@@ -124,13 +101,6 @@ async fn bridge_delegates_downstream_request_to_root() {
     .await
     .unwrap();
 
-    // Pre-consume net_ids so root's next-free (5) differs from the bridge's (3):
-    // root holds nets 2,3,4 in addition to the bridge link (1).
-    let mut held = Vec::new();
-    consume_net_id(&root, &mut held).await; // net 2
-    consume_net_id(&root, &mut held).await; // net 3
-    consume_net_id(&root, &mut held).await; // net 4
-
     // Bootstrap the bridge upstream: a frame from root makes it discover net 1.
     let _ = timeout(
         Duration::from_millis(500),
@@ -141,11 +111,10 @@ async fn bridge_delegates_downstream_request_to_root() {
     let bridge_up_net = wait_interface_active(&bridge, UPSTREAM_IDENT).await;
     assert_eq!(bridge_up_net, 1, "bridge upstream should be root-assigned net 1");
 
-    // ---- bridge ⟷ requester link. Registered now (after the bridge upstream
-    // is net 1), so it gets the bridge's net 2; the bridge's next-free is 3. ----
+    // ---- bridge ⟷ requester link. It starts pending, then root assigns net 2. ----
     let (req_up_read, bridge_r_write) = tokio::io::duplex(8192);
     let (bridge_r_read, req_up_write) = tokio::io::duplex(8192);
-    let bridge_down = tcs::register_router(
+    let bridge_down = tcs::register_bridge_downstream(
         bridge.clone(),
         bridge_r_read,
         bridge_r_write,
@@ -156,10 +125,16 @@ async fn bridge_delegates_downstream_request_to_root() {
     )
     .await
     .unwrap();
+    let bridge_link = root
+        .manage_profile(|im| im.request_seed_net_assign(1))
+        .unwrap();
+    bridge
+        .manage_profile(|im| im.reassign_interface_net_id(bridge_down, bridge_link.net_id))
+        .unwrap();
     assert_eq!(
         bridge.manage_profile(|im| im.net_id_of(bridge_down)),
         Some(2),
-        "bridge's requester link should be net 2 (next-free is then 3)"
+        "bridge's requester link should use root-assigned net 2"
     );
     tcs::register_bridge_upstream(
         requester.clone(),
@@ -172,6 +147,21 @@ async fn bridge_delegates_downstream_request_to_root() {
     .await
     .unwrap();
 
+    let _ = timeout(
+        Duration::from_millis(500),
+        bridge.endpoints().request::<ErgotPingEndpoint>(
+            Address {
+                network_id: 2,
+                node_id: 2,
+                port_id: 0,
+            },
+            &0u32,
+            Some("ping"),
+        ),
+    )
+    .await;
+    assert_eq!(wait_interface_active(&requester, UPSTREAM_IDENT).await, 2);
+
     // ---- The requester asks the bridge for a seed net_id ----
     let lease = timeout(
         Duration::from_secs(5),
@@ -181,11 +171,10 @@ async fn bridge_delegates_downstream_request_to_root() {
     .expect("seed lease timed out — the bridge did not answer")
     .expect("seed lease request failed");
 
-    // Delegation => root allocated it (root's next-free is 5).
-    // The local-allocation bug would have handed out the bridge's next-free, 3.
+    // Delegation => root allocated the next globally unique net.
     assert_eq!(
-        lease.net_id, 5,
-        "delegated net_id must come from the root's pool (5), not the bridge's local pool (3)"
+        lease.net_id, 3,
+        "delegated net_id must come from the root's pool"
     );
 
     // The parent lease is profile-owned, not task-local: restarting the
@@ -207,7 +196,6 @@ async fn bridge_delegates_downstream_request_to_root() {
     assert_ne!(refreshed.refresh_token, lease.refresh_token);
     replacement_handler.abort();
 
-    drop(held);
 }
 
 /// The previous test proves the delegated net_id comes from the root's pool.
@@ -270,14 +258,6 @@ async fn delegated_route_is_routable_end_to_end() {
     .await
     .unwrap();
 
-    // Pre-consume net_ids on root (it holds 2,3,4 besides the bridge link 1) so
-    // the delegated net (root's next-free, 5) cannot coincide with a
-    // bridge-local link net — the bridge↔requester link below is net 2.
-    let mut held = Vec::new();
-    consume_net_id(&root, &mut held).await; // net 2
-    consume_net_id(&root, &mut held).await; // net 3
-    consume_net_id(&root, &mut held).await; // net 4
-
     // Bootstrap the bridge upstream.
     let _ = timeout(
         Duration::from_millis(500),
@@ -290,14 +270,19 @@ async fn delegated_route_is_routable_end_to_end() {
     .await;
     assert_eq!(wait_interface_active(&bridge, UPSTREAM_IDENT).await, 1);
 
-    // ---- bridge ⟷ requester link (bridge-local net 2), registered after the
-    // bridge upstream is net 1 ----
+    // ---- bridge ⟷ requester link (root-assigned net 2) ----
     let (req_up_read, bridge_r_write) = tokio::io::duplex(8192);
     let (bridge_r_read, req_up_write) = tokio::io::duplex(8192);
     let bridge_down =
-        tcs::register_router(bridge.clone(), bridge_r_read, bridge_r_write, 512, 4096, None, None)
+        tcs::register_bridge_downstream(bridge.clone(), bridge_r_read, bridge_r_write, 512, 4096, None, None)
             .await
             .unwrap();
+    let bridge_link = root
+        .manage_profile(|im| im.request_seed_net_assign(1))
+        .unwrap();
+    bridge
+        .manage_profile(|im| im.reassign_interface_net_id(bridge_down, bridge_link.net_id))
+        .unwrap();
     assert_eq!(bridge.manage_profile(|im| im.net_id_of(bridge_down)), Some(2));
     tcs::register_bridge_upstream(
         requester.clone(),
@@ -353,7 +338,7 @@ async fn delegated_route_is_routable_end_to_end() {
     assert_eq!(wait_interface_active(&requester, UPSTREAM_IDENT).await, 2);
 
     // ---- The requester asks the bridge for a seed net for its edge link; the
-    // bridge delegates to root → root allocates net 5 and the requester
+    // bridge delegates to root → root allocates net 3 and the requester
     // reassigns the edge link to it ----
     let lease = timeout(
         Duration::from_secs(5),
@@ -362,17 +347,17 @@ async fn delegated_route_is_routable_end_to_end() {
     .await
     .expect("seed assign timed out")
     .expect("seed assign failed");
-    assert_eq!(lease.net_id, 5, "delegated net must come from the root's pool");
+    assert_eq!(lease.net_id, 3, "delegated net must come from the root's pool");
     assert!(
         matches!(
             requester.manage_profile(|im| im.interface_state(req_down)),
-            Some(InterfaceState::Active { net_id: 5, .. })
+            Some(InterfaceState::Active { net_id: 3, .. })
         ),
-        "the requester's edge link should be reassigned to the delegated net 5"
+        "the requester's edge link should be reassigned to delegated net 3"
     );
 
     // ---- E2E: root pings the edge across both delegated hops ----
-    let edge_addr = Address { network_id: 5, node_id: 2, port_id: 0 };
+    let edge_addr = Address { network_id: 3, node_id: 2, port_id: 0 };
     ping_with_retry(&root, edge_addr, 0).await; // bootstrap the edge
     wait_active(&edge).await;
     let resp = ping_with_retry(&root, edge_addr, 42).await;
@@ -381,5 +366,4 @@ async fn delegated_route_is_routable_end_to_end() {
         "root must reach the edge Root→Bridge→Requester→Edge via the delegated seed routes"
     );
 
-    drop(held);
 }

--- a/crates/ergot/tests/edge_rediscovery.rs
+++ b/crates/ergot/tests/edge_rediscovery.rs
@@ -16,7 +16,7 @@
 use ergot::{
     Address, FrameKind, HeaderSeq,
     interface_manager::{
-        FrameProcessor, Interface, InterfaceSink, InterfaceState, Profile,
+        FrameProcessor, Interface, InterfaceSink, InterfaceState, Profile, SeedLease,
         profiles::{
             direct_edge::{CENTRAL_NODE_ID, DirectEdge, EDGE_NODE_ID, EdgeFrameProcessor},
             router::{Router, UPSTREAM_IDENT},
@@ -91,12 +91,32 @@ fn bridge_stack() -> BridgeStack {
         NullSink,
     ));
     let slot_ident = stack
-        .manage_profile(|im| im.register_interface(NullSink))
+        .manage_profile(|im| im.register_interface_pending(NullSink))
+        .unwrap();
+    stack
+        .manage_profile(|im| im.reassign_interface_net_id(slot_ident, 1))
         .unwrap();
     let slot_net = stack.manage_profile(|im| im.net_id_of(slot_ident)).unwrap();
     assert_eq!(slot_net, 1);
+    let parent = SeedLease {
+        net_id: 2,
+        refresh_addr: Address {
+            network_id: 7,
+            node_id: CENTRAL_NODE_ID,
+            port_id: 42,
+        },
+        release_addr: Address {
+            network_id: 7,
+            node_id: CENTRAL_NODE_ID,
+            port_id: 43,
+        },
+        refresh_token: [0xAA; 8],
+        expires_seconds: 30,
+        max_refresh_seconds: 120,
+        min_refresh_seconds: 62,
+    };
     let seed = stack
-        .manage_profile(|im| im.request_seed_net_assign(slot_net))
+        .manage_profile(|im| im.register_delegated_seed_net(slot_net, &parent))
         .unwrap();
     assert_eq!(seed.net_id, 2);
     stack

--- a/crates/ergot/tests/seed_delegation.rs
+++ b/crates/ergot/tests/seed_delegation.rs
@@ -1,0 +1,265 @@
+//! Unit tests for hierarchical seed delegation.
+//!
+//! These exercise the `Router` delegation hooks directly (the part ported onto
+//! `LeaseTable` when this branch was rebased onto bus-address-claim):
+//! `seed_delegation_upstream`, `register_delegated_seed_net`,
+//! `validate_delegated_refresh`, and `refresh_delegated_seed_net`.
+//!
+//! TODO: an end-to-end cascade test (a bridge running `seed_router_request_handler`
+//! delegating a downstream's request up to the root, then the root routing back
+//! to the requester via the transit route gained as a side effect) is still
+//! missing — it would cover the handler dispatch and the "no net_id collision
+//! across nested bridges" property that motivated this change.
+
+#![cfg(feature = "tokio-std")]
+#![cfg(not(miri))]
+
+use ergot::{
+    HeaderSeq, ProtocolError,
+    interface_manager::{
+        Interface, InterfaceSink, Profile, SeedAssignmentError, SeedNetAssignment,
+        SeedRefreshError,
+        profiles::router::{Router, UPSTREAM_IDENT},
+    },
+    net_stack::ArcNetStack,
+};
+use mutex::raw_impls::cs::CriticalSectionRawMutex;
+use rand::SeedableRng;
+use serde::Serialize;
+
+// A sink that drops everything — these tests inspect return values and the
+// claim/route tables, not forwarded frames.
+#[derive(Clone)]
+struct NullSink;
+impl InterfaceSink for NullSink {
+    fn mtu(&self) -> u16 {
+        2048
+    }
+    fn send_ty<T: Serialize>(&mut self, _: &HeaderSeq, _: &T) -> Result<(), ()> {
+        Ok(())
+    }
+    fn send_raw(&mut self, _: &HeaderSeq, _: &[u8]) -> Result<(), ()> {
+        Ok(())
+    }
+    fn send_err(&mut self, _: &HeaderSeq, _: ProtocolError) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
+struct MockInterface;
+impl Interface for MockInterface {
+    type Sink = NullSink;
+}
+
+type TestRouter = Router<MockInterface, rand::rngs::StdRng, 8, 8, 4>;
+type TestStack = ArcNetStack<CriticalSectionRawMutex, TestRouter>;
+
+fn rng(seed: u8) -> rand::rngs::StdRng {
+    rand::rngs::StdRng::from_seed([seed; 32])
+}
+
+/// An upstream lease as it would arrive from the parent seed router.
+fn upstream_grant(net_id: u16, expires: u16) -> SeedNetAssignment {
+    SeedNetAssignment {
+        net_id,
+        expires_seconds: expires,
+        max_refresh_seconds: 120,
+        min_refresh_seconds: 62,
+        refresh_token: 0x1122_3344_5566_7788u64.to_le_bytes(),
+    }
+}
+
+#[test]
+fn delegation_upstream_only_on_bridges() {
+    // A root router (no upstream) does not delegate.
+    let root: TestStack = TestStack::new_with_profile(Router::new(rng(0)));
+    assert_eq!(
+        root.manage_profile(|im| im.seed_delegation_upstream()),
+        None,
+        "a root router must not delegate"
+    );
+
+    // A bridge router delegates to its upstream interface.
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(1), NullSink));
+    assert_eq!(
+        bridge.manage_profile(|im| im.seed_delegation_upstream()),
+        Some(UPSTREAM_IDENT),
+        "a bridge router delegates via UPSTREAM_IDENT"
+    );
+}
+
+#[test]
+fn register_delegated_seed_net_registers_and_shrinks_refresh_window() {
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(2), NullSink));
+    // Downstream that the requester is reachable through (gets net_id=1).
+    let down = bridge
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
+    assert_eq!(source_net, 1);
+
+    // Unknown source_net is rejected.
+    assert_eq!(
+        bridge.manage_profile(|im| im.register_delegated_seed_net(
+            5,
+            999,
+            &upstream_grant(5, 30)
+        )),
+        Err(SeedAssignmentError::UnknownSource)
+    );
+
+    // Register the net leased from upstream (net_id=5) on behalf of source_net=1.
+    let assignment = bridge
+        .manage_profile(|im| im.register_delegated_seed_net(5, source_net, &upstream_grant(5, 30)))
+        .expect("delegated registration should succeed");
+
+    assert_eq!(assignment.net_id, 5);
+    assert_eq!(assignment.expires_seconds, 30);
+    assert_eq!(assignment.max_refresh_seconds, 120);
+    // min_refresh is shrunk by the per-hop margin so a child refreshes inside
+    // the parent's window (62 - 5 = 57).
+    assert_eq!(assignment.min_refresh_seconds, 57);
+    // The downstream is handed a *local* token, not the upstream's.
+    assert_ne!(assignment.refresh_token, upstream_grant(5, 30).refresh_token);
+
+    // The route now validates for its requester.
+    assert_eq!(
+        bridge.manage_profile(|im| im.validate_delegated_refresh(
+            source_net,
+            5,
+            assignment.refresh_token
+        )),
+        Ok(())
+    );
+}
+
+#[test]
+fn validate_delegated_refresh_checks_scope_token_and_existence() {
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(3), NullSink));
+    let down = bridge
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
+
+    let assignment = bridge
+        .manage_profile(|im| im.register_delegated_seed_net(7, source_net, &upstream_grant(7, 30)))
+        .unwrap();
+
+    // Correct (scope, token) validates.
+    assert_eq!(
+        bridge.manage_profile(|im| im.validate_delegated_refresh(
+            source_net,
+            7,
+            assignment.refresh_token
+        )),
+        Ok(())
+    );
+    // Wrong token.
+    assert_eq!(
+        bridge.manage_profile(|im| im.validate_delegated_refresh(source_net, 7, [0xFF; 8])),
+        Err(SeedRefreshError::BadRequest)
+    );
+    // Wrong requester (scope).
+    assert_eq!(
+        bridge.manage_profile(|im| im.validate_delegated_refresh(
+            source_net + 1,
+            7,
+            assignment.refresh_token
+        )),
+        Err(SeedRefreshError::BadRequest)
+    );
+    // Unknown net_id.
+    assert_eq!(
+        bridge.manage_profile(|im| im.validate_delegated_refresh(
+            source_net,
+            999,
+            assignment.refresh_token
+        )),
+        Err(SeedRefreshError::UnknownNetId)
+    );
+}
+
+#[test]
+fn refresh_delegated_seed_net_extends_and_rotates_token() {
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(4), NullSink));
+    let down = bridge
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
+
+    let first = bridge
+        .manage_profile(|im| im.register_delegated_seed_net(9, source_net, &upstream_grant(9, 30)))
+        .unwrap();
+
+    // Refresh with the refreshed upstream lease (now 120s).
+    let refreshed = bridge
+        .manage_profile(|im| {
+            im.refresh_delegated_seed_net(source_net, first.refresh_token, &upstream_grant(9, 120))
+        })
+        .expect("delegated refresh should succeed");
+
+    assert_eq!(refreshed.net_id, 9);
+    assert_eq!(refreshed.expires_seconds, 120, "lease should track the upstream lease");
+    assert_eq!(refreshed.min_refresh_seconds, 57);
+    assert_ne!(
+        refreshed.refresh_token, first.refresh_token,
+        "the local token must rotate on refresh"
+    );
+
+    // The old token no longer validates; the rotated one does.
+    assert_eq!(
+        bridge.manage_profile(|im| im.validate_delegated_refresh(
+            source_net,
+            9,
+            first.refresh_token
+        )),
+        Err(SeedRefreshError::BadRequest)
+    );
+    assert_eq!(
+        bridge.manage_profile(|im| im.validate_delegated_refresh(
+            source_net,
+            9,
+            refreshed.refresh_token
+        )),
+        Ok(())
+    );
+
+    // Refreshing an unknown net_id fails.
+    assert_eq!(
+        bridge.manage_profile(|im| im.refresh_delegated_seed_net(
+            source_net,
+            refreshed.refresh_token,
+            &upstream_grant(123, 120)
+        )),
+        Err(SeedRefreshError::UnknownNetId)
+    );
+}
+
+#[test]
+fn re_delegation_of_same_net_is_idempotent() {
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(5), NullSink));
+    let down = bridge
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
+
+    let first = bridge
+        .manage_profile(|im| im.register_delegated_seed_net(11, source_net, &upstream_grant(11, 30)))
+        .unwrap();
+    // Re-delegating the same net_id (e.g. the downstream re-requested) replaces
+    // the stale entry rather than duplicating or erroring.
+    let second = bridge
+        .manage_profile(|im| im.register_delegated_seed_net(11, source_net, &upstream_grant(11, 30)))
+        .expect("re-delegation should succeed");
+
+    // Only the latest token is valid (the stale entry was removed).
+    assert_eq!(
+        bridge.manage_profile(|im| im.validate_delegated_refresh(source_net, 11, second.refresh_token)),
+        Ok(())
+    );
+    assert_eq!(
+        bridge.manage_profile(|im| im.validate_delegated_refresh(source_net, 11, first.refresh_token)),
+        Err(SeedRefreshError::BadRequest),
+        "the superseded token must no longer validate"
+    );
+}

--- a/crates/ergot/tests/seed_delegation.rs
+++ b/crates/ergot/tests/seed_delegation.rs
@@ -5,11 +5,10 @@
 //! `seed_delegation_upstream`, `register_delegated_seed_net`,
 //! `validate_delegated_refresh`, and `refresh_delegated_seed_net`.
 //!
-//! TODO: an end-to-end cascade test (a bridge running `seed_router_request_handler`
-//! delegating a downstream's request up to the root, then the root routing back
-//! to the requester via the transit route gained as a side effect) is still
-//! missing — it would cover the handler dispatch and the "no net_id collision
-//! across nested bridges" property that motivated this change.
+//! The end-to-end cascade — a bridge running `seed_router_request_handler`
+//! delegating a downstream's request up to the root, and the "no net_id
+//! collision across nested bridges" property that motivated this change — is
+//! covered in `e2e_seed_delegation.rs`.
 
 #![cfg(feature = "tokio-std")]
 #![cfg(not(miri))]

--- a/crates/ergot/tests/seed_delegation.rs
+++ b/crates/ergot/tests/seed_delegation.rs
@@ -262,3 +262,37 @@ fn re_delegation_of_same_net_is_idempotent() {
         "the superseded token must no longer validate"
     );
 }
+
+#[test]
+fn can_delegate_seed_gates_unknown_source_and_full_table() {
+    // S = 8 (route-table capacity) for TestRouter.
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(6), NullSink));
+    let down = bridge
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
+
+    // Unknown source is rejected before any upstream lease is requested.
+    assert_eq!(
+        bridge.manage_profile(|im| im.can_delegate_seed(source_net + 999)),
+        Err(SeedAssignmentError::UnknownSource)
+    );
+    // A known source with room succeeds.
+    assert_eq!(
+        bridge.manage_profile(|im| im.can_delegate_seed(source_net)),
+        Ok(())
+    );
+
+    // Fill the route table, then the pre-flight reports it full (so the
+    // handler won't lease an upstream net_id it can't register).
+    for net in 100u16..108 {
+        bridge
+            .manage_profile(|im| im.register_delegated_seed_net(net, source_net, &upstream_grant(net, 30)))
+            .expect("registration should succeed until the table is full");
+    }
+    assert_eq!(
+        bridge.manage_profile(|im| im.can_delegate_seed(source_net)),
+        Err(SeedAssignmentError::NetIdsExhausted),
+        "a full route table must be rejected up front"
+    );
+}

--- a/crates/ergot/tests/seed_delegation.rs
+++ b/crates/ergot/tests/seed_delegation.rs
@@ -3,7 +3,7 @@
 //! These exercise the `Router` delegation hooks directly (the part ported onto
 //! `LeaseTable` when this branch was rebased onto bus-address-claim):
 //! `seed_delegation_upstream`, `register_delegated_seed_net`,
-//! `validate_delegated_refresh`, and `refresh_delegated_seed_net`.
+//! `prepare_delegated_refresh`, and `commit_delegated_refresh`.
 //!
 //! The end-to-end cascade — a bridge running `seed_router_request_handler`
 //! delegating a downstream's request up to the root, and the "no net_id
@@ -14,10 +14,9 @@
 #![cfg(not(miri))]
 
 use ergot::{
-    HeaderSeq, ProtocolError,
+    Address, HeaderSeq, ProtocolError,
     interface_manager::{
-        Interface, InterfaceSink, Profile, SeedAssignmentError, SeedNetAssignment,
-        SeedRefreshError,
+        Interface, InterfaceSink, Profile, SeedAssignmentError, SeedLease, SeedRefreshError,
         profiles::router::{Router, UPSTREAM_IDENT},
     },
     net_stack::ArcNetStack,
@@ -58,13 +57,18 @@ fn rng(seed: u8) -> rand::rngs::StdRng {
 }
 
 /// An upstream lease as it would arrive from the parent seed router.
-fn upstream_grant(net_id: u16, expires: u16) -> SeedNetAssignment {
-    SeedNetAssignment {
+fn upstream_grant(net_id: u16, expires: u16) -> SeedLease {
+    SeedLease {
         net_id,
+        refresh_addr: Address {
+            network_id: 1,
+            node_id: 1,
+            port_id: 42,
+        },
         expires_seconds: expires,
         max_refresh_seconds: 120,
         min_refresh_seconds: 62,
-        refresh_token: 0x1122_3344_5566_7788u64.to_le_bytes(),
+        refresh_token: (0x1122_3344_5566_7788u64 ^ expires as u64).to_le_bytes(),
     }
 }
 
@@ -100,7 +104,6 @@ fn register_delegated_seed_net_registers_and_shrinks_refresh_window() {
     // Unknown source_net is rejected.
     assert_eq!(
         bridge.manage_profile(|im| im.register_delegated_seed_net(
-            5,
             999,
             &upstream_grant(5, 30)
         )),
@@ -109,7 +112,7 @@ fn register_delegated_seed_net_registers_and_shrinks_refresh_window() {
 
     // Register the net leased from upstream (net_id=5) on behalf of source_net=1.
     let assignment = bridge
-        .manage_profile(|im| im.register_delegated_seed_net(5, source_net, &upstream_grant(5, 30)))
+        .manage_profile(|im| im.register_delegated_seed_net(source_net, &upstream_grant(5, 30)))
         .expect("delegated registration should succeed");
 
     assert_eq!(assignment.net_id, 5);
@@ -123,17 +126,18 @@ fn register_delegated_seed_net_registers_and_shrinks_refresh_window() {
 
     // The route now validates for its requester.
     assert_eq!(
-        bridge.manage_profile(|im| im.validate_delegated_refresh(
+        bridge.manage_profile(|im| im.prepare_delegated_refresh(
             source_net,
             5,
             assignment.refresh_token
         )),
-        Ok(())
+        Ok(upstream_grant(5, 30)),
+        "the complete parent lease must be stored with the route"
     );
 }
 
 #[test]
-fn validate_delegated_refresh_checks_scope_token_and_existence() {
+fn prepare_delegated_refresh_checks_scope_token_and_existence() {
     let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(3), NullSink));
     let down = bridge
         .manage_profile(|im| im.register_interface(NullSink))
@@ -141,26 +145,26 @@ fn validate_delegated_refresh_checks_scope_token_and_existence() {
     let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
 
     let assignment = bridge
-        .manage_profile(|im| im.register_delegated_seed_net(7, source_net, &upstream_grant(7, 30)))
+        .manage_profile(|im| im.register_delegated_seed_net(source_net, &upstream_grant(7, 30)))
         .unwrap();
 
     // Correct (scope, token) validates.
-    assert_eq!(
-        bridge.manage_profile(|im| im.validate_delegated_refresh(
+    assert!(
+        bridge.manage_profile(|im| im.prepare_delegated_refresh(
             source_net,
             7,
             assignment.refresh_token
-        )),
-        Ok(())
+        ))
+        .is_ok()
     );
     // Wrong token.
     assert_eq!(
-        bridge.manage_profile(|im| im.validate_delegated_refresh(source_net, 7, [0xFF; 8])),
+        bridge.manage_profile(|im| im.prepare_delegated_refresh(source_net, 7, [0xFF; 8])),
         Err(SeedRefreshError::BadRequest)
     );
     // Wrong requester (scope).
     assert_eq!(
-        bridge.manage_profile(|im| im.validate_delegated_refresh(
+        bridge.manage_profile(|im| im.prepare_delegated_refresh(
             source_net + 1,
             7,
             assignment.refresh_token
@@ -169,7 +173,7 @@ fn validate_delegated_refresh_checks_scope_token_and_existence() {
     );
     // Unknown net_id.
     assert_eq!(
-        bridge.manage_profile(|im| im.validate_delegated_refresh(
+        bridge.manage_profile(|im| im.prepare_delegated_refresh(
             source_net,
             999,
             assignment.refresh_token
@@ -179,7 +183,7 @@ fn validate_delegated_refresh_checks_scope_token_and_existence() {
 }
 
 #[test]
-fn refresh_delegated_seed_net_extends_and_rotates_token() {
+fn commit_delegated_refresh_extends_and_rotates_token() {
     let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(4), NullSink));
     let down = bridge
         .manage_profile(|im| im.register_interface(NullSink))
@@ -187,13 +191,13 @@ fn refresh_delegated_seed_net_extends_and_rotates_token() {
     let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
 
     let first = bridge
-        .manage_profile(|im| im.register_delegated_seed_net(9, source_net, &upstream_grant(9, 30)))
+        .manage_profile(|im| im.register_delegated_seed_net(source_net, &upstream_grant(9, 30)))
         .unwrap();
 
     // Refresh with the refreshed upstream lease (now 120s).
     let refreshed = bridge
         .manage_profile(|im| {
-            im.refresh_delegated_seed_net(source_net, first.refresh_token, &upstream_grant(9, 120))
+            im.commit_delegated_refresh(source_net, first.refresh_token, &upstream_grant(9, 120))
         })
         .expect("delegated refresh should succeed");
 
@@ -204,28 +208,37 @@ fn refresh_delegated_seed_net_extends_and_rotates_token() {
         refreshed.refresh_token, first.refresh_token,
         "the local token must rotate on refresh"
     );
+    assert_eq!(
+        bridge.manage_profile(|im| im.prepare_delegated_refresh(
+            source_net,
+            9,
+            refreshed.refresh_token
+        )),
+        Ok(upstream_grant(9, 120)),
+        "commit must atomically replace the stored parent lease"
+    );
 
     // The old token no longer validates; the rotated one does.
     assert_eq!(
-        bridge.manage_profile(|im| im.validate_delegated_refresh(
+        bridge.manage_profile(|im| im.prepare_delegated_refresh(
             source_net,
             9,
             first.refresh_token
         )),
         Err(SeedRefreshError::BadRequest)
     );
-    assert_eq!(
-        bridge.manage_profile(|im| im.validate_delegated_refresh(
+    assert!(
+        bridge.manage_profile(|im| im.prepare_delegated_refresh(
             source_net,
             9,
             refreshed.refresh_token
-        )),
-        Ok(())
+        ))
+        .is_ok()
     );
 
     // Refreshing an unknown net_id fails.
     assert_eq!(
-        bridge.manage_profile(|im| im.refresh_delegated_seed_net(
+        bridge.manage_profile(|im| im.commit_delegated_refresh(
             source_net,
             refreshed.refresh_token,
             &upstream_grant(123, 120)
@@ -243,21 +256,22 @@ fn re_delegation_of_same_net_is_idempotent() {
     let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
 
     let first = bridge
-        .manage_profile(|im| im.register_delegated_seed_net(11, source_net, &upstream_grant(11, 30)))
+        .manage_profile(|im| im.register_delegated_seed_net(source_net, &upstream_grant(11, 30)))
         .unwrap();
     // Re-delegating the same net_id (e.g. the downstream re-requested) replaces
     // the stale entry rather than duplicating or erroring.
     let second = bridge
-        .manage_profile(|im| im.register_delegated_seed_net(11, source_net, &upstream_grant(11, 30)))
+        .manage_profile(|im| im.register_delegated_seed_net(source_net, &upstream_grant(11, 30)))
         .expect("re-delegation should succeed");
 
     // Only the latest token is valid (the stale entry was removed).
-    assert_eq!(
-        bridge.manage_profile(|im| im.validate_delegated_refresh(source_net, 11, second.refresh_token)),
-        Ok(())
+    assert!(
+        bridge
+            .manage_profile(|im| im.prepare_delegated_refresh(source_net, 11, second.refresh_token))
+            .is_ok()
     );
     assert_eq!(
-        bridge.manage_profile(|im| im.validate_delegated_refresh(source_net, 11, first.refresh_token)),
+        bridge.manage_profile(|im| im.prepare_delegated_refresh(source_net, 11, first.refresh_token)),
         Err(SeedRefreshError::BadRequest),
         "the superseded token must no longer validate"
     );
@@ -287,12 +301,46 @@ fn can_delegate_seed_gates_unknown_source_and_full_table() {
     // handler won't lease an upstream net_id it can't register).
     for net in 100u16..108 {
         bridge
-            .manage_profile(|im| im.register_delegated_seed_net(net, source_net, &upstream_grant(net, 30)))
+            .manage_profile(|im| im.register_delegated_seed_net(source_net, &upstream_grant(net, 30)))
             .expect("registration should succeed until the table is full");
     }
     assert_eq!(
         bridge.manage_profile(|im| im.can_delegate_seed(source_net)),
         Err(SeedAssignmentError::NetIdsExhausted),
         "a full route table must be rejected up front"
+    );
+}
+
+#[test]
+fn delegated_parent_state_scales_with_route_capacity() {
+    type LargeRouter = Router<MockInterface, rand::rngs::StdRng, 1, 40, 0>;
+    type LargeStack = ArcNetStack<CriticalSectionRawMutex, LargeRouter>;
+
+    let bridge: LargeStack =
+        LargeStack::new_with_profile(Router::new_bridge(rng(7), NullSink));
+    let down = bridge
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
+
+    for net_id in 100u16..140 {
+        let assignment = bridge
+            .manage_profile(|im| {
+                im.register_delegated_seed_net(source_net, &upstream_grant(net_id, 30))
+            })
+            .expect("every route up to S must carry its own parent lease");
+        assert_eq!(
+            bridge.manage_profile(|im| im.prepare_delegated_refresh(
+                source_net,
+                net_id,
+                assignment.refresh_token,
+            )),
+            Ok(upstream_grant(net_id, 30))
+        );
+    }
+
+    assert_eq!(
+        bridge.manage_profile(|im| im.can_delegate_seed(source_net)),
+        Err(SeedAssignmentError::NetIdsExhausted)
     );
 }

--- a/crates/ergot/tests/seed_delegation.rs
+++ b/crates/ergot/tests/seed_delegation.rs
@@ -16,7 +16,8 @@
 use ergot::{
     Address, HeaderSeq, ProtocolError,
     interface_manager::{
-        Interface, InterfaceSink, Profile, SeedAssignmentError, SeedLease, SeedRefreshError,
+        DelegatedRefreshPreparation, Interface, InterfaceSink, Profile, SeedAssignmentError,
+        SeedLease, SeedRefreshError,
         profiles::router::{Router, UPSTREAM_IDENT},
     },
     net_stack::ArcNetStack,
@@ -131,7 +132,7 @@ fn register_delegated_seed_net_registers_and_shrinks_refresh_window() {
             5,
             assignment.refresh_token
         )),
-        Ok(upstream_grant(5, 30)),
+        Ok(DelegatedRefreshPreparation::Forward(upstream_grant(5, 30))),
         "the complete parent lease must be stored with the route"
     );
 }
@@ -214,18 +215,19 @@ fn commit_delegated_refresh_extends_and_rotates_token() {
             9,
             refreshed.refresh_token
         )),
-        Ok(upstream_grant(9, 120)),
+        Ok(DelegatedRefreshPreparation::Forward(upstream_grant(9, 120))),
         "commit must atomically replace the stored parent lease"
     );
 
-    // The old token no longer validates; the rotated one does.
+    // The immediately previous token replays the committed response so a lost
+    // response can be retried without another upstream refresh.
     assert_eq!(
         bridge.manage_profile(|im| im.prepare_delegated_refresh(
             source_net,
             9,
             first.refresh_token
         )),
-        Err(SeedRefreshError::BadRequest)
+        Ok(DelegatedRefreshPreparation::Replay(refreshed.clone()))
     );
     assert!(
         bridge.manage_profile(|im| im.prepare_delegated_refresh(
@@ -335,7 +337,9 @@ fn delegated_parent_state_scales_with_route_capacity() {
                 net_id,
                 assignment.refresh_token,
             )),
-            Ok(upstream_grant(net_id, 30))
+            Ok(DelegatedRefreshPreparation::Forward(upstream_grant(
+                net_id, 30
+            )))
         );
     }
 

--- a/crates/ergot/tests/seed_delegation.rs
+++ b/crates/ergot/tests/seed_delegation.rs
@@ -57,6 +57,16 @@ fn rng(seed: u8) -> rand::rngs::StdRng {
     rand::rngs::StdRng::from_seed([seed; 32])
 }
 
+fn add_downstream(stack: &TestStack, net_id: u16) -> u8 {
+    let ident = stack
+        .manage_profile(|im| im.register_interface_pending(NullSink))
+        .unwrap();
+    stack
+        .manage_profile(|im| im.reassign_interface_net_id(ident, net_id))
+        .unwrap();
+    ident
+}
+
 /// An upstream lease as it would arrive from the parent seed router.
 fn upstream_grant(net_id: u16, expires: u16) -> SeedLease {
     SeedLease {
@@ -65,6 +75,11 @@ fn upstream_grant(net_id: u16, expires: u16) -> SeedLease {
             network_id: 1,
             node_id: 1,
             port_id: 42,
+        },
+        release_addr: Address {
+            network_id: 1,
+            node_id: 1,
+            port_id: 43,
         },
         expires_seconds: expires,
         max_refresh_seconds: 120,
@@ -96,9 +111,7 @@ fn delegation_upstream_only_on_bridges() {
 fn register_delegated_seed_net_registers_and_shrinks_refresh_window() {
     let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(2), NullSink));
     // Downstream that the requester is reachable through (gets net_id=1).
-    let down = bridge
-        .manage_profile(|im| im.register_interface(NullSink))
-        .unwrap();
+    let down = add_downstream(&bridge, 1);
     let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
     assert_eq!(source_net, 1);
 
@@ -140,9 +153,7 @@ fn register_delegated_seed_net_registers_and_shrinks_refresh_window() {
 #[test]
 fn prepare_delegated_refresh_checks_scope_token_and_existence() {
     let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(3), NullSink));
-    let down = bridge
-        .manage_profile(|im| im.register_interface(NullSink))
-        .unwrap();
+    let down = add_downstream(&bridge, 1);
     let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
 
     let assignment = bridge
@@ -186,9 +197,7 @@ fn prepare_delegated_refresh_checks_scope_token_and_existence() {
 #[test]
 fn commit_delegated_refresh_extends_and_rotates_token() {
     let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(4), NullSink));
-    let down = bridge
-        .manage_profile(|im| im.register_interface(NullSink))
-        .unwrap();
+    let down = add_downstream(&bridge, 1);
     let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
 
     let first = bridge
@@ -252,9 +261,7 @@ fn commit_delegated_refresh_extends_and_rotates_token() {
 #[test]
 fn re_delegation_of_same_net_is_idempotent() {
     let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(5), NullSink));
-    let down = bridge
-        .manage_profile(|im| im.register_interface(NullSink))
-        .unwrap();
+    let down = add_downstream(&bridge, 1);
     let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
 
     let first = bridge
@@ -283,9 +290,7 @@ fn re_delegation_of_same_net_is_idempotent() {
 fn can_delegate_seed_gates_unknown_source_and_full_table() {
     // S = 8 (route-table capacity) for TestRouter.
     let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(6), NullSink));
-    let down = bridge
-        .manage_profile(|im| im.register_interface(NullSink))
-        .unwrap();
+    let down = add_downstream(&bridge, 1);
     let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
 
     // Unknown source is rejected before any upstream lease is requested.
@@ -321,7 +326,10 @@ fn delegated_parent_state_scales_with_route_capacity() {
     let bridge: LargeStack =
         LargeStack::new_with_profile(Router::new_bridge(rng(7), NullSink));
     let down = bridge
-        .manage_profile(|im| im.register_interface(NullSink))
+        .manage_profile(|im| im.register_interface_pending(NullSink))
+        .unwrap();
+    bridge
+        .manage_profile(|im| im.reassign_interface_net_id(down, 1))
         .unwrap();
     let source_net = bridge.manage_profile(|im| im.net_id_of(down)).unwrap();
 

--- a/crates/ergot/tests/seed_delegation_regressions.rs
+++ b/crates/ergot/tests/seed_delegation_regressions.rs
@@ -1,0 +1,450 @@
+//! Regression tests for delegated seed failure handling.
+
+#![cfg(feature = "tokio-std")]
+#![cfg(not(miri))]
+
+use std::time::Duration;
+
+use ergot::{
+    Address, HeaderSeq, ProtocolError,
+    interface_manager::{
+        Interface, InterfaceSink, InterfaceState, Profile, SeedAssignmentError, SeedLease,
+        SeedRefreshError,
+        interface_impls::tokio_stream::TokioStreamInterface,
+        profiles::router::{Router, UPSTREAM_IDENT},
+    },
+    net_stack::{
+        ArcNetStack,
+        services::{SeedClientError, bridge_seed_refresh, request_seed_lease},
+    },
+    well_known::{ErgotPingEndpoint, ErgotSeedRouterAssignmentEndpoint},
+};
+use mutex::raw_impls::cs::CriticalSectionRawMutex;
+use rand::SeedableRng;
+use serde::Serialize;
+use tokio::time::{sleep, timeout};
+
+#[derive(Clone)]
+struct NullSink;
+
+impl InterfaceSink for NullSink {
+    fn mtu(&self) -> u16 {
+        2048
+    }
+
+    fn send_ty<T: Serialize>(&mut self, _: &HeaderSeq, _: &T) -> Result<(), ()> {
+        Ok(())
+    }
+
+    fn send_raw(&mut self, _: &HeaderSeq, _: &[u8]) -> Result<(), ()> {
+        Ok(())
+    }
+
+    fn send_err(&mut self, _: &HeaderSeq, _: ProtocolError) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
+struct MockInterface;
+
+impl Interface for MockInterface {
+    type Sink = NullSink;
+}
+
+type TestRouter = Router<MockInterface, rand::rngs::StdRng, 8, 8, 4>;
+type TestStack = ArcNetStack<CriticalSectionRawMutex, TestRouter>;
+
+fn rng(seed: u8) -> rand::rngs::StdRng {
+    rand::rngs::StdRng::from_seed([seed; 32])
+}
+
+#[test]
+fn upstream_refresh_retry_after_lost_response_is_idempotent() {
+    let root: TestStack = TestStack::new_with_profile(Router::new(rng(1)));
+    let root_down = root
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let root_source_net = root.manage_profile(|im| im.net_id_of(root_down)).unwrap();
+
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(2), NullSink));
+    let bridge_down = bridge
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let bridge_source_net = bridge
+        .manage_profile(|im| im.net_id_of(bridge_down))
+        .unwrap();
+
+    let parent_assignment = root
+        .manage_profile(|im| im.request_seed_net_assign(root_source_net))
+        .unwrap();
+    let parent = SeedLease {
+        net_id: parent_assignment.net_id,
+        refresh_addr: Address {
+            network_id: root_source_net,
+            node_id: 1,
+            port_id: 42,
+        },
+        refresh_token: parent_assignment.refresh_token,
+        expires_seconds: parent_assignment.expires_seconds,
+        max_refresh_seconds: parent_assignment.max_refresh_seconds,
+        min_refresh_seconds: parent_assignment.min_refresh_seconds,
+    };
+    let child_assignment = bridge
+        .manage_profile(|im| im.register_delegated_seed_net(bridge_source_net, &parent))
+        .unwrap();
+
+    let prepared = bridge
+        .manage_profile(|im| {
+            im.prepare_delegated_refresh(
+                bridge_source_net,
+                child_assignment.net_id,
+                child_assignment.refresh_token,
+            )
+        })
+        .unwrap();
+    let ergot::interface_manager::DelegatedRefreshPreparation::Forward(prepared) = prepared else {
+        panic!("the first refresh must be forwarded upstream");
+    };
+    let first_response = root
+        .manage_profile(|im| {
+            im.refresh_seed_net_assignment(root_source_net, prepared.net_id, prepared.refresh_token)
+        })
+        .unwrap();
+
+    // Simulate losing that response (or cancelling the bridge handler) before
+    // commit. After restart the bridge can only retry the old parent token.
+    let prepared_after_restart = bridge
+        .manage_profile(|im| {
+            im.prepare_delegated_refresh(
+                bridge_source_net,
+                child_assignment.net_id,
+                child_assignment.refresh_token,
+            )
+        })
+        .unwrap();
+    let ergot::interface_manager::DelegatedRefreshPreparation::Forward(prepared_after_restart) =
+        prepared_after_restart
+    else {
+        panic!("an uncommitted refresh must still be forwarded after restart");
+    };
+    let retry = root.manage_profile(|im| {
+        im.refresh_seed_net_assignment(
+            root_source_net,
+            prepared_after_restart.net_id,
+            prepared_after_restart.refresh_token,
+        )
+    });
+
+    assert_eq!(
+        retry,
+        Ok(first_response),
+        "retrying after a lost refresh response must be idempotent"
+    );
+}
+
+#[test]
+fn delegation_rejects_a_hop_that_would_exhaust_the_refresh_margin() {
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(3), NullSink));
+    let bridge_down = bridge
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let source_net = bridge
+        .manage_profile(|im| im.net_id_of(bridge_down))
+        .unwrap();
+    let parent = SeedLease {
+        net_id: 42,
+        refresh_addr: Address {
+            network_id: 1,
+            node_id: 1,
+            port_id: 42,
+        },
+        refresh_token: [0xAA; 8],
+        expires_seconds: 120,
+        max_refresh_seconds: 120,
+        min_refresh_seconds: 5,
+    };
+
+    assert_eq!(
+        bridge.manage_profile(|im| im.register_delegated_seed_net(source_net, &parent)),
+        Err(SeedAssignmentError::DelegationDepthExceeded)
+    );
+}
+
+type RouterStack =
+    ArcNetStack<CriticalSectionRawMutex, Router<TokioStreamInterface, rand::rngs::StdRng, 64, 64>>;
+
+async fn wait_interface_active(stack: &RouterStack, ident: u8) -> u16 {
+    for _ in 0..60 {
+        if let Some(InterfaceState::Active { net_id, .. }) =
+            stack.manage_profile(|im| im.interface_state(ident))
+        {
+            return net_id;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    panic!("interface {ident} never became Active");
+}
+
+async fn setup_delegation_chain() -> (RouterStack, RouterStack, RouterStack) {
+    use ergot::interface_manager::transports::tokio_cobs_stream as tcs;
+    use ergot::interface_manager::utils::{cobs_stream, std::new_std_queue};
+
+    let root: RouterStack = RouterStack::new();
+
+    let bridge_up_queue = new_std_queue(4096);
+    let bridge: RouterStack = RouterStack::new_with_profile(Router::new_bridge_std(
+        cobs_stream::Sink::new_from_handle(bridge_up_queue.clone(), 512),
+    ));
+
+    let requester_up_queue = new_std_queue(4096);
+    let requester: RouterStack = RouterStack::new_with_profile(Router::new_bridge_std(
+        cobs_stream::Sink::new_from_handle(requester_up_queue.clone(), 512),
+    ));
+
+    let (bridge_up_read, root_b_write) = tokio::io::duplex(8192);
+    let (root_b_read, bridge_up_write) = tokio::io::duplex(8192);
+    tcs::register_router(
+        root.clone(),
+        root_b_read,
+        root_b_write,
+        512,
+        4096,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    tcs::register_bridge_upstream(
+        bridge.clone(),
+        bridge_up_read,
+        bridge_up_write,
+        bridge_up_queue,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let _ = timeout(
+        Duration::from_millis(500),
+        root.endpoints().request::<ErgotPingEndpoint>(
+            Address {
+                network_id: 1,
+                node_id: 2,
+                port_id: 0,
+            },
+            &0u32,
+            Some("ping"),
+        ),
+    )
+    .await;
+    assert_eq!(wait_interface_active(&bridge, UPSTREAM_IDENT).await, 1);
+
+    let (req_up_read, bridge_r_write) = tokio::io::duplex(8192);
+    let (bridge_r_read, req_up_write) = tokio::io::duplex(8192);
+    let bridge_down = tcs::register_router(
+        bridge.clone(),
+        bridge_r_read,
+        bridge_r_write,
+        512,
+        4096,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let bridge_down_net = bridge
+        .manage_profile(|im| im.net_id_of(bridge_down))
+        .unwrap();
+    tcs::register_bridge_upstream(
+        requester.clone(),
+        req_up_read,
+        req_up_write,
+        requester_up_queue,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let _ = timeout(
+        Duration::from_millis(500),
+        bridge.endpoints().request::<ErgotPingEndpoint>(
+            Address {
+                network_id: bridge_down_net,
+                node_id: 2,
+                port_id: 0,
+            },
+            &0u32,
+            Some("ping"),
+        ),
+    )
+    .await;
+    assert_eq!(
+        wait_interface_active(&requester, UPSTREAM_IDENT).await,
+        bridge_down_net
+    );
+
+    (root, bridge, requester)
+}
+
+#[tokio::test]
+async fn lost_upstream_assignment_response_does_not_block_later_requests() {
+    let (root, bridge, requester) = setup_delegation_chain().await;
+
+    let bridge_handler = tokio::spawn({
+        let stack = bridge.clone();
+        async move { stack.services().seed_router_request_handler::<4>().await }
+    });
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let (received_tx, received_rx) = tokio::sync::oneshot::channel();
+    let blackhole = tokio::spawn({
+        let stack = root.clone();
+        async move {
+            let server = stack
+                .endpoints()
+                .bounded_server::<ErgotSeedRouterAssignmentEndpoint, 4>(None);
+            tokio::pin!(server);
+            let mut handle = server.attach();
+            ready_tx.send(()).unwrap();
+            loop {
+                if handle.recv_manual().await.is_ok() {
+                    break;
+                }
+            }
+            received_tx.send(()).unwrap();
+            core::future::pending::<()>().await;
+        }
+    });
+    ready_rx.await.unwrap();
+
+    let first_request = tokio::spawn({
+        let stack = requester.clone();
+        async move { request_seed_lease(&stack, UPSTREAM_IDENT).await }
+    });
+    timeout(Duration::from_secs(1), received_rx)
+        .await
+        .expect("the blackhole root never received the delegated request")
+        .unwrap();
+
+    blackhole.abort();
+    let _ = blackhole.await;
+    let root_handler = tokio::spawn({
+        let stack = root.clone();
+        async move { stack.services().seed_router_request_handler::<4>().await }
+    });
+    tokio::task::yield_now().await;
+
+    let first_err = timeout(Duration::from_secs(2), first_request)
+        .await
+        .expect("the unanswered upstream RPC did not time out")
+        .expect("the first requester task panicked")
+        .expect_err("the blackholed assignment unexpectedly succeeded");
+    assert!(matches!(
+        first_err,
+        SeedClientError::AssignmentDenied(SeedAssignmentError::UpstreamUnavailable)
+    ));
+
+    let second = timeout(
+        Duration::from_secs(1),
+        request_seed_lease(&requester, UPSTREAM_IDENT),
+    )
+    .await
+    .expect("one lost upstream response blocked the seed handler permanently")
+    .expect("the healthy root should grant the later request");
+    assert_ne!(second.net_id, 0);
+
+    bridge_handler.abort();
+    root_handler.abort();
+}
+
+#[tokio::test]
+async fn upstream_seed_error_is_not_reported_as_net_ids_exhausted() {
+    let (root, bridge, requester) = setup_delegation_chain().await;
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let root_handler = tokio::spawn({
+        let stack = root.clone();
+        async move {
+            let server = stack
+                .endpoints()
+                .bounded_server::<ErgotSeedRouterAssignmentEndpoint, 4>(None);
+            tokio::pin!(server);
+            let mut handle = server.attach();
+            ready_tx.send(()).unwrap();
+            loop {
+                let Ok(req) = handle.recv_manual().await else {
+                    continue;
+                };
+                let response = Err(SeedAssignmentError::ProfileCantSeed);
+                stack
+                    .endpoints()
+                    .respond_owned::<ErgotSeedRouterAssignmentEndpoint>(&req.hdr, &response)
+                    .unwrap();
+            }
+        }
+    });
+    ready_rx.await.unwrap();
+
+    let bridge_handler = tokio::spawn({
+        let stack = bridge.clone();
+        async move { stack.services().seed_router_request_handler::<4>().await }
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let err = timeout(
+        Duration::from_secs(1),
+        request_seed_lease(&requester, UPSTREAM_IDENT),
+    )
+    .await
+    .expect("bridge did not relay the upstream seed error")
+    .expect_err("assignment should preserve the upstream seed error");
+
+    assert!(matches!(
+        err,
+        SeedClientError::AssignmentDenied(SeedAssignmentError::ProfileCantSeed)
+    ));
+
+    bridge_handler.abort();
+    root_handler.abort();
+}
+
+#[tokio::test]
+async fn disconnected_upstream_refresh_is_not_reported_as_bad_request() {
+    let (root, bridge, requester) = setup_delegation_chain().await;
+    let root_handler = tokio::spawn({
+        let stack = root.clone();
+        async move { stack.services().seed_router_request_handler::<4>().await }
+    });
+    let bridge_handler = tokio::spawn({
+        let stack = bridge.clone();
+        async move { stack.services().seed_router_request_handler::<4>().await }
+    });
+
+    let lease = timeout(
+        Duration::from_secs(1),
+        request_seed_lease(&requester, UPSTREAM_IDENT),
+    )
+    .await
+    .expect("initial delegated assignment timed out")
+    .expect("initial delegated assignment failed");
+
+    bridge
+        .manage_profile(|im| im.set_interface_state(UPSTREAM_IDENT, InterfaceState::Down))
+        .unwrap();
+    let err = timeout(
+        Duration::from_secs(1),
+        bridge_seed_refresh(&requester, &lease),
+    )
+    .await
+    .expect("bridge did not answer after its upstream disconnected")
+    .expect_err("refresh should fail while the upstream is disconnected");
+
+    assert!(matches!(
+        err,
+        SeedClientError::RefreshDenied(SeedRefreshError::UpstreamUnavailable)
+    ));
+
+    bridge_handler.abort();
+    root_handler.abort();
+}

--- a/crates/ergot/tests/seed_delegation_regressions.rs
+++ b/crates/ergot/tests/seed_delegation_regressions.rs
@@ -9,7 +9,7 @@ use ergot::{
     Address, HeaderSeq, ProtocolError,
     interface_manager::{
         Interface, InterfaceSink, InterfaceState, Profile, SeedAssignmentError, SeedLease,
-        SeedRefreshError,
+        SeedRefreshError, SetStateError,
         interface_impls::tokio_stream::TokioStreamInterface,
         profiles::router::{Router, UPSTREAM_IDENT},
     },
@@ -17,7 +17,10 @@ use ergot::{
         ArcNetStack,
         services::{SeedClientError, bridge_seed_refresh, request_seed_lease},
     },
-    well_known::{ErgotPingEndpoint, ErgotSeedRouterAssignmentEndpoint},
+    well_known::{
+        ErgotPingEndpoint, ErgotSeedRouterAssignmentEndpoint, ErgotSeedRouterReleaseEndpoint,
+        SeedRouterAssignment,
+    },
 };
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use rand::SeedableRng;
@@ -68,7 +71,15 @@ fn upstream_refresh_retry_after_lost_response_is_idempotent() {
 
     let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(2), NullSink));
     let bridge_down = bridge
-        .manage_profile(|im| im.register_interface(NullSink))
+        .manage_profile(|im| im.register_interface_pending(NullSink))
+        .unwrap();
+    let bridge_link_assignment = root
+        .manage_profile(|im| im.request_seed_net_assign(root_source_net))
+        .unwrap();
+    bridge
+        .manage_profile(|im| {
+            im.reassign_interface_net_id(bridge_down, bridge_link_assignment.net_id)
+        })
         .unwrap();
     let bridge_source_net = bridge
         .manage_profile(|im| im.net_id_of(bridge_down))
@@ -83,6 +94,11 @@ fn upstream_refresh_retry_after_lost_response_is_idempotent() {
             network_id: root_source_net,
             node_id: 1,
             port_id: 42,
+        },
+        release_addr: Address {
+            network_id: root_source_net,
+            node_id: 1,
+            port_id: 43,
         },
         refresh_token: parent_assignment.refresh_token,
         expires_seconds: parent_assignment.expires_seconds,
@@ -143,10 +159,43 @@ fn upstream_refresh_retry_after_lost_response_is_idempotent() {
 }
 
 #[test]
+fn replay_reports_actual_remaining_lease_time() {
+    let root: TestStack = TestStack::new_with_profile(Router::new(rng(8)));
+    let down = root
+        .manage_profile(|im| im.register_interface(NullSink))
+        .unwrap();
+    let source_net = root.manage_profile(|im| im.net_id_of(down)).unwrap();
+    let initial = root
+        .manage_profile(|im| im.request_seed_net_assign(source_net))
+        .unwrap();
+    let refreshed = root
+        .manage_profile(|im| {
+            im.refresh_seed_net_assignment(source_net, initial.net_id, initial.refresh_token)
+        })
+        .unwrap();
+
+    std::thread::sleep(Duration::from_millis(1_100));
+
+    let replay = root
+        .manage_profile(|im| {
+            im.refresh_seed_net_assignment(source_net, initial.net_id, initial.refresh_token)
+        })
+        .unwrap();
+    assert_eq!(replay.refresh_token, refreshed.refresh_token);
+    assert!(
+        replay.expires_seconds < refreshed.expires_seconds,
+        "a replay must not restart the downstream's 120-second clock"
+    );
+}
+
+#[test]
 fn delegation_rejects_a_hop_that_would_exhaust_the_refresh_margin() {
     let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(3), NullSink));
     let bridge_down = bridge
-        .manage_profile(|im| im.register_interface(NullSink))
+        .manage_profile(|im| im.register_interface_pending(NullSink))
+        .unwrap();
+    bridge
+        .manage_profile(|im| im.reassign_interface_net_id(bridge_down, 1))
         .unwrap();
     let source_net = bridge
         .manage_profile(|im| im.net_id_of(bridge_down))
@@ -158,6 +207,11 @@ fn delegation_rejects_a_hop_that_would_exhaust_the_refresh_margin() {
             node_id: 1,
             port_id: 42,
         },
+        release_addr: Address {
+            network_id: 1,
+            node_id: 1,
+            port_id: 43,
+        },
         refresh_token: [0xAA; 8],
         expires_seconds: 120,
         max_refresh_seconds: 120,
@@ -167,6 +221,72 @@ fn delegation_rejects_a_hop_that_would_exhaust_the_refresh_margin() {
     assert_eq!(
         bridge.manage_profile(|im| im.register_delegated_seed_net(source_net, &parent)),
         Err(SeedAssignmentError::DelegationDepthExceeded)
+    );
+}
+
+#[test]
+fn bridge_requires_pending_root_assigned_downlinks() {
+    use ergot::interface_manager::profiles::router::RegisterError;
+
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(4), NullSink));
+    assert_eq!(
+        bridge.manage_profile(|im| im.register_interface(NullSink)),
+        Err(RegisterError::BridgeRequiresSeedAssignment)
+    );
+
+    let pending = bridge
+        .manage_profile(|im| im.register_interface_pending(NullSink))
+        .unwrap();
+    assert_eq!(bridge.manage_profile(|im| im.net_id_of(pending)), Some(0));
+}
+
+#[test]
+fn bridge_rejects_zero_source_and_local_seed_allocation() {
+    let bridge: TestStack = TestStack::new_with_profile(Router::new_bridge(rng(5), NullSink));
+    let pending = bridge
+        .manage_profile(|im| im.register_interface_pending(NullSink))
+        .unwrap();
+
+    assert_eq!(
+        bridge.manage_profile(|im| im.can_delegate_seed(0)),
+        Err(SeedAssignmentError::UnknownSource)
+    );
+    assert_eq!(
+        bridge.manage_profile(|im| im.request_seed_net_assign(0)),
+        Err(SeedAssignmentError::ProfileCantSeed)
+    );
+
+    bridge
+        .manage_profile(|im| im.reassign_interface_net_id(pending, 7))
+        .unwrap();
+    let colliding_parent = SeedLease {
+        net_id: 7,
+        refresh_addr: Address {
+            network_id: 1,
+            node_id: 1,
+            port_id: 42,
+        },
+        release_addr: Address {
+            network_id: 1,
+            node_id: 1,
+            port_id: 43,
+        },
+        refresh_token: [0xBB; 8],
+        expires_seconds: 120,
+        max_refresh_seconds: 120,
+        min_refresh_seconds: 62,
+    };
+    assert_eq!(
+        bridge.manage_profile(|im| im.register_delegated_seed_net(7, &colliding_parent)),
+        Err(SeedAssignmentError::NetIdCollision)
+    );
+
+    let other = bridge
+        .manage_profile(|im| im.register_interface_pending(NullSink))
+        .unwrap();
+    assert_eq!(
+        bridge.manage_profile(|im| im.reassign_interface_net_id(other, 7)),
+        Err(SetStateError::NetIdInUse)
     );
 }
 
@@ -242,7 +362,7 @@ async fn setup_delegation_chain() -> (RouterStack, RouterStack, RouterStack) {
 
     let (req_up_read, bridge_r_write) = tokio::io::duplex(8192);
     let (bridge_r_read, req_up_write) = tokio::io::duplex(8192);
-    let bridge_down = tcs::register_router(
+    let bridge_down = tcs::register_bridge_downstream(
         bridge.clone(),
         bridge_r_read,
         bridge_r_write,
@@ -253,6 +373,14 @@ async fn setup_delegation_chain() -> (RouterStack, RouterStack, RouterStack) {
     )
     .await
     .unwrap();
+    let bridge_link_assignment = root
+        .manage_profile(|im| im.request_seed_net_assign(1))
+        .unwrap();
+    bridge
+        .manage_profile(|im| {
+            im.reassign_interface_net_id(bridge_down, bridge_link_assignment.net_id)
+        })
+        .unwrap();
     let bridge_down_net = bridge
         .manage_profile(|im| im.net_id_of(bridge_down))
         .unwrap();
@@ -354,6 +482,108 @@ async fn lost_upstream_assignment_response_does_not_block_later_requests() {
     .expect("one lost upstream response blocked the seed handler permanently")
     .expect("the healthy root should grant the later request");
     assert_ne!(second.net_id, 0);
+
+    bridge_handler.abort();
+    root_handler.abort();
+}
+
+#[tokio::test]
+async fn disappearing_downlink_releases_the_upstream_assignment() {
+    let (root, bridge, requester) = setup_delegation_chain().await;
+    let bridge_handler = tokio::spawn({
+        let stack = bridge.clone();
+        async move { stack.services().seed_router_request_handler::<4>().await }
+    });
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let (assigned_tx, assigned_rx) = tokio::sync::oneshot::channel();
+    let (released_tx, released_rx) = tokio::sync::oneshot::channel();
+    let root_handler = tokio::spawn({
+        let stack = root.clone();
+        async move {
+            let assignment = stack
+                .endpoints()
+                .bounded_server::<ErgotSeedRouterAssignmentEndpoint, 4>(None);
+            let release = stack
+                .endpoints()
+                .bounded_server::<ErgotSeedRouterReleaseEndpoint, 4>(None);
+            tokio::pin!(assignment);
+            tokio::pin!(release);
+            let mut assignment = assignment.attach();
+            let mut release = release.attach();
+            let release_port = release.port();
+            ready_tx.send(()).unwrap();
+            let mut assigned_tx = Some(assigned_tx);
+            let mut released_tx = Some(released_tx);
+            loop {
+                match embassy_futures::select::select(
+                    assignment.recv_manual(),
+                    release.recv_manual(),
+                )
+                .await
+                {
+                    embassy_futures::select::Either::First(Ok(req)) => {
+                        let result = stack
+                            .manage_profile(|p| p.request_seed_net_assign(req.hdr.src.network_id))
+                            .map(|assignment| SeedRouterAssignment {
+                                assignment,
+                                refresh_port: 0,
+                                release_port,
+                            });
+                        if let Some(tx) = assigned_tx.take() {
+                            tx.send(()).unwrap();
+                        }
+                        sleep(Duration::from_millis(100)).await;
+                        stack
+                            .endpoints()
+                            .respond_owned::<ErgotSeedRouterAssignmentEndpoint>(&req.hdr, &result)
+                            .unwrap();
+                    }
+                    embassy_futures::select::Either::Second(Ok(req)) => {
+                        let result = stack.manage_profile(|p| {
+                            p.release_seed_net_assignment(
+                                req.hdr.src.network_id,
+                                req.t.release_net,
+                                req.t.refresh_token,
+                            )
+                        });
+                        stack
+                            .endpoints()
+                            .respond_owned::<ErgotSeedRouterReleaseEndpoint>(&req.hdr, &result)
+                            .unwrap();
+                        if let Some(tx) = released_tx.take() {
+                            tx.send(()).unwrap();
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    });
+    ready_rx.await.unwrap();
+
+    let request = tokio::spawn({
+        let stack = requester.clone();
+        async move { request_seed_lease(&stack, UPSTREAM_IDENT).await }
+    });
+    timeout(Duration::from_secs(1), assigned_rx)
+        .await
+        .expect("root did not allocate the delegated lease")
+        .unwrap();
+    bridge
+        .manage_profile(|p| p.deregister_interface(0))
+        .unwrap();
+
+    timeout(Duration::from_secs(1), released_rx)
+        .await
+        .expect("bridge did not roll back the upstream lease")
+        .unwrap();
+    request.abort();
+
+    let reused = root
+        .manage_profile(|p| p.request_seed_net_assign(1))
+        .unwrap();
+    assert_eq!(reused.net_id, 3, "released root net_id should be reusable");
 
     bridge_handler.abort();
     root_handler.abort();


### PR DESCRIPTION
## Summary

Make bridge seed routers delegate downstream net-id assignments to their own upstream seed router, keeping the root as the single allocator for the routing tree.

Without delegation, every bridge allocates from its own local 16-bit pool. Nested bridges can therefore assign a net-id already used elsewhere in the tree, producing ambiguous routes and eventually unreachable downstream segments.

## What changed

- Add delegation hooks to `Profile`; root routers continue allocating locally, while bridge routers forward assignment and refresh requests upstream.
- Register the root-issued net-id as a route through the requesting downstream interface and issue a bridge-local refresh token.
- Reduce `min_refresh_seconds` by a per-hop margin so every downstream refresh arrives inside its parent's allowed refresh window.
- Store each delegated route's parent lease in `Router::seed_routes`, alongside the route that owns it.
- Use a prepare/async-refresh/commit flow so invalid child tokens cannot trigger upstream traffic and successful refreshes atomically update the parent lease, local expiration, and child token.
- Split seed-lease acquisition from downstream-interface reassignment so the same client path can serve both direct bridge links and delegated requests.

Keeping the parent lease in the route table removes the task-local `Vec<SeedLease, 32>` lifetime/capacity mismatch: capacity is now exactly `S`, route GC removes the corresponding parent state, and restarting `seed_router_request_handler` does not lose refresh tokens.

## Validation

- Unit coverage for delegation mode, source/token validation, refresh-window staggering, token rotation, idempotent re-registration, route-table capacity, and 40 parent leases with `S = 40`.
- End-to-end proof that a nested request receives a net-id from the root pool rather than the intermediate bridge's local pool.
- End-to-end routing from root through two bridges to an edge on the delegated network.
- End-to-end refresh after aborting and restarting the intermediate bridge's seed handler.
- `cargo test --features tokio-std`
- `cargo check --no-default-features --features nostd-seed-router --lib`
- `cargo clippy --features tokio-std --all-targets -- -D warnings`

This is based on main after #213, so hierarchical routes also use the guarded upstream rediscovery behavior.
