### PR TITLE
Keep upstream rediscovery open after transit

### DIFF
--- a/crates/ergot/src/interface_manager/profiles/direct_edge.rs
+++ b/crates/ergot/src/interface_manager/profiles/direct_edge.rs
@@ -142,7 +142,7 @@ impl<I: Interface> Profile for DirectEdge<I> {
 /// Discovers `net_id` from incoming frames and transitions the interface to
 /// [`InterfaceState::Active`]. Discovery only runs while the *window* is
 /// open — after construction or [`reset()`](crate::interface_manager::FrameProcessor::reset)
-/// (liveness timeout), while the interface is not yet Active — and only from
+/// (liveness timeout), including while a sticky ID is provisionally Active — and only from
 /// a frame that is plausibly addressed to this device: `dst.node_id` matches
 /// our role's node_id AND the profile does not already route
 /// `dst.network_id` somewhere else ([`Profile::is_transit_net`]).
@@ -167,6 +167,10 @@ pub struct EdgeFrameProcessor {
     /// produced; while closed, frames are processed with zero profile
     /// queries. Cleared by `reset()`.
     activated: bool,
+    /// `true` after a liveness reset with a sticky net_id. Transit traffic may
+    /// reactivate that ID, but the window stays open until an addressed frame
+    /// confirms or replaces it.
+    rediscovering: bool,
 }
 
 impl EdgeFrameProcessor {
@@ -176,6 +180,7 @@ impl EdgeFrameProcessor {
             net_id: None,
             own_node: EDGE_NODE_ID,
             activated: false,
+            rediscovering: false,
         }
     }
 
@@ -185,6 +190,7 @@ impl EdgeFrameProcessor {
             net_id: Some(net_id),
             own_node: CENTRAL_NODE_ID,
             activated: false,
+            rediscovering: false,
         }
     }
 }
@@ -214,6 +220,7 @@ where
         // transit, and only a frame passing the discovery guard may replace
         // the net with a different one.
         self.activated = false;
+        self.rediscovering = self.net_id.is_some();
     }
 }
 
