### PR TITLE
Adds a sink to support message fragmentation 

### DIFF
--- a/crates/ergot/Cargo.lock
+++ b/crates/ergot/Cargo.lock
@@ -242,6 +242,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "defmt"
 version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +648,7 @@ dependencies = [
  "rand_core",
  "rtt-target",
  "serde",
+ "serde_with",
  "ssmarshal",
  "static_cell",
  "tokio",
@@ -816,6 +851,12 @@ dependencies = [
  "serde_core",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "io-kit-sys"
@@ -1367,6 +1408,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "serde_core",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serialport"
 version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1531,12 @@ checksum = "0530892bb4fa575ee0da4b86f86c667132a94b74bb72160f58ee5a4afec74c23"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/crates/ergot/Cargo.toml
+++ b/crates/ergot/Cargo.toml
@@ -184,6 +184,7 @@ rand_core = { version = "0.9", optional = true, default-features = false }
 futures-io = { version = "0.3.32", optional = true }
 tokio-util = { version = "0.7.18", features = ["compat"], optional = true }
 web-time = { version = "1.1.0", optional = true }
+serde_with = { version = "3.22.0", default-features = false, features = ["macros"] }
 
 [dev-dependencies]
 tokio   = { version = "1.45.1", features = ["macros", "rt-multi-thread", "time", "io-util", "net", "sync"] }

--- a/crates/ergot/src/book/_02_major_concepts.rs
+++ b/crates/ergot/src/book/_02_major_concepts.rs
@@ -102,7 +102,8 @@
 //!
 //! Currently, Ergot does NOT mandate a minimum or maximum "transmission unit", e.g. the min/max size of a frame.
 //!
-//! Ergot also currently does not handle fragmentation, or splitting a frame to fit within a maximum transmission unit of an interface.
+//! Ergot also currently does not handle fragmentation in every interface, or splitting a frame to fit within a maximum transmission unit of an interface.
+//! However, there is the fragmentation sink which can be used to send messages larger than a transport supports normally.
 //!
 //! Ergot also currently does not mandate any kind of message integrity check, e.g. a CRC or other checksum.
 //!

--- a/crates/ergot/src/interface_manager/edge_port.rs
+++ b/crates/ergot/src/interface_manager/edge_port.rs
@@ -206,7 +206,7 @@ impl<I: Interface> EdgePort<I> {
     #[allow(dead_code)]
     pub fn send_raw(&mut self, hdr: &HeaderSeq, data: &[u8]) -> Result<(), InterfaceSendError> {
         // Check if the frame would exceed the outgoing interface's MTU
-        let frame_size = crate::wire_frames::MAX_HDR_ENCODED_SIZE + data.len();
+        let frame_size = self.sink.max_header_size() + data.len();
         let iface_mtu = self.sink.mtu() as usize;
         if frame_size > iface_mtu {
             return Err(InterfaceSendError::PacketTooBig {

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -34,7 +34,7 @@
 //!
 //! [`NetStack`]: crate::NetStack
 
-use crate::{Header, HeaderSeq, ProtocolError};
+use crate::{Header, HeaderSeq, NetStackSendError, ProtocolError, net_stack::ReqRespError, wire_frames};
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
@@ -485,12 +485,20 @@ pub trait Interface {
 /// TX worker.
 #[allow(clippy::result_unit_err)]
 pub trait InterfaceSink {
+    const MAX_HEADER_SIZE: usize = wire_frames::MAX_HDR_ENCODED_SIZE;
+
     /// Returns the maximum total ergot packet size (header + payload) that this
     /// interface can accept for sending.
     ///
     /// If the interface performs internal fragmentation/reassembly, this returns
     /// the max reassembled size, not the raw link frame size.
     fn mtu(&self) -> u16;
+
+    /// The max size the header used by this interface can be after encoding
+    /// Useful to calculate how big a message is allowed to be to be guaranteed to fit
+    fn max_header_size(&self) -> usize {
+        Self::MAX_HEADER_SIZE    
+    }
 
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, body: &T) -> Result<(), ()>;
     fn send_raw(&mut self, hdr: &HeaderSeq, body: &[u8]) -> Result<(), ()>;
@@ -607,4 +615,39 @@ impl InterfaceSendError {
             }
         }
     }
+}
+
+/// An error occurred when requesting a free buffer slot to send a fragmented message
+#[derive(Serialize, Deserialize, Schema, Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
+pub enum FragmentRequestError {
+    // The service has no free buffer to assemble the fragmented message
+    NoFreeSlot,
+    // Assembled message is larger than the maximum message size we expect
+    MsgTooBig
+}
+
+/// An error occurred when sending a packet of a fragmented message
+#[derive(Serialize, Deserialize, Schema, Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
+pub enum FragmentPacketError {
+    // The fragmentation service doesn't have a buffer with that slot Id
+    UnknownSlotId,
+    // The buffer slot exists but is not active/was not requested beforehand
+    SlotUnprepared,
+    // The packet's `packet_idx` * the set `packet_data_size` field was larger than the buffer
+    IndexTooLarge,
+}
+
+/// An error that can occur in the fragmentation sink
+#[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
+pub enum FragmentError {
+    Request(FragmentRequestError),
+    Packet(FragmentPacketError),
+    Transport(ReqRespError),
+    HandlerRaised,
+    ParseHeader(postcard::Error),
+    NetStack(NetStackSendError),
+    DeserPacket,
 }

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -34,7 +34,9 @@
 //!
 //! [`NetStack`]: crate::NetStack
 
-use crate::{Header, HeaderSeq, NetStackSendError, ProtocolError, net_stack::ReqRespError, wire_frames};
+use crate::{
+    Header, HeaderSeq, NetStackSendError, ProtocolError, net_stack::ReqRespError, wire_frames,
+};
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
@@ -497,7 +499,7 @@ pub trait InterfaceSink {
     /// The max size the header used by this interface can be after encoding
     /// Useful to calculate how big a message is allowed to be to be guaranteed to fit
     fn max_header_size(&self) -> usize {
-        Self::MAX_HEADER_SIZE    
+        Self::MAX_HEADER_SIZE
     }
 
     fn send_ty<T: Serialize>(&mut self, hdr: &HeaderSeq, body: &T) -> Result<(), ()>;
@@ -624,7 +626,7 @@ pub enum FragmentRequestError {
     // The service has no free buffer to assemble the fragmented message
     NoFreeSlot,
     // Assembled message is larger than the maximum message size we expect
-    MsgTooBig
+    MsgTooBig,
 }
 
 /// An error occurred when sending a packet of a fragmented message

--- a/crates/ergot/src/interface_manager/mod.rs
+++ b/crates/ergot/src/interface_manager/mod.rs
@@ -643,7 +643,6 @@ pub enum FragmentPacketError {
 
 /// An error that can occur in the fragmentation sink
 #[derive(Debug, PartialEq)]
-#[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
 pub enum FragmentError {
     Request(FragmentRequestError),
     Packet(FragmentPacketError),

--- a/crates/ergot/src/interface_manager/utils/cobs_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/cobs_stream.rs
@@ -6,7 +6,7 @@
 use bbqueue::{prod_cons::stream::StreamProducer, traits::bbqhdl::BbqHandle};
 use postcard::{
     Serializer,
-    ser_flavors::{self, Flavor},
+    ser_flavors::{self, Cobs, Flavor, Slice},
 };
 use serde::Serialize;
 
@@ -107,7 +107,8 @@ where
         let max_len = cobs::max_encoding_length(self.mtu as usize) + 1;
         let mut wgr = self.prod.grant_exact(max_len).map_err(drop)?;
 
-        let ser = ser_flavors::Cobs::try_new(ser_flavors::Slice::new(&mut wgr)).map_err(drop)?;
+        let ser: Cobs<Slice<'_>> =
+            ser_flavors::Cobs::try_new(ser_flavors::Slice::new(&mut wgr)).map_err(drop)?;
         let used = wire_frames::encode_frame_err(ser, hdr, err).map_err(drop)?;
         let len = used.len();
         wgr.commit(len);

--- a/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
+++ b/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
@@ -334,12 +334,15 @@ where
 
         let () = assert!(inner_sink.is_some(), "An inner Sink must be provided");
         let () = assert!(queue_handle.is_some(), "A queue handle must be provided");
-        
+
         let inner_sink = inner_sink.expect("An inner Sink must be provided");
         let queue_handle = queue_handle.expect("A queue handle must be provided");
         let max_inner_msg_size = size_of::<FragmentPacket<BAR_SIZE>>();
-        
-        assert!(size_of::<FragmentPacket<0>>() < inner_sink.mtu() as usize, "The overhead of the fragmentation messages is larger as the MTU of the inner sink");
+
+        assert!(
+            size_of::<FragmentPacket<0>>() < inner_sink.mtu() as usize,
+            "The overhead of the fragmentation messages is larger as the MTU of the inner sink"
+        );
 
         (
             Sink {

--- a/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
+++ b/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
@@ -334,10 +334,12 @@ where
 
         let () = assert!(inner_sink.is_some(), "An inner Sink must be provided");
         let () = assert!(queue_handle.is_some(), "A queue handle must be provided");
-
+        
         let inner_sink = inner_sink.expect("An inner Sink must be provided");
         let queue_handle = queue_handle.expect("A queue handle must be provided");
         let max_inner_msg_size = size_of::<FragmentPacket<BAR_SIZE>>();
+        
+        assert!(size_of::<FragmentPacket<0>>() < inner_sink.mtu() as usize, "The overhead of the fragmentation messages is larger as the MTU of the inner sink");
 
         (
             Sink {

--- a/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
+++ b/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
@@ -1,0 +1,644 @@
+use core::{fmt::Debug, marker::PhantomData, pin::pin};
+
+use bbqueue::{
+    prod_cons::framed::{FramedConsumer, FramedProducer},
+    traits::{bbqhdl::BbqHandle, notifier::AsyncNotifier},
+};
+use embassy_futures::select::Either;
+use postcard::{
+    Serializer,
+    ser_flavors::{Flavor, Slice},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    Address, AnyAllAppendix, HeaderSeq, interface_manager::{
+        FragmentError, FragmentPacketError, FragmentRequestError, Interface, InterfaceSink, Profile,
+    }, logging::{error, trace, warn}, net_stack::NetStackHandle, well_known::{
+        ErgotFragmentPacketEndpoint, ErgotFragmentRequestEndpoint, FragmentPacket, FragmentRequest,
+        FragmentRequestResponse,
+    }, wire_frames::{self, CommonHeader, de_frame, encode_frame_hdr},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct FragmentationHeader {
+    max_inner_size: u16,
+    dst: Address,
+}
+
+/// How the fragmentation service should handle a non-fatal issue that has come up 
+pub enum FragmentationIssueResolution {
+    Retry,
+    Drop,
+    RaiseError,
+}
+
+// REGISTRY_SIZE should be the MTU divided and rounded up (div_ceil) by the package size (BAR_SIZE in FragmentationConfig) and then divided by eight
+// Without nightly there is currently no way to calculate that automatically
+#[derive(Debug, Clone, Copy)]
+pub struct FragmentationBuffer<const MTU: usize, const REGISTRY_SIZE: usize> {
+    // To know (in combination with received_size) when the message is fully received
+    pub(crate) complete_size: u16,
+    pub(crate) received_size: u16,
+    pub(crate) packet_size: u16,
+    pub(crate) buffer: [u8; MTU],
+    pub(crate) reserved: bool,
+    // The registry is used to make sure we don't apply and count a package twice.
+    pub(crate) registry: [u8; REGISTRY_SIZE],
+}
+
+impl<const MTU: usize, const REGISTRY_SIZE: usize> FragmentationBuffer<MTU, REGISTRY_SIZE> {
+    pub const fn new() -> Self {
+        Self {
+            complete_size: 0,
+            received_size: 0,
+            packet_size: 0,
+            reserved: false,
+            buffer: [0; MTU],
+            registry: [0; REGISTRY_SIZE],
+        }
+    }
+}
+
+pub trait FragmentationIssueHandler: Clone {
+    fn handle_issue(
+        &self,
+        error: FragmentError,
+        addr: Address,
+    ) -> impl Future<Output = FragmentationIssueResolution>;
+    fn handle_error(&self, err: FragmentError);
+}
+
+#[derive(Clone)]
+pub struct DefaultFragmentationIssueHandler;
+
+impl FragmentationIssueHandler for DefaultFragmentationIssueHandler {
+    async fn handle_issue(
+        &self,
+        _error: FragmentError,
+        _addr: Address,
+    ) -> FragmentationIssueResolution {
+        FragmentationIssueResolution::Drop
+    }
+
+    fn handle_error(&self, _err: FragmentError) {}
+}
+
+pub struct FragmentationConfig<
+    Q,
+    H: FragmentationIssueHandler,
+    const MTU: usize,
+    const N: usize,
+    const BAR_SIZE: usize,
+    const REGISTRY_SIZE: usize,
+> where
+    Q: BbqHandle,
+{
+    pub(crate) cons: FramedConsumer<Q>,
+    pub(crate) handler: H,
+    pub(crate) receive_buffer: [FragmentationBuffer<MTU, REGISTRY_SIZE>; N],
+}
+
+pub struct FragmentationSinkInterface<I, Q> {
+    _s: PhantomData<I>,
+    _q: PhantomData<Q>,
+}
+
+impl<I, Q> Interface for FragmentationSinkInterface<I, Q>
+where
+    I: Interface,
+    Q: BbqHandle,
+{
+    type Sink = Sink<I::Sink, Q>;
+}
+
+pub struct Sink<S, Q>
+where
+    S: InterfaceSink,
+    Q: BbqHandle,
+{
+    pub(crate) inner_sink: S,
+    pub(crate) mtu: u16,
+    pub(crate) prod: FramedProducer<Q>,
+    pub(crate) max_inner_msg_size: usize,
+    pub(crate) any_handling: bool,
+}
+
+impl<S, Q> InterfaceSink for Sink<S, Q>
+where
+    Q: BbqHandle,
+    S: InterfaceSink,
+{
+    const MAX_HEADER_SIZE: usize = 4;
+
+    fn mtu(&self) -> u16 {
+        self.mtu
+    }
+
+    fn send_ty<T: serde::Serialize>(&mut self, hdr: &HeaderSeq, body: &T) -> Result<(), ()> {
+        let msg_size = size_of::<T>();
+
+        let max_inner_msg_size = if self.any_handling && hdr.any_all.is_none() {
+            self.max_inner_msg_size + size_of::<AnyAllAppendix>()
+        } else {
+            self.max_inner_msg_size
+        };
+
+        if msg_size > max_inner_msg_size {
+            if hdr.dst.port_id == 255 {
+                error!("The fragmentation sink does not support the fragmentation of broadcasts");
+                return Err(())
+            }
+            let mut wgr = self
+                .prod
+                .grant(self.mtu() + Self::MAX_HEADER_SIZE as u16)
+                .map_err(drop)?;
+            let mut serializer = Serializer {
+                output: Slice::new(&mut wgr),
+            };
+
+            let footer = FragmentationHeader {
+                dst: hdr.dst,
+                max_inner_size: self.max_inner_msg_size as u16,
+            };
+            footer.serialize(&mut serializer).map_err(drop)?;
+
+            wire_frames::encode_frame_hdr(&mut serializer, hdr).map_err(drop)?;
+
+            body.serialize(&mut serializer).map_err(drop)?;
+            let used = serializer.output.finalize().map_err(drop)?;
+            let len = used.len() as u16;
+            wgr.commit(len);
+            Ok(())
+        } else {
+            self.inner_sink.send_ty(hdr, body)
+        }
+    }
+
+    fn send_err(
+        &mut self,
+        hdr: &crate::prelude::HeaderSeq,
+        err: crate::prelude::ProtocolError,
+    ) -> Result<(), ()> {
+        let msg_size = size_of::<crate::prelude::ProtocolError>();
+
+        let max_inner_msg_size = if self.any_handling && hdr.any_all.is_none() {
+            self.max_inner_msg_size + size_of::<AnyAllAppendix>()
+        } else {
+            self.max_inner_msg_size
+        };
+
+        if msg_size > max_inner_msg_size {
+            if hdr.dst.port_id == 255 {
+                error!("The fragmentation sink does not support the fragmentation of broadcasts");
+                return Err(())
+            }
+            let mut wgr = self
+                .prod
+                .grant(self.mtu() + Self::MAX_HEADER_SIZE as u16)
+                .map_err(drop)?;
+            let mut serializer = Serializer {
+                output: Slice::new(&mut wgr),
+            };
+
+            let footer = FragmentationHeader {
+                dst: hdr.dst,
+                max_inner_size: self.max_inner_msg_size as u16,
+            };
+            footer.serialize(&mut serializer).map_err(drop)?;
+
+            let chdr: CommonHeader = hdr.into();
+            chdr.serialize(&mut serializer).map_err(drop)?;
+            err.serialize(&mut serializer).map_err(drop)?;
+
+            let used = serializer.output.finalize().map_err(drop)?;
+            let len = used.len() as u16;
+            wgr.commit(len);
+            Ok(())
+        } else {
+            self.inner_sink.send_err(hdr, err)
+        }
+    }
+
+    fn send_raw(&mut self, hdr: &crate::prelude::HeaderSeq, body: &[u8]) -> Result<(), ()> {
+
+        let max_inner_msg_size = if self.any_handling && hdr.any_all.is_none() {
+            self.max_inner_msg_size + size_of::<AnyAllAppendix>()
+        } else {
+            self.max_inner_msg_size
+        };
+
+        if body.len() > max_inner_msg_size {
+            if hdr.dst.port_id == 255 {
+                error!("The fragmentation sink does not support the fragmentation of broadcasts");
+                return Err(())
+            }
+            let mut wgr = self
+                .prod
+                .grant(self.mtu() + Self::MAX_HEADER_SIZE as u16)
+                .map_err(drop)?;
+            let mut serializer = Serializer {
+                output: Slice::new(&mut wgr),
+            };
+            let footer = FragmentationHeader {
+                dst: hdr.dst,
+                max_inner_size: self.max_inner_msg_size as u16,
+            };
+            footer.serialize(&mut serializer).map_err(drop)?;
+            encode_frame_hdr(&mut serializer, hdr).map_err(drop)?;
+            serializer.output.try_extend(body).map_err(drop)?;
+            let len = serializer.output.finalize().map_err(drop)?.len();
+            wgr.commit(len as u16);
+            Ok(())
+        } else {
+            self.inner_sink.send_raw(hdr, body)
+        }
+    }
+}
+
+pub struct FragmentationSinkBuilder<
+    S,
+    Q,
+    H,
+    const MTU: usize,
+    const N: usize,
+    const BAR_SIZE: usize,
+    const REGISTRY_SIZE: usize,
+> where
+    S: InterfaceSink,
+    Q: BbqHandle,
+    H: FragmentationIssueHandler,
+{
+    inner_sink: Option<S>,
+    queue_handle: Option<Q>,
+    handler: H,
+    any_handling: bool,
+}
+
+impl<S, Q, H, const MTU: usize, const N: usize, const BAR_SIZE: usize, const REGISTRY_SIZE: usize>
+    FragmentationSinkBuilder<S, Q, H, MTU, N, BAR_SIZE, REGISTRY_SIZE>
+where
+    S: InterfaceSink,
+    Q: BbqHandle,
+    H: FragmentationIssueHandler,
+{
+    /// Creates a new [`FragmentationSinkBuilder`] to create a fragmentation sink. 
+    /// 
+    /// Receives a [`FragmentationIssueHandler`]. If it's not used [`DefaultFragmentationIssueHandler`] can be passed
+    pub fn new(handler: H) -> Self {
+        Self {
+            queue_handle: None,
+            inner_sink: None,
+            handler,
+            any_handling: true,
+        }
+    }
+
+    /// The queue to store the messages in that get fragmented by the fragmentation service
+    pub fn with_bbqueue(&mut self, queue: Option<Q>) -> &mut Self {
+        self.queue_handle = queue;
+        self
+    }
+
+    /// The inner sink the fragmentation sink should wrap
+    pub fn with_sink(&mut self, sink: S) -> &mut Self {
+        self.inner_sink = Some(sink);
+        self
+    }
+
+    /// If the fragmentation sink should take the Any header appendix into account when checking if a message can fit into the underlying sink
+    /// 
+    /// Needs to be set to false in case the inner sink does any special encoding of the Any header appendix
+    pub fn with_any_handling(&mut self, handle_any_all: bool) -> &mut Self {
+        self.any_handling = handle_any_all;
+        self
+    }
+
+    /// Creates the fragmentation sink as well as a fragmentation config to pass to the [`Services::fragmented_message_handler`]
+    pub fn generate(
+        self,
+    ) -> (
+        Sink<S, Q>,
+        FragmentationConfig<Q, H, MTU, N, BAR_SIZE, REGISTRY_SIZE>,
+    ) {
+        let FragmentationSinkBuilder {
+            inner_sink,
+            queue_handle,
+            handler,
+            any_handling,
+        } = self;
+
+        let () = assert!(inner_sink.is_some(), "An inner Sink must be provided");
+        let () = assert!(queue_handle.is_some(), "A queue handle must be provided");
+
+
+        let inner_sink = inner_sink.expect("An inner Sink must be provided");
+        let queue_handle = queue_handle.expect("A queue handle must be provided");
+        let max_inner_msg_size = size_of::<FragmentPacket<BAR_SIZE>>();
+
+        (
+            Sink {
+                inner_sink: inner_sink,
+                prod: queue_handle.framed_producer(),
+                max_inner_msg_size,
+                mtu: MTU as u16,
+                any_handling,
+            },
+            FragmentationConfig {
+                cons: queue_handle.framed_consumer(),
+                handler,
+                receive_buffer: [FragmentationBuffer {
+                    complete_size: 0,
+                    packet_size: 0,
+                    received_size: 0,
+                    reserved: false,
+                    buffer: [0; MTU],
+                    registry: [0; REGISTRY_SIZE],
+                }; N],
+            },
+        )
+    }
+}
+
+/// The part of the fragmentation service that handles all incomming messages (fragmentation requests and fragment packets)
+pub(crate) async fn handle_incomming_fragmentation_packets<
+    Q,
+    P,
+    H,
+    NS,
+    const D: usize,
+    const MTU: usize,
+    const N: usize,
+    const BAR_SIZE: usize,
+    const REGISTRY_SIZE: usize,
+>(
+    ns_handle: NS,
+    mut receive_buffers: [FragmentationBuffer<MTU, REGISTRY_SIZE>; N],
+    ident: <<NS as NetStackHandle>::Profile as Profile>::InterfaceIdent,
+    handler: H,
+) where
+    Q: BbqHandle,
+    Q::Notifier: AsyncNotifier,
+    NS: NetStackHandle,
+    H: FragmentationIssueHandler,
+{
+    let stack = ns_handle.stack();
+    let endpoints = stack.endpoints();
+
+    let request = endpoints
+        .clone()
+        .bounded_server::<ErgotFragmentRequestEndpoint, D>(None);
+    let request = pin!(request);
+    let mut request_svr = request.attach();
+
+    let packet = endpoints
+        .clone()
+        .bounded_server::<ErgotFragmentPacketEndpoint<BAR_SIZE>, D>(None);
+    let packet = pin!(packet);
+    let mut packet_svr = packet.attach();
+    let prt = packet_svr.port();
+
+    loop {
+        let res =
+            embassy_futures::select::select(request_svr.recv_manual(), packet_svr.recv_manual())
+                .await;
+        match res {
+            Either::First(req_res) => {
+                let Ok(msg) = req_res else {
+                    continue;
+                };
+                let resp = if msg.t.complete_size > MTU as u16 {
+                    Err(FragmentRequestError::MsgTooBig)
+                } else {
+                    let mut index = usize::MAX;
+                    for idx in 0..receive_buffers.len() {
+                        if !receive_buffers[idx].reserved {
+                            receive_buffers[idx].reserved = true;
+                            receive_buffers[idx].complete_size = msg.t.complete_size;
+                            receive_buffers[idx].packet_size = msg.t.packet_data_size;
+                            receive_buffers[idx].received_size = 0;
+                            index = idx;
+                            break;
+                        }
+                    }
+                    if index != usize::MAX {
+                        Ok(FragmentRequestResponse {
+                            buffer_id: index as u8,
+                            port: prt,
+                        })
+                    } else {
+                        Err(FragmentRequestError::NoFreeSlot)
+                    }
+                };
+                trace!(
+                    "Received a fragment request {:?}, answering with {:?}",
+                    msg,
+                    resp
+                );
+                _ = endpoints
+                    .clone()
+                    .respond_owned::<ErgotFragmentRequestEndpoint>(&msg.hdr, &resp);
+            }
+            Either::Second(pack_res) => {
+                let Ok(msg) = pack_res else {
+                    continue;
+                };
+                let resp = if msg.t.buffer_id >= N as u8 {
+                    Err(FragmentPacketError::UnknownSlotId)
+                } else if !receive_buffers[msg.t.buffer_id as usize].reserved {
+                    Err(FragmentPacketError::SlotUnprepared)
+                } else {
+                    let buffer_info = &mut receive_buffers[msg.t.buffer_id as usize];
+                    let addr = msg.t.packet_idx * buffer_info.packet_size;
+                    let registry_idx = msg.t.packet_idx / 8;
+                    let bit_idx = msg.t.packet_idx % 8;
+                    let byte: u8 = 1 << bit_idx;
+                    if addr > buffer_info.complete_size {
+                        Err(FragmentPacketError::IndexTooLarge)
+                    } else if buffer_info.registry[registry_idx as usize] & byte == 1 {
+                        // We already received that package, so we just ignore it and move on
+                        warn!(
+                            "Fragmentation packet with index {} was received already and will be ignored",
+                            msg.t.packet_idx
+                        );
+                        Ok(())
+                    } else {
+                        // Make sure that we don't copy over the end of the buffer
+                        let len = u16::min(BAR_SIZE as u16, buffer_info.complete_size - addr);
+                        buffer_info.buffer[(addr as usize)..(addr + len) as usize]
+                            .copy_from_slice(&msg.t.data[..(len as usize)]);
+                        // Set the bit in the registry so we can make sure that we don't process a package twice
+                        buffer_info.registry[registry_idx as usize] =
+                            buffer_info.registry[registry_idx as usize] | byte;
+
+                        buffer_info.received_size += len;
+                        if buffer_info.received_size == buffer_info.complete_size {
+                            let frame =
+                                de_frame(&buffer_info.buffer[..buffer_info.complete_size as usize]);
+                            if let Some(frame) = frame
+                                && frame.body.is_ok()
+                            {
+                                let res = ns_handle.stack().send_raw(
+                                    &frame.hdr,
+                                    frame.body.expect(
+                                        "We already checked that the frame body is not an error",
+                                    ),
+                                    ident.clone(),
+                                );
+                                if let Err(e) = res {
+                                    error!("Fragmentation packet handler error: {:?}", e);
+                                    handler.handle_error(FragmentError::NetStack(e));
+                                }
+                            } else {
+                                handler.handle_error(FragmentError::DeserPacket);
+                            }
+                            buffer_info.reserved = false;
+                            // Reset the registry
+                            buffer_info.registry.fill(0);
+                        }
+
+                        Ok(())
+                    }
+                };
+                let res = endpoints
+                    .clone()
+                    .respond_owned::<ErgotFragmentPacketEndpoint<BAR_SIZE>>(&msg.hdr, &resp);
+                if let Err(e) = res {
+                    handler.handle_error(FragmentError::NetStack(e));
+                }
+
+            }
+        }
+    }
+}
+
+/// The part of the fragmentation service that handles all outgoing messages (requesting a buffer and sending fragment packets)
+pub(crate) async fn handle_outgoing_fragmentation_packets<
+    Q,
+    P,
+    H,
+    NS,
+    const D: usize,
+    const MTU: usize,
+    const BAR_SIZE: usize,
+>(
+    ns_handle: NS,
+    cons: FramedConsumer<Q>,
+    handler: H,
+) where
+    Q: BbqHandle,
+    Q::Notifier: AsyncNotifier,
+    NS: NetStackHandle,
+    H: FragmentationIssueHandler,
+{
+    let stack = ns_handle.stack();
+    let endpoints = stack.endpoints();
+
+    'outer: loop {
+        let grant = cons.wait_read().await;
+        let result = postcard::take_from_bytes::<FragmentationHeader>(&grant);
+        let Ok((header, rem)) = result else {
+            // Something went wrong when reading the header, we're dropping the packet
+            error!("Could not read fragmentation header, dropping packet");
+            handler.handle_error(FragmentError::ParseHeader(result.expect_err("We already checked that the result is an error")));
+            grant.release();
+            continue;
+        };
+        let complete_size = rem.len() as u16;
+        let packet_data_size: u16 = BAR_SIZE as u16;
+
+        let req: FragmentRequest = FragmentRequest {
+            complete_size,
+            packet_data_size,
+        };
+
+        // We don't know which port the `ErgotFragmentRequestEndpoint` has on the other side so we set the port to zero
+        let mut dst = header.dst;
+        dst.port_id = 0;
+
+        let response: Result<FragmentRequestResponse, FragmentError> = {
+            'buffer_grant: loop {
+                let ans = endpoints
+                    .clone()
+                    .request::<ErgotFragmentRequestEndpoint>(dst, &req, None)
+                    .await;
+                if let Ok(res) = ans {
+                    match res {
+                        Ok(resp) => break Ok(resp),
+                        Err(e) => {
+                            let handle_as = handler.handle_issue(FragmentError::Request(e), dst).await;
+                            match handle_as {
+                                FragmentationIssueResolution::Drop => continue 'outer, // Could not get a buffer_id to send to, so we're dropping the message
+                                FragmentationIssueResolution::Retry => continue 'buffer_grant, // Retry
+                                FragmentationIssueResolution::RaiseError => {
+                                    break Err(FragmentError::HandlerRaised);
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    break Err(FragmentError::Transport(ans.expect_err("We already tested that the value is an error")));
+                }
+            }
+        };
+
+        let Ok(FragmentRequestResponse { buffer_id, port }) = response else {
+            handler.handle_error(response.expect_err("We already checked if the response is an error"));
+            grant.release();
+            continue;
+        };
+
+        // We receive the port id so we don't send packets with any/all enabled, which would allow us to encode more data bytes per packet (see the comment in send_ty)
+        dst.port_id = port;
+
+        let packet_amount = complete_size.div_ceil(packet_data_size);
+
+        let mut buf: [u8; BAR_SIZE] = [0; BAR_SIZE];
+
+        for idx in 0..packet_amount {
+            let start = (idx * packet_data_size) as usize;
+            let len = usize::min(packet_data_size as usize, rem.len() - start);
+            let end = start + len;
+            buf[..len].copy_from_slice(&rem[start..end]);
+            let req = FragmentPacket::<BAR_SIZE> {
+                buffer_id,
+                packet_idx: idx,
+                data: buf,
+            };
+            let res = endpoints
+                .clone()
+                .request::<ErgotFragmentPacketEndpoint<BAR_SIZE>>(dst, &req, None)
+                .await;
+            if let Err(e) = res {
+                let action = handler.handle_issue(FragmentError::Transport(e), dst).await;
+                match action {
+                    FragmentationIssueResolution::Drop => break,
+                    FragmentationIssueResolution::RaiseError => {
+                        handler.handle_error(FragmentError::HandlerRaised);
+                        break;
+                    },
+                    FragmentationIssueResolution::Retry => continue,
+                }
+            }
+        }
+        grant.release();
+    }
+}
+
+/// Calculates the `BAR_SIZE` constant 
+/// 
+/// `BAR_SIZE` being the max size the Byte ARray in a [`FragmentPacket`] might have based on the underlying sink
+pub const fn calc_barray_size<I: Interface, Q: BbqHandle, const MTU: usize>() -> usize
+where
+    I::Sink: InterfaceSink,
+{
+    MTU - I::Sink::MAX_HEADER_SIZE
+        - <FragmentationSinkInterface<I, Q> as Interface>::Sink::MAX_HEADER_SIZE
+}
+
+/// Calculates the `REGISTRY_SIZE` constant
+/// 
+/// `REGISTRY_SIZE` being the number of [`FragmentPacket`]s that are needed to fully send a message of `MTU` size
+pub const fn calc_registry_size<const MTU: usize, const BAR_SIZE: usize>() -> usize {
+    MTU.div_ceil(BAR_SIZE).div_ceil(8)
+}

--- a/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
+++ b/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
@@ -65,6 +65,14 @@ impl<const MTU: usize, const REGISTRY_SIZE: usize> FragmentationBuffer<MTU, REGI
     }
 }
 
+impl<const MTU: usize, const REGISTRY_SIZE: usize> Default
+    for FragmentationBuffer<MTU, REGISTRY_SIZE>
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub trait FragmentationIssueHandler: Clone {
     fn handle_issue(
         &self,
@@ -318,7 +326,7 @@ where
         self
     }
 
-    /// Creates the fragmentation sink as well as a fragmentation config to pass to the [`Services::fragmented_message_handler`]
+    /// Creates the fragmentation sink as well as a fragmentation config to pass to the fragmented_message_handler
     pub fn generate(
         self,
     ) -> (
@@ -346,7 +354,7 @@ where
 
         (
             Sink {
-                inner_sink: inner_sink,
+                inner_sink,
                 prod: queue_handle.framed_producer(),
                 max_inner_msg_size,
                 mtu: MTU as u16,
@@ -371,7 +379,6 @@ where
 /// The part of the fragmentation service that handles all incomming messages (fragmentation requests and fragment packets)
 pub(crate) async fn handle_incomming_fragmentation_packets<
     Q,
-    P,
     H,
     NS,
     const D: usize,
@@ -419,12 +426,12 @@ pub(crate) async fn handle_incomming_fragmentation_packets<
                     Err(FragmentRequestError::MsgTooBig)
                 } else {
                     let mut index = usize::MAX;
-                    for idx in 0..receive_buffers.len() {
-                        if !receive_buffers[idx].reserved {
-                            receive_buffers[idx].reserved = true;
-                            receive_buffers[idx].complete_size = msg.t.complete_size;
-                            receive_buffers[idx].packet_size = msg.t.packet_data_size;
-                            receive_buffers[idx].received_size = 0;
+                    for (idx, receive_buffer) in receive_buffers.iter_mut().enumerate() {
+                        if !receive_buffer.reserved {
+                            receive_buffer.reserved = true;
+                            receive_buffer.complete_size = msg.t.complete_size;
+                            receive_buffer.packet_size = msg.t.packet_data_size;
+                            receive_buffer.received_size = 0;
                             index = idx;
                             break;
                         }
@@ -475,8 +482,7 @@ pub(crate) async fn handle_incomming_fragmentation_packets<
                         buffer_info.buffer[(addr as usize)..(addr + len) as usize]
                             .copy_from_slice(&msg.t.data[..(len as usize)]);
                         // Set the bit in the registry so we can make sure that we don't process a package twice
-                        buffer_info.registry[registry_idx as usize] =
-                            buffer_info.registry[registry_idx as usize] | byte;
+                        buffer_info.registry[registry_idx as usize] |= byte;
 
                         buffer_info.received_size += len;
                         if buffer_info.received_size == buffer_info.complete_size {
@@ -521,7 +527,6 @@ pub(crate) async fn handle_incomming_fragmentation_packets<
 /// The part of the fragmentation service that handles all outgoing messages (requesting a buffer and sending fragment packets)
 pub(crate) async fn handle_outgoing_fragmentation_packets<
     Q,
-    P,
     H,
     NS,
     const D: usize,

--- a/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
+++ b/crates/ergot/src/interface_manager/utils/fragmentation_sink.rs
@@ -12,12 +12,17 @@ use postcard::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Address, AnyAllAppendix, HeaderSeq, interface_manager::{
+    Address, AnyAllAppendix, HeaderSeq,
+    interface_manager::{
         FragmentError, FragmentPacketError, FragmentRequestError, Interface, InterfaceSink, Profile,
-    }, logging::{error, trace, warn}, net_stack::NetStackHandle, well_known::{
+    },
+    logging::{error, trace, warn},
+    net_stack::NetStackHandle,
+    well_known::{
         ErgotFragmentPacketEndpoint, ErgotFragmentRequestEndpoint, FragmentPacket, FragmentRequest,
         FragmentRequestResponse,
-    }, wire_frames::{self, CommonHeader, de_frame, encode_frame_hdr},
+    },
+    wire_frames::{self, CommonHeader, de_frame, encode_frame_hdr},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,7 +31,7 @@ pub(crate) struct FragmentationHeader {
     dst: Address,
 }
 
-/// How the fragmentation service should handle a non-fatal issue that has come up 
+/// How the fragmentation service should handle a non-fatal issue that has come up
 pub enum FragmentationIssueResolution {
     Retry,
     Drop,
@@ -147,7 +152,7 @@ where
         if msg_size > max_inner_msg_size {
             if hdr.dst.port_id == 255 {
                 error!("The fragmentation sink does not support the fragmentation of broadcasts");
-                return Err(())
+                return Err(());
             }
             let mut wgr = self
                 .prod
@@ -191,7 +196,7 @@ where
         if msg_size > max_inner_msg_size {
             if hdr.dst.port_id == 255 {
                 error!("The fragmentation sink does not support the fragmentation of broadcasts");
-                return Err(())
+                return Err(());
             }
             let mut wgr = self
                 .prod
@@ -221,7 +226,6 @@ where
     }
 
     fn send_raw(&mut self, hdr: &crate::prelude::HeaderSeq, body: &[u8]) -> Result<(), ()> {
-
         let max_inner_msg_size = if self.any_handling && hdr.any_all.is_none() {
             self.max_inner_msg_size + size_of::<AnyAllAppendix>()
         } else {
@@ -231,7 +235,7 @@ where
         if body.len() > max_inner_msg_size {
             if hdr.dst.port_id == 255 {
                 error!("The fragmentation sink does not support the fragmentation of broadcasts");
-                return Err(())
+                return Err(());
             }
             let mut wgr = self
                 .prod
@@ -282,8 +286,8 @@ where
     Q: BbqHandle,
     H: FragmentationIssueHandler,
 {
-    /// Creates a new [`FragmentationSinkBuilder`] to create a fragmentation sink. 
-    /// 
+    /// Creates a new [`FragmentationSinkBuilder`] to create a fragmentation sink.
+    ///
     /// Receives a [`FragmentationIssueHandler`]. If it's not used [`DefaultFragmentationIssueHandler`] can be passed
     pub fn new(handler: H) -> Self {
         Self {
@@ -307,7 +311,7 @@ where
     }
 
     /// If the fragmentation sink should take the Any header appendix into account when checking if a message can fit into the underlying sink
-    /// 
+    ///
     /// Needs to be set to false in case the inner sink does any special encoding of the Any header appendix
     pub fn with_any_handling(&mut self, handle_any_all: bool) -> &mut Self {
         self.any_handling = handle_any_all;
@@ -330,7 +334,6 @@ where
 
         let () = assert!(inner_sink.is_some(), "An inner Sink must be provided");
         let () = assert!(queue_handle.is_some(), "A queue handle must be provided");
-
 
         let inner_sink = inner_sink.expect("An inner Sink must be provided");
         let queue_handle = queue_handle.expect("A queue handle must be provided");
@@ -432,8 +435,7 @@ pub(crate) async fn handle_incomming_fragmentation_packets<
                 };
                 trace!(
                     "Received a fragment request {:?}, answering with {:?}",
-                    msg,
-                    resp
+                    msg, resp
                 );
                 _ = endpoints
                     .clone()
@@ -506,7 +508,6 @@ pub(crate) async fn handle_incomming_fragmentation_packets<
                 if let Err(e) = res {
                     handler.handle_error(FragmentError::NetStack(e));
                 }
-
             }
         }
     }
@@ -540,7 +541,9 @@ pub(crate) async fn handle_outgoing_fragmentation_packets<
         let Ok((header, rem)) = result else {
             // Something went wrong when reading the header, we're dropping the packet
             error!("Could not read fragmentation header, dropping packet");
-            handler.handle_error(FragmentError::ParseHeader(result.expect_err("We already checked that the result is an error")));
+            handler.handle_error(FragmentError::ParseHeader(
+                result.expect_err("We already checked that the result is an error"),
+            ));
             grant.release();
             continue;
         };
@@ -566,7 +569,8 @@ pub(crate) async fn handle_outgoing_fragmentation_packets<
                     match res {
                         Ok(resp) => break Ok(resp),
                         Err(e) => {
-                            let handle_as = handler.handle_issue(FragmentError::Request(e), dst).await;
+                            let handle_as =
+                                handler.handle_issue(FragmentError::Request(e), dst).await;
                             match handle_as {
                                 FragmentationIssueResolution::Drop => continue 'outer, // Could not get a buffer_id to send to, so we're dropping the message
                                 FragmentationIssueResolution::Retry => continue 'buffer_grant, // Retry
@@ -577,13 +581,17 @@ pub(crate) async fn handle_outgoing_fragmentation_packets<
                         }
                     }
                 } else {
-                    break Err(FragmentError::Transport(ans.expect_err("We already tested that the value is an error")));
+                    break Err(FragmentError::Transport(
+                        ans.expect_err("We already tested that the value is an error"),
+                    ));
                 }
             }
         };
 
         let Ok(FragmentRequestResponse { buffer_id, port }) = response else {
-            handler.handle_error(response.expect_err("We already checked if the response is an error"));
+            handler.handle_error(
+                response.expect_err("We already checked if the response is an error"),
+            );
             grant.release();
             continue;
         };
@@ -616,7 +624,7 @@ pub(crate) async fn handle_outgoing_fragmentation_packets<
                     FragmentationIssueResolution::RaiseError => {
                         handler.handle_error(FragmentError::HandlerRaised);
                         break;
-                    },
+                    }
                     FragmentationIssueResolution::Retry => continue,
                 }
             }
@@ -625,8 +633,8 @@ pub(crate) async fn handle_outgoing_fragmentation_packets<
     }
 }
 
-/// Calculates the `BAR_SIZE` constant 
-/// 
+/// Calculates the `BAR_SIZE` constant
+///
 /// `BAR_SIZE` being the max size the Byte ARray in a [`FragmentPacket`] might have based on the underlying sink
 pub const fn calc_barray_size<I: Interface, Q: BbqHandle, const MTU: usize>() -> usize
 where
@@ -637,7 +645,7 @@ where
 }
 
 /// Calculates the `REGISTRY_SIZE` constant
-/// 
+///
 /// `REGISTRY_SIZE` being the number of [`FragmentPacket`]s that are needed to fully send a message of `MTU` size
 pub const fn calc_registry_size<const MTU: usize, const BAR_SIZE: usize>() -> usize {
     MTU.div_ceil(BAR_SIZE).div_ceil(8)

--- a/crates/ergot/src/interface_manager/utils/framed_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/framed_stream.rs
@@ -3,7 +3,10 @@
 //! The "Framed Stream" is one flavor of interface sinks. It is intended for packet-like
 //! interfaces that do NOT require framing in software.
 
-use bbqueue::{prod_cons::framed::FramedProducer, traits::bbqhdl::BbqHandle};
+use bbqueue::{
+    prod_cons::framed::{FramedProducer},
+    traits::bbqhdl::BbqHandle,
+};
 use postcard::{
     Serializer,
     ser_flavors::{self, Flavor, Slice},

--- a/crates/ergot/src/interface_manager/utils/framed_stream.rs
+++ b/crates/ergot/src/interface_manager/utils/framed_stream.rs
@@ -3,10 +3,7 @@
 //! The "Framed Stream" is one flavor of interface sinks. It is intended for packet-like
 //! interfaces that do NOT require framing in software.
 
-use bbqueue::{
-    prod_cons::framed::{FramedProducer},
-    traits::bbqhdl::BbqHandle,
-};
+use bbqueue::{prod_cons::framed::FramedProducer, traits::bbqhdl::BbqHandle};
 use postcard::{
     Serializer,
     ser_flavors::{self, Flavor, Slice},

--- a/crates/ergot/src/interface_manager/utils/mod.rs
+++ b/crates/ergot/src/interface_manager/utils/mod.rs
@@ -1,6 +1,6 @@
 pub mod cobs_stream;
-pub mod framed_stream;
 pub mod fragmentation_sink;
+pub mod framed_stream;
 
 #[cfg(feature = "std")]
 pub mod std;

--- a/crates/ergot/src/interface_manager/utils/mod.rs
+++ b/crates/ergot/src/interface_manager/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod cobs_stream;
 pub mod framed_stream;
+pub mod fragmentation_sink;
 
 #[cfg(feature = "std")]
 pub mod std;

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -320,13 +320,13 @@ impl<NS: NetStackHandle> Services<NS> {
         } = config;
 
         join(
-            handle_incomming_fragmentation_packets::<Q, P, H, NS, D, MTU, N, SIZE, REGISTRY_SIZE>(
+            handle_incomming_fragmentation_packets::<Q, H, NS, D, MTU, N, SIZE, REGISTRY_SIZE>(
                 nsh.clone(),
                 receive_buffer,
                 ident,
                 handler.clone(),
             ),
-            handle_outgoing_fragmentation_packets::<Q, P, H, NS, D, MTU, SIZE>(nsh, cons, handler),
+            handle_outgoing_fragmentation_packets::<Q, H, NS, D, MTU, SIZE>(nsh, cons, handler),
         )
         .await;
     }

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -8,10 +8,15 @@ use embassy_futures::{
 use crate::fmtlog::ErgotFmtRxOwned;
 use crate::{
     interface_manager::{
-        Profile, utils::fragmentation_sink::{
-            FragmentationConfig, FragmentationIssueHandler, handle_incomming_fragmentation_packets, handle_outgoing_fragmentation_packets,
+        Profile,
+        utils::fragmentation_sink::{
+            FragmentationConfig, FragmentationIssueHandler, handle_incomming_fragmentation_packets,
+            handle_outgoing_fragmentation_packets,
         },
-    }, net_stack::{NetStackHandle, endpoints::Endpoints, topics::Topics}, socket::HeaderMessage, well_known::{
+    },
+    net_stack::{NetStackHandle, endpoints::Endpoints, topics::Topics},
+    socket::HeaderMessage,
+    well_known::{
         AddressClaimGranted, AddressClaimRequest, AddressRefreshRequest, DeviceInfo,
         ErgotAddressClaimEndpoint, ErgotAddressRefreshEndpoint, ErgotDeviceInfoInterrogationTopic,
         ErgotDeviceInfoTopic, ErgotPingEndpoint, ErgotSeedRouterAssignmentEndpoint,
@@ -307,7 +312,6 @@ impl<NS: NetStackHandle> Services<NS> {
         Q::Notifier: AsyncNotifier,
         H: FragmentationIssueHandler,
     {
-
         let nsh = self.inner.clone();
         let FragmentationConfig {
             receive_buffer,
@@ -316,26 +320,13 @@ impl<NS: NetStackHandle> Services<NS> {
         } = config;
 
         join(
-            handle_incomming_fragmentation_packets::<
-                Q,
-                P,
-                H,
-                NS,
-                D,
-                MTU,
-                N,
-                SIZE,
-                REGISTRY_SIZE,
-            >(nsh.clone(), receive_buffer, ident, handler.clone()),
-            handle_outgoing_fragmentation_packets::<
-                Q,
-                P,
-                H,
-                NS,
-                D,
-                MTU,
-                SIZE,
-            >(nsh ,cons, handler ),
+            handle_incomming_fragmentation_packets::<Q, P, H, NS, D, MTU, N, SIZE, REGISTRY_SIZE>(
+                nsh.clone(),
+                receive_buffer,
+                ident,
+                handler.clone(),
+            ),
+            handle_outgoing_fragmentation_packets::<Q, P, H, NS, D, MTU, SIZE>(nsh, cons, handler),
         )
         .await;
     }

--- a/crates/ergot/src/net_stack/services.rs
+++ b/crates/ergot/src/net_stack/services.rs
@@ -1,12 +1,17 @@
-use embassy_futures::select::{Either, Either3, select3};
+use bbqueue::traits::{bbqhdl::BbqHandle, notifier::AsyncNotifier};
+use embassy_futures::{
+    join::join,
+    select::{Either, Either3, select3},
+};
 
 #[cfg(feature = "std")]
 use crate::fmtlog::ErgotFmtRxOwned;
 use crate::{
-    interface_manager::Profile,
-    net_stack::{NetStackHandle, endpoints::Endpoints, topics::Topics},
-    socket::HeaderMessage,
-    well_known::{
+    interface_manager::{
+        Profile, utils::fragmentation_sink::{
+            FragmentationConfig, FragmentationIssueHandler, handle_incomming_fragmentation_packets, handle_outgoing_fragmentation_packets,
+        },
+    }, net_stack::{NetStackHandle, endpoints::Endpoints, topics::Topics}, socket::HeaderMessage, well_known::{
         AddressClaimGranted, AddressClaimRequest, AddressRefreshRequest, DeviceInfo,
         ErgotAddressClaimEndpoint, ErgotAddressRefreshEndpoint, ErgotDeviceInfoInterrogationTopic,
         ErgotDeviceInfoTopic, ErgotPingEndpoint, ErgotSeedRouterAssignmentEndpoint,
@@ -282,6 +287,57 @@ impl<NS: NetStackHandle> Services<NS> {
                 }
             }
         }
+    }
+    /// Handler for sending and receiving fragmented packages (to be used in combination with fragmentation_sink)
+    pub async fn fragmented_message_handler<
+        Q,
+        P,
+        H,
+        const D: usize,
+        const MTU: usize,
+        const N: usize,
+        const SIZE: usize,
+        const REGISTRY_SIZE: usize,
+    >(
+        self,
+        config: FragmentationConfig<Q, H, MTU, N, SIZE, REGISTRY_SIZE>,
+        ident: <<NS as NetStackHandle>::Profile as Profile>::InterfaceIdent,
+    ) where
+        Q: BbqHandle,
+        Q::Notifier: AsyncNotifier,
+        H: FragmentationIssueHandler,
+    {
+
+        let nsh = self.inner.clone();
+        let FragmentationConfig {
+            receive_buffer,
+            handler,
+            cons,
+        } = config;
+
+        join(
+            handle_incomming_fragmentation_packets::<
+                Q,
+                P,
+                H,
+                NS,
+                D,
+                MTU,
+                N,
+                SIZE,
+                REGISTRY_SIZE,
+            >(nsh.clone(), receive_buffer, ident, handler.clone()),
+            handle_outgoing_fragmentation_packets::<
+                Q,
+                P,
+                H,
+                NS,
+                D,
+                MTU,
+                SIZE,
+            >(nsh ,cons, handler ),
+        )
+        .await;
     }
     /// Handler for accepting and responding to bus address claim and refresh requests.
     ///

--- a/crates/ergot/src/well_known.rs
+++ b/crates/ergot/src/well_known.rs
@@ -12,7 +12,8 @@ use crate::logging::defmtlog::ErgotDefmtRxOwned;
 use crate::logging::defmtlog::{ErgotDefmtRx, ErgotDefmtTx};
 
 use crate::interface_manager::{
-    AddressClaimError, AddressRefreshError, FragmentPacketError, FragmentRequestError, NodeClaimAssignment, SeedAssignmentError, SeedNetAssignment, SeedRefreshError,
+    AddressClaimError, AddressRefreshError, FragmentPacketError, FragmentRequestError,
+    NodeClaimAssignment, SeedAssignmentError, SeedNetAssignment, SeedRefreshError,
 };
 use crate::nash::NameHash;
 use crate::{Address, FrameKind, endpoint, topic};
@@ -215,7 +216,6 @@ pub struct PathMtuResult {
     pub path_mtu: u16,
 }
 
-
 #[derive(Debug, Serialize, Deserialize, Schema, Clone, PartialEq)]
 pub struct FragmentRequest {
     pub complete_size: u16,
@@ -234,15 +234,18 @@ pub struct FragmentPacket<const SIZE: usize> {
     pub buffer_id: u8,
     pub packet_idx: u16,
     #[serde_as(as = "[_; SIZE]")]
-    pub data: [u8; SIZE]
+    pub data: [u8; SIZE],
 }
-
 
 type FragmentRequestResponseResult = Result<FragmentRequestResponse, FragmentRequestError>;
 type FragmentPacketResponse = Result<(), FragmentPacketError>;
 
-endpoint!(ErgotFragmentRequestEndpoint, FragmentRequest, FragmentRequestResponseResult, "ergot/.well-known/fragment/request");
-
+endpoint!(
+    ErgotFragmentRequestEndpoint,
+    FragmentRequest,
+    FragmentRequestResponseResult,
+    "ergot/.well-known/fragment/request"
+);
 
 // Implemented by hand since the [`endpoint!`] macro doesn't like const generics
 pub struct ErgotFragmentPacketEndpoint<const SIZE: usize> {

--- a/crates/ergot/src/well_known.rs
+++ b/crates/ergot/src/well_known.rs
@@ -251,7 +251,7 @@ endpoint!(
 pub struct ErgotFragmentPacketEndpoint<const SIZE: usize> {
     _priv: core::marker::PhantomData<()>,
 }
-impl<'a, const SIZE: usize> crate::traits::Endpoint for ErgotFragmentPacketEndpoint<SIZE> {
+impl<const SIZE: usize> crate::traits::Endpoint for ErgotFragmentPacketEndpoint<SIZE> {
     type Request = FragmentPacket<SIZE>;
     type Response = FragmentPacketResponse;
     const PATH: &'static str = "ergot/.well-known/fragment/packet";

--- a/crates/ergot/src/well_known.rs
+++ b/crates/ergot/src/well_known.rs
@@ -1,5 +1,6 @@
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 #[cfg(feature = "std")]
 use crate::fmtlog::ErgotFmtRxOwned;
@@ -11,8 +12,7 @@ use crate::logging::defmtlog::ErgotDefmtRxOwned;
 use crate::logging::defmtlog::{ErgotDefmtRx, ErgotDefmtTx};
 
 use crate::interface_manager::{
-    AddressClaimError, AddressRefreshError, NodeClaimAssignment, SeedAssignmentError,
-    SeedNetAssignment, SeedRefreshError,
+    AddressClaimError, AddressRefreshError, FragmentPacketError, FragmentRequestError, NodeClaimAssignment, SeedAssignmentError, SeedNetAssignment, SeedRefreshError,
 };
 use crate::nash::NameHash;
 use crate::{Address, FrameKind, endpoint, topic};
@@ -213,4 +213,47 @@ pub struct PathMtuQuery {
 #[cfg_attr(feature = "defmt-v1", derive(defmt::Format))]
 pub struct PathMtuResult {
     pub path_mtu: u16,
+}
+
+
+#[derive(Debug, Serialize, Deserialize, Schema, Clone, PartialEq)]
+pub struct FragmentRequest {
+    pub complete_size: u16,
+    pub packet_data_size: u16,
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema, Clone, PartialEq)]
+pub struct FragmentRequestResponse {
+    pub buffer_id: u8,
+    pub port: u8,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Schema, Clone, PartialEq)]
+pub struct FragmentPacket<const SIZE: usize> {
+    pub buffer_id: u8,
+    pub packet_idx: u16,
+    #[serde_as(as = "[_; SIZE]")]
+    pub data: [u8; SIZE]
+}
+
+
+type FragmentRequestResponseResult = Result<FragmentRequestResponse, FragmentRequestError>;
+type FragmentPacketResponse = Result<(), FragmentPacketError>;
+
+endpoint!(ErgotFragmentRequestEndpoint, FragmentRequest, FragmentRequestResponseResult, "ergot/.well-known/fragment/request");
+
+
+// Implemented by hand since the [`endpoint!`] macro doesn't like const generics
+pub struct ErgotFragmentPacketEndpoint<const SIZE: usize> {
+    _priv: core::marker::PhantomData<()>,
+}
+impl<'a, const SIZE: usize> crate::traits::Endpoint for ErgotFragmentPacketEndpoint<SIZE> {
+    type Request = FragmentPacket<SIZE>;
+    type Response = FragmentPacketResponse;
+    const PATH: &'static str = "ergot/.well-known/fragment/packet";
+    const REQ_KEY: crate::traits::Key =
+        crate::traits::Key::for_path::<FragmentPacket<SIZE>>("ergot/.well-known/fragment/packet");
+    const RESP_KEY: crate::traits::Key =
+        crate::traits::Key::for_path::<FragmentPacketResponse>("ergot/.well-known/fragment/packet");
 }

--- a/crates/ergot/tests/fragmentation_sink.rs
+++ b/crates/ergot/tests/fragmentation_sink.rs
@@ -5,18 +5,30 @@
 use std::{assert_matches, pin::pin, time::Duration};
 
 use ergot::{
-    endpoint, interface_manager::{
-        InterfaceState, interface_impls::tokio_stream::TokioStreamInterface, profiles::direct_edge::{CENTRAL_NODE_ID, DirectEdge, EDGE_NODE_ID, EdgeFrameProcessor}, transports::tokio_cobs_stream, utils::{
-            cobs_stream, fragmentation_sink::{
-                DefaultFragmentationIssueHandler, FragmentationSinkBuilder, FragmentationSinkInterface, calc_barray_size, calc_registry_size,
-            }, std::StdQueue,
+    endpoint,
+    interface_manager::{
+        InterfaceState,
+        interface_impls::tokio_stream::TokioStreamInterface,
+        profiles::direct_edge::{CENTRAL_NODE_ID, DirectEdge, EDGE_NODE_ID, EdgeFrameProcessor},
+        transports::tokio_cobs_stream,
+        utils::{
+            cobs_stream,
+            fragmentation_sink::{
+                DefaultFragmentationIssueHandler, FragmentationSinkBuilder,
+                FragmentationSinkInterface, calc_barray_size, calc_registry_size,
+            },
+            std::StdQueue,
         },
-    }, net_stack::ArcNetStack, toolkits::tokio_stream::{
-        self as stream_kit,
-    }, well_known::ErgotPingEndpoint,
+    },
+    net_stack::ArcNetStack,
+    toolkits::tokio_stream::{self as stream_kit},
+    well_known::ErgotPingEndpoint,
 };
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
-use tokio::{select, time::{sleep, timeout}};
+use tokio::{
+    select,
+    time::{sleep, timeout},
+};
 
 const INNER_MTU: usize = 64;
 const MTU: usize = 1024;
@@ -132,7 +144,9 @@ async fn fragmentation_test() {
     let ctrl_queue = stream_kit::new_std_queue(4096);
     let frag_queue = stream_kit::new_std_queue(4096);
     let mut frag_sink_builder =
-        FragmentationSinkBuilder::<_, _, _, MTU, 1, SIZE, REGISTRY_SIZE>::new(DefaultFragmentationIssueHandler);
+        FragmentationSinkBuilder::<_, _, _, MTU, 1, SIZE, REGISTRY_SIZE>::new(
+            DefaultFragmentationIssueHandler,
+        );
     frag_sink_builder.with_bbqueue(Some(frag_queue));
     frag_sink_builder.with_sink(cobs_stream::Sink::new_from_handle(
         ctrl_queue.clone(),
@@ -147,7 +161,9 @@ async fn fragmentation_test() {
     let tgt_queue = stream_kit::new_std_queue(4096);
     let tgt_frag_queue = stream_kit::new_std_queue(4096);
     let mut tgt_frag_sink_builder =
-        FragmentationSinkBuilder::<_, _, _, MTU, 1, SIZE, REGISTRY_SIZE>::new(DefaultFragmentationIssueHandler);
+        FragmentationSinkBuilder::<_, _, _, MTU, 1, SIZE, REGISTRY_SIZE>::new(
+            DefaultFragmentationIssueHandler,
+        );
     tgt_frag_sink_builder.with_bbqueue(Some(tgt_frag_queue));
     tgt_frag_sink_builder.with_sink(cobs_stream::Sink::new_from_handle(
         tgt_queue.clone(),

--- a/crates/ergot/tests/fragmentation_sink.rs
+++ b/crates/ergot/tests/fragmentation_sink.rs
@@ -1,0 +1,231 @@
+//! Tests for the fragmentation sink
+
+#![cfg(feature = "tokio-std")]
+
+use std::{assert_matches, pin::pin, time::Duration};
+
+use ergot::{
+    endpoint, interface_manager::{
+        InterfaceState, interface_impls::tokio_stream::TokioStreamInterface, profiles::direct_edge::{CENTRAL_NODE_ID, DirectEdge, EDGE_NODE_ID, EdgeFrameProcessor}, transports::tokio_cobs_stream, utils::{
+            cobs_stream, fragmentation_sink::{
+                DefaultFragmentationIssueHandler, FragmentationSinkBuilder, FragmentationSinkInterface, calc_barray_size, calc_registry_size,
+            }, std::StdQueue,
+        },
+    }, net_stack::ArcNetStack, toolkits::tokio_stream::{
+        self as stream_kit,
+    }, well_known::ErgotPingEndpoint,
+};
+use mutex::raw_impls::cs::CriticalSectionRawMutex;
+use tokio::{select, time::{sleep, timeout}};
+
+const INNER_MTU: usize = 64;
+const MTU: usize = 1024;
+const DEVICE_ADDR: ergot::Address = ergot::Address {
+    network_id: 1,
+    node_id: 2,
+    port_id: 0,
+};
+
+type FragStack = ArcNetStack<
+    CriticalSectionRawMutex,
+    DirectEdge<FragmentationSinkInterface<TokioStreamInterface, StdQueue>>,
+>;
+
+type LargeVec = heapless::Vec<u8, 255>;
+
+endpoint!(NormalSizedEndpoint, u64, u64, "normal-sized");
+endpoint!(OversizedEndpoint, LargeVec, LargeVec, "over-sized");
+
+/// Spawn a ping server on the target stack.
+fn spawn_ping_server(stack: &FragStack) {
+    tokio::spawn({
+        let stack = stack.clone();
+        async move {
+            let server = stack
+                .endpoints()
+                .bounded_server::<ErgotPingEndpoint, 4>(Some("ping"));
+            let server = pin!(server);
+            let mut hdl = server.attach();
+            loop {
+                let _ = hdl
+                    .serve(|val: &u32| {
+                        let v = *val;
+                        async move { v }
+                    })
+                    .await;
+            }
+        }
+    });
+}
+
+/// Spawn a ping server on the target stack.
+fn spawn_normal_sized_server(stack: &FragStack) {
+    tokio::spawn({
+        let stack = stack.clone();
+        async move {
+            let server = stack
+                .endpoints()
+                .bounded_server::<NormalSizedEndpoint, 4>(None);
+            let server = pin!(server);
+            let mut hdl = server.attach();
+            loop {
+                let _ = hdl
+                    .serve(|val: &u64| {
+                        let v = *val;
+                        async move { v }
+                    })
+                    .await;
+            }
+        }
+    });
+}
+
+/// Spawn a ping server on the target stack.
+fn spawn_oversized_server(stack: &FragStack) {
+    tokio::spawn({
+        let stack = stack.clone();
+        async move {
+            let server = stack
+                .endpoints()
+                .bounded_server::<OversizedEndpoint, 4>(None);
+            let server = pin!(server);
+            let mut hdl = server.attach();
+            loop {
+                let _ = hdl
+                    .serve(|val: &LargeVec| {
+                        let v = val.to_owned();
+                        async move { v }
+                    })
+                    .await;
+            }
+        }
+    });
+}
+
+/// Send a ping with retries (the first ping establishes the target's net_id).
+async fn ping_with_retry(stack: &FragStack, val: u32) -> u32 {
+    for _ in 0..20 {
+        let result = timeout(
+            Duration::from_millis(500),
+            stack
+                .endpoints()
+                .request::<ErgotPingEndpoint>(DEVICE_ADDR, &val, None),
+        )
+        .await;
+        match result {
+            Ok(Ok(v)) => return v,
+            _ => sleep(Duration::from_millis(100)).await,
+        }
+    }
+    panic!("ping failed after retries");
+}
+
+#[tokio::test]
+async fn fragmentation_test() {
+    env_logger::init();
+    const SIZE: usize = calc_barray_size::<TokioStreamInterface, StdQueue, INNER_MTU>();
+    const REGISTRY_SIZE: usize = calc_registry_size::<MTU, SIZE>();
+
+    let (ctrl_read, tgt_write) = tokio::io::duplex(8192);
+    let (tgt_read, ctrl_write) = tokio::io::duplex(8192);
+
+    let ctrl_queue = stream_kit::new_std_queue(4096);
+    let frag_queue = stream_kit::new_std_queue(4096);
+    let mut frag_sink_builder =
+        FragmentationSinkBuilder::<_, _, _, MTU, 1, SIZE, REGISTRY_SIZE>::new(DefaultFragmentationIssueHandler);
+    frag_sink_builder.with_bbqueue(Some(frag_queue));
+    frag_sink_builder.with_sink(cobs_stream::Sink::new_from_handle(
+        ctrl_queue.clone(),
+        INNER_MTU as u16,
+    ));
+
+    let (sink, ctrl_config) = frag_sink_builder.generate();
+
+    let ctrl_stack: FragStack =
+        ArcNetStack::new_with_profile(DirectEdge::new_controller(sink, InterfaceState::Down));
+
+    let tgt_queue = stream_kit::new_std_queue(4096);
+    let tgt_frag_queue = stream_kit::new_std_queue(4096);
+    let mut tgt_frag_sink_builder =
+        FragmentationSinkBuilder::<_, _, _, MTU, 1, SIZE, REGISTRY_SIZE>::new(DefaultFragmentationIssueHandler);
+    tgt_frag_sink_builder.with_bbqueue(Some(tgt_frag_queue));
+    tgt_frag_sink_builder.with_sink(cobs_stream::Sink::new_from_handle(
+        tgt_queue.clone(),
+        INNER_MTU as u16,
+    ));
+
+    let (sink, tgt_config) = tgt_frag_sink_builder.generate();
+    let tgt_stack: FragStack = ArcNetStack::new_with_profile(DirectEdge::new_target(sink));
+
+    tokio_cobs_stream::register_edge::<
+        _,
+        FragmentationSinkInterface<TokioStreamInterface, StdQueue>,
+        _,
+        _,
+    >(
+        ctrl_stack.clone(),
+        ctrl_read,
+        ctrl_write,
+        ctrl_queue,
+        EdgeFrameProcessor::new_controller(1),
+        InterfaceState::Active {
+            net_id: 1,
+            node_id: CENTRAL_NODE_ID,
+        },
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    tokio_cobs_stream::register_edge::<
+        _,
+        FragmentationSinkInterface<TokioStreamInterface, StdQueue>,
+        _,
+        _,
+    >(
+        tgt_stack.clone(),
+        tgt_read,
+        tgt_write,
+        tgt_queue,
+        EdgeFrameProcessor::new(),
+        InterfaceState::Active {
+            net_id: 1,
+            node_id: EDGE_NODE_ID,
+        },
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    spawn_ping_server(&tgt_stack.clone());
+    spawn_normal_sized_server(&tgt_stack.clone());
+    spawn_oversized_server(&tgt_stack.clone());
+
+    select!(
+        _ = ctrl_stack
+            .services()
+            .fragmented_message_handler::<StdQueue, DirectEdge<FragmentationSinkInterface<TokioStreamInterface, StdQueue>>, _, 4, MTU, 1, SIZE, REGISTRY_SIZE>(ctrl_config, ()) => {}
+        _ = tgt_stack
+            .services()
+            .fragmented_message_handler::<StdQueue, DirectEdge<FragmentationSinkInterface<TokioStreamInterface, StdQueue>>, _, 4, MTU, 1, SIZE, REGISTRY_SIZE>(tgt_config, ()) => {}
+        _ = async {
+
+            // Run a ping to make sure the target has the correct net_id
+            let result = ping_with_retry(&ctrl_stack, 42).await;
+
+            assert_matches!(result, 42);
+
+            let result = ctrl_stack.endpoints().request::<NormalSizedEndpoint>(DEVICE_ADDR, &u64::MAX, None).await;
+
+            assert_matches!(result, Ok(u64::MAX));
+
+            let _vec: LargeVec = heapless::Vec::from_iter(std::iter::repeat_n(5, 255));
+
+            let result = ctrl_stack.endpoints().request::<OversizedEndpoint>(DEVICE_ADDR, &_vec, None).await;
+            assert_matches!(result, Ok(_vec));
+
+        } => {}
+    );
+}


### PR DESCRIPTION
This PR adds a fragmentation sink which can be used to wrap an existing sink to add message fragmentation support.
It also adds a test to make sure the message fragmentation works as intended.

Note that the packages the fragmentation sink sends have an overhead of about four bytes, so transports that support less than that might not work with it.
It also doesn't support the fragmentation of broadcast messages, since it requests a buffer on the destination side before transmitting the fragmented message, which doesn't work with multiple recipients.

Bellow you'll find a small explanation on how the fragmentation sink works and why it was implemented that way.
I also ran into some issues in making it work well with ergot and will start a discussion about some of the issues I ran into [here](https://github.com/jamesmunns/ergot/discussions/224).

One of the goals of the fragmentation sink was to not block the inner transport while the package fragments get transferred, with the idea that time critical messages like pings wont get delayed.

To make that goal possible the fragmentation sink includes a separate queue for messages that are too large for the inner sink.
The fragmentation sink wraps an inner sink and checks each message size in the `send_ty`, `send_raw` and `send_err` methods.
If the messages fit into the inner sinks they get transferred to the inner sink and no further work is done.
Messages that are too large get serialized into the separate queue, including a small header that includes the destination the message should get sent to.
Since a sink doesn't have a good way to continue working on async tasks, the sink works together with a fragmentation service (`fragmented_message_handler`), which needs to be run on both sides, sender and receiver.
This service receives the large message through the queue and deserializes the header to know the destination the message needs to be sent to without deserializing the full header from the message.
After it receives such a large message the service sends a fragmentation request to the destination which the service on the destination receives.
The service has a list of one or more buffers to rebuild the larger messages. If one of them is free that buffer_id of that buffer will get returned from the destination to the sender.
After the sender gets the buffer_id, it will start sending message fragments to the destination. The fragments are sized to use the inner MTU to it's fullest. The sender will wait for each packet to get acknowledged before sending the next. 
However, since it's not guaranteed for the packets to be received in order, the header of the message fragments includes information for the destination service so that the message can get rebuilt even with the messages getting received in a random order.
When all parts of the message have been received, the service on the destination side will rebuilt it, mark the buffer as no longer being reserved and pass it to the netstack, while the service on the sending side will release the grant it got from the queue.