### PR TITLE
Add optional custom filter for finding nusb ergot devices

### DIFF
--- a/crates/ergot/src/interface_manager/interface_impls/nusb_bulk.rs
+++ b/crates/ergot/src/interface_manager/interface_impls/nusb_bulk.rs
@@ -56,11 +56,30 @@ pub async fn find_new_devices(devs: &HashSet<DeviceInfo>) -> Vec<NewDevice> {
     find_new_devices_with_filter(devs, coarse_device_filter).await
 }
 
-/// A helper function for finding new devices not contained in the provided `devs` set with a custom device filter.
+/// A helper function for finding new devices not contained in the provided `devs` set without the default filter.
+/// The caller has to provide their own filter. If they want to expand on the default filtering they can use the
+/// existing [`coarse_device_filter`] in combination with their own filter
 ///
 /// This function does not add new devices to `devs`, the caller will need to do that
 /// between calls to `find_new_devices_with_filter`.
-pub async fn find_new_devices_with_filter<T: Fn(&nusb::DeviceInfo) -> bool>(devs: &HashSet<DeviceInfo>, filter: T) -> Vec<NewDevice> {
+///
+/// # Examples
+/// Filtering only on the interfaces product string
+/// ```no_run
+/// find_new_devices_with_filter(&devs, |d| d.product_string() == Some("my_custom_usb_interface"))
+/// ```
+///
+/// 
+/// Expanding on the existing filtering by using the default filtering method [`coarse_device_filter`] as well as checking the product string
+/// ```no_run
+/// find_new_devices_with_filter(&devs, |d| {
+///     coarse_device_filter(d) || d.product_string() == Some("my_custom_usb_interface")
+/// })
+/// ```
+pub async fn find_new_devices_with_filter<T: Fn(&nusb::DeviceInfo) -> bool>(
+    devs: &HashSet<DeviceInfo>,
+    filter: T,
+) -> Vec<NewDevice> {
     trace!("Searching for new devices...");
     let mut out = vec![];
     let devices = nusb::list_devices().unwrap();
@@ -170,7 +189,11 @@ pub async fn find_new_devices_with_filter<T: Fn(&nusb::DeviceInfo) -> bool>(devs
     out
 }
 
-fn coarse_device_filter(info: &nusb::DeviceInfo) -> bool {
+/// The default filter function used in [`find_new_devices`]
+///
+/// Checks if any interface uses `0xFF` as class, `0xCA` as subclass and `0x7D` as protocol
+/// as well as if the interface string is `ergot`, all of which are set in the nusb examples
+pub fn coarse_device_filter(info: &nusb::DeviceInfo) -> bool {
     info.interfaces().any(|intfc| {
         let pre_check =
             intfc.class() == 0xFF && intfc.subclass() == 0xCA && intfc.protocol() == 0x7D;

--- a/crates/ergot/src/interface_manager/interface_impls/nusb_bulk.rs
+++ b/crates/ergot/src/interface_manager/interface_impls/nusb_bulk.rs
@@ -64,17 +64,23 @@ pub async fn find_new_devices(devs: &HashSet<DeviceInfo>) -> Vec<NewDevice> {
 /// between calls to `find_new_devices_with_filter`.
 ///
 /// # Examples
-/// Filtering only on the interfaces product string
+/// Filtering only on the interface's product string
 /// ```no_run
-/// find_new_devices_with_filter(&devs, |d| d.product_string() == Some("my_custom_usb_interface"))
+/// use std::collections::HashSet;
+/// use ergot::toolkits::nusb_v0_1::{coarse_device_filter,find_new_devices_with_filter};
+/// let devices = HashSet::new();
+/// find_new_devices_with_filter(&devices, |d| d.product_string() == Some("my_custom_usb_interface"));
 /// ```
 ///
 /// 
 /// Expanding on the existing filtering by using the default filtering method [`coarse_device_filter`] as well as checking the product string
 /// ```no_run
-/// find_new_devices_with_filter(&devs, |d| {
+/// use std::collections::HashSet;
+/// use ergot::toolkits::nusb_v0_1::{coarse_device_filter,find_new_devices_with_filter};
+/// let devices = HashSet::new();
+/// find_new_devices_with_filter(&devices, |d| {
 ///     coarse_device_filter(d) || d.product_string() == Some("my_custom_usb_interface")
-/// })
+/// });
 /// ```
 pub async fn find_new_devices_with_filter<T: Fn(&nusb::DeviceInfo) -> bool>(
     devs: &HashSet<DeviceInfo>,

--- a/crates/ergot/src/interface_manager/interface_impls/nusb_bulk.rs
+++ b/crates/ergot/src/interface_manager/interface_impls/nusb_bulk.rs
@@ -59,7 +59,7 @@ pub async fn find_new_devices(devs: &HashSet<DeviceInfo>) -> Vec<NewDevice> {
 /// A helper function for finding new devices not contained in the provided `devs` set with a custom device filter.
 ///
 /// This function does not add new devices to `devs`, the caller will need to do that
-/// between calls to `find_new_devices`.
+/// between calls to `find_new_devices_with_filter`.
 pub async fn find_new_devices_with_filter<T: Fn(&nusb::DeviceInfo) -> bool>(devs: &HashSet<DeviceInfo>, filter: T) -> Vec<NewDevice> {
     trace!("Searching for new devices...");
     let mut out = vec![];

--- a/crates/ergot/src/interface_manager/interface_impls/nusb_bulk.rs
+++ b/crates/ergot/src/interface_manager/interface_impls/nusb_bulk.rs
@@ -53,10 +53,18 @@ fn device_match(d1: &nusb::DeviceInfo, d2: &nusb::DeviceInfo) -> bool {
 /// This function does not add new devices to `devs`, the caller will need to do that
 /// between calls to `find_new_devices`.
 pub async fn find_new_devices(devs: &HashSet<DeviceInfo>) -> Vec<NewDevice> {
+    find_new_devices_with_filter(devs, coarse_device_filter).await
+}
+
+/// A helper function for finding new devices not contained in the provided `devs` set with a custom device filter.
+///
+/// This function does not add new devices to `devs`, the caller will need to do that
+/// between calls to `find_new_devices`.
+pub async fn find_new_devices_with_filter<T: Fn(&nusb::DeviceInfo) -> bool>(devs: &HashSet<DeviceInfo>, filter: T) -> Vec<NewDevice> {
     trace!("Searching for new devices...");
     let mut out = vec![];
     let devices = nusb::list_devices().unwrap();
-    let devices = devices.filter(coarse_device_filter).collect::<Vec<_>>();
+    let devices = devices.filter(filter).collect::<Vec<_>>();
 
     for device in devices {
         let dinfo = DeviceInfo {

--- a/crates/ergot/src/toolkits.rs
+++ b/crates/ergot/src/toolkits.rs
@@ -476,7 +476,7 @@ pub mod nusb_v0_1 {
 
     use crate::net_stack::ArcNetStack;
 
-    pub use crate::interface_manager::interface_impls::nusb_bulk::{NewDevice, find_new_devices, find_new_devices_with_filter};
+    pub use crate::interface_manager::interface_impls::nusb_bulk::{NewDevice, find_new_devices, find_new_devices_with_filter, coarse_device_filter};
 
     pub type RouterStack =
         ArcNetStack<CriticalSectionRawMutex, Router<NusbBulk, rand::rngs::StdRng, 64, 64>>;

--- a/crates/ergot/src/toolkits.rs
+++ b/crates/ergot/src/toolkits.rs
@@ -476,7 +476,7 @@ pub mod nusb_v0_1 {
 
     use crate::net_stack::ArcNetStack;
 
-    pub use crate::interface_manager::interface_impls::nusb_bulk::{NewDevice, find_new_devices};
+    pub use crate::interface_manager::interface_impls::nusb_bulk::{NewDevice, find_new_devices, find_new_devices_with_filter};
 
     pub type RouterStack =
         ArcNetStack<CriticalSectionRawMutex, Router<NusbBulk, rand::rngs::StdRng, 64, 64>>;


### PR DESCRIPTION
In case the interface has a different name or one of the class/subclass/protocol values is different.

My original use-case was that nusb for whatever reason didn't show the ergot interface in the `list_devices` call so the device was never selected. This happened on Windows. After I modified the filter locally to make it select the device anyway calls like `claim_interface` still worked, so I have no idea why the interface didn't show up.
Interestingly this change was no longer needed after a reboot, but I figured the option to define a filter could still come in handy.