@@ -247,74 +254,68 @@ where
     // with no profile queries at all.
     if !state.activated {
         let dst = frame.hdr.dst;
-        let (if_state, dst_is_transit) = nsh.stack().manage_profile(|im| {
-            (
-                im.interface_state(ident.clone()),
-                im.is_transit_net(dst.network_id),
-            )
-        });
-
-        match if_state {
-            // Already Active with a real net (pre-activated by registration
-            // code or reassigned by a seed router): adopt it, close the window.
-            Some(InterfaceState::Active { net_id, .. }) if net_id != 0 => {
-                state.net_id = Some(net_id);
-                state.activated = true;
-            }
-            // Not yet fully active: Inactive/Down after a liveness timeout or
-            // at boot, or the link-local placeholder `Active{net_id: 0}` a
-            // bridge upstream starts with.
-            Some(
-                InterfaceState::Active { .. } | InterfaceState::Inactive | InterfaceState::Down,
-            ) => {
-                // A frame may donate its dst as our net_id only if it is
-                // plausibly addressed to us: a real net, our own node, and
-                // not a segment the profile already routes (transit traffic
-                // on a bridge upstream carries downstream dst nets).
-                let donates =
-                    dst.network_id != 0 && dst.node_id == state.own_node && !dst_is_transit;
-
-                let new_net = if donates {
-                    Some(dst.network_id)
-                } else {
-                    // Sticky reactivation: a non-donating frame (e.g.
-                    // transit) still proves the link is alive, so bring the
-                    // interface back up with the previously known net.
-                    state.net_id
-                };
-
-                if let Some(net) = new_net {
-                    let ok = nsh.stack().manage_profile(|im| {
-                        im.set_interface_state(
-                            ident.clone(),
-                            InterfaceState::Active {
-                                net_id: net,
-                                node_id: state.own_node,
-                            },
-                        )
-                        .is_ok()
-                    });
-                    if ok {
-                        state.net_id = Some(net);
-                        state.activated = true;
-                        state_changed = true;
-                    } else {
-                        warn!("Failed to set interface state from frame, dropping");
-                        return state_changed;
-                    }
+        let can_donate = dst.network_id != 0 && dst.node_id == state.own_node;
+        let discovery = nsh.stack().manage_profile(|im| {
+            let if_state = im
+                .interface_state(ident.clone())
+                .ok_or("Frame for unknown interface")?;
+            match if_state {
+                // Already Active with a real net (pre-activated by
+                // registration code or reassigned by a seed router): adopt it
+                // and close a boot-time window.
+                InterfaceState::Active { net_id, .. }
+                    if net_id != 0 && !state.rediscovering =>
+                {
+                    state.net_id = Some(net_id);
+                    state.activated = true;
                 }
-                // No net known and the frame doesn't qualify: keep the window
-                // open and process the frame with link-local addressing.
+                // Not fully confirmed: Inactive/Down, link-local net 0, or a
+                // sticky ID provisionally reactivated during rediscovery.
+                InterfaceState::Active { .. }
+                | InterfaceState::Inactive
+                | InterfaceState::Down => {
+                    // Only plausible donors pay the transit lookup cost.
+                    let donates = can_donate && !im.is_transit_net(dst.network_id);
+                    let new_net = if donates {
+                        Some(dst.network_id)
+                    } else {
+                        state.net_id
+                    };
+
+                    if let Some(net) = new_net {
+                        let already_active = matches!(
+                            if_state,
+                            InterfaceState::Active { net_id, node_id }
+                                if net_id == net && node_id == state.own_node
+                        );
+                        if !already_active {
+                            im.set_interface_state(
+                                ident.clone(),
+                                InterfaceState::Active {
+                                    net_id: net,
+                                    node_id: state.own_node,
+                                },
+                            )
+                            .map_err(|_| "Failed to set interface state from frame")?;
+                        }
+                        state.net_id = Some(net);
+                        if donates {
+                            state.activated = true;
+                            state.rediscovering = false;
+                        }
+                        state_changed |= !already_active;
+                    }
+                    // No net known and no donor: keep the window open and
+                    // process this frame with link-local addressing.
+                }
+                // Bus-style local-only state is managed by the claim protocol.
+                InterfaceState::ActiveLocal { .. } => state.activated = true,
             }
-            // Bus-style local-only state is managed by the claim protocol;
-            // close the window and leave it alone.
-            Some(InterfaceState::ActiveLocal { .. }) => {
-                state.activated = true;
-            }
-            None => {
-                warn!("Frame for unknown interface, dropping");
-                return state_changed;
-            }
+            Ok::<(), &'static str>(())
+        });
+        if let Err(_message) = discovery {
+            warn!("{}, dropping", _message);
+            return state_changed;
         }
     }
 

--- a/crates/ergot/src/interface_manager/profiles/router.rs
+++ b/crates/ergot/src/interface_manager/profiles/router.rs
@@ -118,6 +118,12 @@ enum RefreshDenied {
     TooSoon,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TokenMatch {
+    Current,
+    Replay,
+}
+
 impl LeaseKind {
     /// A fresh active lease expiring `secs` from `now`.
     fn active(now: Instant, secs: u16, token: u64) -> Self {
@@ -155,6 +161,36 @@ impl LeaseKind {
         }
     }
 
+    /// Validate a current refresh token or, when enabled, the immediately
+    /// previous token used to replay a lost response. Expiry handling and
+    /// token ordering live here for every seed state-machine path.
+    fn validate_token(
+        &mut self,
+        req_token: u64,
+        now: Instant,
+        allow_replay: bool,
+    ) -> Result<TokenMatch, RefreshDenied> {
+        match self {
+            LeaseKind::Tombstone { .. } => Err(RefreshDenied::Expired),
+            LeaseKind::Active(lease) => {
+                let token_match = if lease.refresh_token == req_token {
+                    TokenMatch::Current
+                } else if allow_replay && lease.previous_refresh_token == Some(req_token) {
+                    TokenMatch::Replay
+                } else {
+                    return Err(RefreshDenied::BadToken);
+                };
+                if now >= lease.expiration {
+                    *self = LeaseKind::Tombstone {
+                        clear_time: lease.expiration + Duration::from_secs(TOMBSTONE_DURATION_SECS),
+                    };
+                    return Err(RefreshDenied::Expired);
+                }
+                Ok(token_match)
+            }
+        }
+    }
+
     /// Refresh an active lease: verify the token, reject if expired (tombstoning
     /// it) or too soon, otherwise extend to `MAX_LEASE_SECS` and rotate
     /// the token to `new_token`. Returns the renewed lease and whether this
@@ -166,34 +202,20 @@ impl LeaseKind {
         new_token: u64,
         allow_replay: bool,
     ) -> Result<(Lease, bool), RefreshDenied> {
-        match self {
-            LeaseKind::Tombstone { .. } => Err(RefreshDenied::Expired),
-            LeaseKind::Active(lease) => {
-                // Token is checked before expiry on purpose: a caller with the
-                // wrong token learns nothing about whether the lease exists or
-                // has already expired (it always sees BadToken).
-                let is_replay = allow_replay && lease.previous_refresh_token == Some(req_token);
-                if lease.refresh_token != req_token && !is_replay {
-                    return Err(RefreshDenied::BadToken);
-                }
-                if now >= lease.expiration {
-                    *self = LeaseKind::Tombstone {
-                        clear_time: lease.expiration + Duration::from_secs(TOMBSTONE_DURATION_SECS),
-                    };
-                    return Err(RefreshDenied::Expired);
-                }
-                if is_replay {
-                    return Ok((*lease, true));
-                }
-                if lease.expiration - now > Duration::from_secs(MIN_REFRESH_SECS as u64) {
-                    return Err(RefreshDenied::TooSoon);
-                }
-                lease.expiration = now + Duration::from_secs(MAX_LEASE_SECS as u64);
-                lease.previous_refresh_token = allow_replay.then_some(lease.refresh_token);
-                lease.refresh_token = new_token;
-                Ok((*lease, false))
-            }
+        let token_match = self.validate_token(req_token, now, allow_replay)?;
+        let LeaseKind::Active(lease) = self else {
+            unreachable!("successful validation guarantees an active lease")
+        };
+        if token_match == TokenMatch::Replay {
+            return Ok((*lease, true));
         }
+        if lease.expiration - now > Duration::from_secs(MIN_REFRESH_SECS as u64) {
+            return Err(RefreshDenied::TooSoon);
+        }
+        lease.expiration = now + Duration::from_secs(MAX_LEASE_SECS as u64);
+        lease.previous_refresh_token = allow_replay.then_some(lease.refresh_token);
+        lease.refresh_token = new_token;
+        Ok((*lease, false))
     }
 }
 
@@ -235,10 +257,28 @@ impl<K: Copy + Eq, X, const N: usize> LeaseTable<K, X, N> {
         self.entries.iter().any(|e| e.key == key)
     }
 
+    /// Check one key while lazily advancing or removing only that entry's
+    /// lease state. This avoids a full-table GC on hot membership checks.
+    fn contains_key_at(&mut self, key: K, now: Instant) -> bool {
+        let Some(pos) = self.entries.iter().position(|entry| entry.key == key) else {
+            return false;
+        };
+        if self.entries[pos].kind.gc_retain(now) {
+            true
+        } else {
+            self.entries.swap_remove(pos);
+            false
+        }
+    }
+
     /// Look up by key alone — for callers where `key` is globally unique
     /// (e.g. seed-assigned net_ids).
     fn by_key(&self, key: K) -> Option<&LeaseEntry<K, X>> {
         self.entries.iter().find(|e| e.key == key)
+    }
+
+    fn by_key_mut(&mut self, key: K) -> Option<&mut LeaseEntry<K, X>> {
+        self.entries.iter_mut().find(|e| e.key == key)
     }
 
     /// Look up by `(key, scope)` — for keys only unique within a segment
@@ -1003,35 +1043,37 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         // net_id is the unique key; the requester (source_net) is the scope.
         let entry = self
             .seed_routes
-            .by_key(refresh_net)
+            .by_key_mut(refresh_net)
             .ok_or(SeedRefreshError::UnknownNetId)?;
-        match entry.kind {
-            LeaseKind::Tombstone { .. } => Err(SeedRefreshError::AlreadyExpired),
-            LeaseKind::Active(lease) => {
-                if entry.scope != source_net {
-                    Err(SeedRefreshError::BadRequest)
-                } else if lease.previous_refresh_token == Some(req_token) {
-                    let parent = entry
-                        .extra
-                        .parent
-                        .as_ref()
-                        .ok_or(SeedRefreshError::NotAssigned)?;
-                    Ok(DelegatedRefreshPreparation::Replay(delegated_assignment(
-                        parent,
-                        lease.refresh_token,
-                        remaining_lease_seconds(lease.expiration, now),
-                    )))
-                } else if lease.refresh_token != req_token {
-                    Err(SeedRefreshError::BadRequest)
-                } else {
-                    entry
-                        .extra
-                        .parent
-                        .clone()
-                        .map(DelegatedRefreshPreparation::Forward)
-                        .ok_or(SeedRefreshError::NotAssigned)
-                }
+        if entry.scope != source_net {
+            return Err(SeedRefreshError::BadRequest);
+        }
+        match entry.kind.validate_token(req_token, now, true) {
+            Err(RefreshDenied::Expired) => Err(SeedRefreshError::AlreadyExpired),
+            Err(RefreshDenied::BadToken | RefreshDenied::TooSoon) => {
+                Err(SeedRefreshError::BadRequest)
             }
+            Ok(TokenMatch::Replay) => {
+                let LeaseKind::Active(lease) = entry.kind else {
+                    unreachable!("successful validation guarantees an active lease")
+                };
+                let parent = entry
+                    .extra
+                    .parent
+                    .as_ref()
+                    .ok_or(SeedRefreshError::NotAssigned)?;
+                Ok(DelegatedRefreshPreparation::Replay(delegated_assignment(
+                    parent,
+                    lease.refresh_token,
+                    remaining_lease_seconds(lease.expiration, now),
+                )))
+            }
+            Ok(TokenMatch::Current) => entry
+                .extra
+                .parent
+                .clone()
+                .map(DelegatedRefreshPreparation::Forward)
+                .ok_or(SeedRefreshError::NotAssigned),
         }
     }
 
@@ -1053,12 +1095,15 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
             .get_mut(refreshed_parent.net_id, source_net)
             .ok_or(SeedRefreshError::UnknownNetId)?;
 
-        match &mut entry.kind {
-            LeaseKind::Tombstone { .. } => Err(SeedRefreshError::AlreadyExpired),
-            LeaseKind::Active(lease) => {
-                if lease.refresh_token != req_token {
-                    return Err(SeedRefreshError::BadRequest);
-                }
+        match entry.kind.validate_token(req_token, now, false) {
+            Err(RefreshDenied::Expired) => Err(SeedRefreshError::AlreadyExpired),
+            Err(RefreshDenied::BadToken | RefreshDenied::TooSoon) => {
+                Err(SeedRefreshError::BadRequest)
+            }
+            Ok(_) => {
+                let LeaseKind::Active(lease) = &mut entry.kind else {
+                    unreachable!("successful validation guarantees an active lease")
+                };
                 // No TooSoon check here: pacing is enforced by the upstream
                 // seed router, whose refresh has already succeeded. Extend to
                 // track the upstream lease and rotate the local token.
@@ -1092,14 +1137,14 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         let req_token = u64::from_le_bytes(refresh_token);
         let entry = self
             .seed_routes
-            .get(release_net, source_net)
+            .get_mut(release_net, source_net)
             .ok_or(SeedRefreshError::UnknownNetId)?;
-        match entry.kind {
-            LeaseKind::Tombstone { .. } => Err(SeedRefreshError::AlreadyExpired),
-            LeaseKind::Active(lease) if lease.refresh_token != req_token => {
+        match entry.kind.validate_token(req_token, now, false) {
+            Err(RefreshDenied::Expired) => Err(SeedRefreshError::AlreadyExpired),
+            Err(RefreshDenied::BadToken | RefreshDenied::TooSoon) => {
                 Err(SeedRefreshError::BadRequest)
             }
-            LeaseKind::Active(_) => entry
+            Ok(_) => entry
                 .extra
                 .parent
                 .clone()
@@ -1116,14 +1161,14 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         let req_token = u64::from_le_bytes(refresh_token);
         let entry = self
             .seed_routes
-            .get(release_net, source_net)
+            .get_mut(release_net, source_net)
             .ok_or(SeedRefreshError::UnknownNetId)?;
-        match entry.kind {
-            LeaseKind::Tombstone { .. } => return Err(SeedRefreshError::AlreadyExpired),
-            LeaseKind::Active(lease) if lease.refresh_token != req_token => {
+        match entry.kind.validate_token(req_token, Instant::now(), false) {
+            Err(RefreshDenied::Expired) => return Err(SeedRefreshError::AlreadyExpired),
+            Err(RefreshDenied::BadToken | RefreshDenied::TooSoon) => {
                 return Err(SeedRefreshError::BadRequest);
             }
-            LeaseKind::Active(_) => {}
+            Ok(_) => {}
         }
         self.seed_routes.remove(release_net, source_net);
         Ok(())
@@ -1140,14 +1185,14 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         let req_token = u64::from_le_bytes(refresh_token);
         let entry = self
             .seed_routes
-            .get(release_net, source_net)
+            .get_mut(release_net, source_net)
             .ok_or(SeedRefreshError::UnknownNetId)?;
-        match entry.kind {
-            LeaseKind::Tombstone { .. } => return Err(SeedRefreshError::AlreadyExpired),
-            LeaseKind::Active(lease) if lease.refresh_token != req_token => {
+        match entry.kind.validate_token(req_token, now, false) {
+            Err(RefreshDenied::Expired) => return Err(SeedRefreshError::AlreadyExpired),
+            Err(RefreshDenied::BadToken | RefreshDenied::TooSoon) => {
                 return Err(SeedRefreshError::BadRequest);
             }
-            LeaseKind::Active(_) => {}
+            Ok(_) => {}
         }
         self.seed_routes.remove(release_net, source_net);
         Ok(())
@@ -1298,17 +1343,12 @@ impl<I: Interface, R: RngCore, const N: usize, const S: usize, const C: usize> P
         if net_id == 0 {
             return false;
         }
-        // `LeaseTable` GC is lazy. Without collecting here, a tombstone whose
-        // grace period has already elapsed can still make a newly renumbered
-        // upstream look like transit traffic. `EdgeFrameProcessor` would then
-        // reactivate with its sticky old net_id and close the discovery window
-        // before the later routing lookup gets a chance to collect the entry.
-        self.seed_routes.gc(Instant::now());
         // Direct downstream segments (pending slots hold net_id=0 and are
         // excluded by the check above) and seed-assigned routes. Tombstoned
         // seed routes count too: a recently expired downstream net is still
         // known-not-ours and must not be adopted as the upstream's own.
-        self.slots.iter().any(|s| s.net_id == net_id) || self.seed_routes.contains_key(net_id)
+        self.slots.iter().any(|s| s.net_id == net_id)
+            || self.seed_routes.contains_key_at(net_id, Instant::now())
     }
 }
 

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -231,6 +231,12 @@ impl<NS: NetStackHandle> Services<NS> {
         let assign = pin!(assign);
         let mut assign_svr = assign.attach();
 
+        // Router topology is fixed at construction, so delegation direction
+        // cannot change while this handler is running.
+        let upstream = nsh
+            .stack()
+            .manage_profile(|p| p.seed_delegation_upstream());
+
         loop {
             let res = select3(
                 assign_svr.recv_manual(),
@@ -241,22 +247,19 @@ impl<NS: NetStackHandle> Services<NS> {
             // Bridges delegate to the upstream seed router instead of
             // allocating locally: the root must stay the single owner of
             // the net-id space or nested assignments collide.
-            let upstream = nsh
-                .stack()
-                .manage_profile(|p| p.seed_delegation_upstream());
             match res {
                 Either3::First(assign_req) => {
                     let Ok(assign_req) = assign_req else {
                         continue;
                     };
                     match upstream {
-                        Some(up) => {
+                        Some(ref up) => {
                             handle_assign_delegated(
                                 &nsh,
                                 refresh_port,
                                 release_port,
                                 &assign_req,
-                                up,
+                                up.clone(),
                                 &timeout,
                             )
                             .await

--- a/crates/ergot/tests/edge_rediscovery.rs
+++ b/crates/ergot/tests/edge_rediscovery.rs
@@ -273,6 +273,43 @@ fn rediscovery_accepts_renumbered_upstream_net() {
     ));
 }
 
+/// A transit frame may be the first sign that a quiet link is alive, but it
+/// must not permanently close renumbering discovery on the sticky old net.
+#[test]
+fn transit_first_then_donor_accepts_renumbered_upstream_net() {
+    let stack = bridge_stack();
+    stack
+        .manage_profile(|im| {
+            im.set_interface_state(
+                UPSTREAM_IDENT,
+                InterfaceState::Active {
+                    net_id: 0,
+                    node_id: EDGE_NODE_ID,
+                },
+            )
+        })
+        .unwrap();
+    let mut proc = EdgeFrameProcessor::new();
+    proc.process_frame(&frame_to(7, EDGE_NODE_ID), &stack, UPSTREAM_IDENT);
+
+    stack
+        .manage_profile(|im| im.set_interface_state(UPSTREAM_IDENT, InterfaceState::Inactive))
+        .unwrap();
+    reset_bridge_proc(&mut proc);
+
+    assert!(proc.process_frame(&frame_to(1, EDGE_NODE_ID), &stack, UPSTREAM_IDENT));
+    assert!(matches!(
+        upstream_state(&stack),
+        InterfaceState::Active { net_id: 7, .. }
+    ));
+
+    assert!(proc.process_frame(&frame_to(9, EDGE_NODE_ID), &stack, UPSTREAM_IDENT));
+    assert!(matches!(
+        upstream_state(&stack),
+        InterfaceState::Active { net_id: 9, .. }
+    ));
+}
+
 /// Frames addressed to the far side's node (CENTRAL, from an edge's point of
 /// view) never donate a net — only frames addressed to us do.
 #[test]


### PR DESCRIPTION
Follow-up to #214, now rebased directly onto `main`.

Fixes the follow-up rediscovery and hot-path issues:
- keep the sticky rediscovery window open after transit-only reactivation
- accept a later addressed donor when the upstream net is renumbered
- skip transit lookups for frames that cannot donate a net
- use one profile lock for discovery and point-GC only the queried seed route
- centralize lease token/expiry/replay validation
- cache the fixed seed-delegation upstream outside the handler loop

Validation:
- cargo test --features tokio-std --tests --no-fail-fast
- cargo clippy --features tokio-std --tests -- -D warnings
- cargo check --no-default-features --features std --lib
- cargo check --no-default-features --features nostd-seed-router --lib
- local ergot-demo WASM rebuild plus 28 tests and production build