### PR TITLE
Add a split endpoint request API

### DIFF
--- a/crates/ergot/src/book/_04_delivery_and_reliability.rs
+++ b/crates/ergot/src/book/_04_delivery_and_reliability.rs
@@ -113,7 +113,10 @@
 //!   configured, silence alone never changes the interface state.
 //! * A `state_notify` wait-queue is woken on **every interface state change**:
 //!   `Inactive → Active` on the first frame, `→ Inactive`/`Down` on a liveness
-//!   timeout, and on (de)registration. You `wait()` on it and react.
+//!   timeout, and on (de)registration. Use `wait_for()`/`wait_for_value()` to
+//!   register the waiter and inspect the current interface state without a
+//!   lost-wakeup window. A bare `wait().await` followed by a state read can
+//!   miss a transition that happens immediately before the waiter is linked.
 //!
 //! Each interface carries an `InterfaceState`:
 //!
@@ -124,9 +127,10 @@
 //!   worker exits and you re-register.
 //!
 //! The canonical reliability loop is therefore: register the interface with
-//! `liveness` and `state_notify`, `wait()` on the notify, and on each transition
-//! react — on `Active` mark the link up (and run any handshake), on `Inactive`
-//! wait a recovery window, on `Down` (or once the recovery window expires) tear
+//! `liveness` and `state_notify`, then use `wait_for_value(|| read_state())` so
+//! the condition is checked both before sleeping and after every wake. On
+//! `Active` mark the link up (and run any handshake), on `Inactive` wait a
+//! recovery window, and on `Down` (or once the recovery window expires) tear
 //! down and reconnect.
 //!
 //! ## Backpressure, lossiness, and the absence of QoS

--- a/crates/ergot/src/book/_04_delivery_and_reliability.rs
+++ b/crates/ergot/src/book/_04_delivery_and_reliability.rs
@@ -117,6 +117,8 @@
 //!   register the waiter and inspect the current interface state without a
 //!   lost-wakeup window. A bare `wait().await` followed by a state read can
 //!   miss a transition that happens immediately before the waiter is linked.
+//!   Wakeups may coalesce, so observers should react to the latest state rather
+//!   than treating the queue as a log of every intermediate transition.
 //!
 //! Each interface carries an `InterfaceState`:
 //!
@@ -127,11 +129,13 @@
 //!   worker exits and you re-register.
 //!
 //! The canonical reliability loop is therefore: register the interface with
-//! `liveness` and `state_notify`, then use `wait_for_value(|| read_state())` so
-//! the condition is checked both before sleeping and after every wake. On
-//! `Active` mark the link up (and run any handshake), on `Inactive` wait a
-//! recovery window, and on `Down` (or once the recovery window expires) tear
-//! down and reconnect.
+//! `liveness` and `state_notify`, read and react to its initial state, then
+//! remember that state and use `wait_for_value()` with a closure that returns
+//! `Some(current)` only when `current != last_state`. The comparison is checked
+//! after the waiter is registered and after every wake, without busy-looping on
+//! an unchanged `Some(InterfaceState)`. On `Active` mark the link up (and run any
+//! handshake), on `Inactive` wait a recovery window, and on `Down` (or once the
+//! recovery window expires) tear down and reconnect.
 //!
 //! ## Backpressure, lossiness, and the absence of QoS
 //!

--- a/crates/ergot/src/net_stack/endpoints.rs
+++ b/crates/ergot/src/net_stack/endpoints.rs
@@ -3,8 +3,7 @@ use core::{marker::PhantomData, pin::pin};
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
-    Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, HeaderSeq, Key, nash::NameHash,
-    socket::HeaderMessage, traits::Endpoint,
+    Address, DEFAULT_TTL, FrameKind, Header, HeaderSeq, socket::HeaderMessage, traits::Endpoint,
 };
 
 use super::{NetStackHandle, NetStackSendError, ReqRespError};
@@ -123,37 +122,11 @@ impl<NS: NetStackHandle> Endpoints<NS> {
         //
         // We can also use a "single"/oneshot response because we know
         // this request will get exactly one response.
-        let stack = self.inner.stack();
         let resp_sock = self.clone().single_client::<E>();
         let resp_sock = pin!(resp_sock);
         let mut resp_hdl = resp_sock.attach();
 
-        // If the destination is wildcard, include the any_all appendix to the
-        // header
-        let any_all = match dst.port_id {
-            0 => Some(AnyAllAppendix {
-                key: Key(E::REQ_KEY.to_bytes()),
-                nash: name.map(NameHash::new),
-            }),
-            255 => {
-                return Err(ReqRespError::NoBroadcast);
-            }
-            _ => None,
-        };
-
-        let hdr = Header {
-            src: Address {
-                network_id: 0,
-                node_id: 0,
-                port_id: resp_hdl.port(),
-            },
-            dst,
-            any_all,
-            seq_no: None,
-            kind: FrameKind::ENDPOINT_REQ,
-            ttl: DEFAULT_TTL,
-        };
-        stack.send_ty(&hdr, req).map_err(ReqRespError::Local)?;
+        resp_hdl.send_request(dst, req, name)?;
         // TODO: assert seq nos match somewhere? do we NEED seq nos if we have
         // port ids now?
         let resp = resp_hdl.recv().await;

--- a/crates/ergot/src/net_stack/endpoints.rs
+++ b/crates/ergot/src/net_stack/endpoints.rs
@@ -161,7 +161,6 @@ impl<NS: NetStackHandle> Endpoints<NS> {
 
     pub fn single_client<E: Endpoint>(self) -> crate::socket::endpoint::single::Client<E, NS>
     where
-        E::Request: Serialize + DeserializeOwned + Clone,
         E::Response: Serialize + DeserializeOwned + Clone,
     {
         crate::socket::endpoint::single::Client::new(self.inner, None)

--- a/crates/ergot/src/net_stack/mod.rs
+++ b/crates/ergot/src/net_stack/mod.rs
@@ -435,6 +435,8 @@ pub enum ReqRespError {
     Remote(ProtocolError),
     // Requests cannot be sent to broadcast ports
     NoBroadcast,
+    /// This client already has a request awaiting a response
+    RequestPending,
 }
 
 impl<R, P> Default for NetStack<R, P>

--- a/crates/ergot/src/socket/endpoint.rs
+++ b/crates/ergot/src/socket/endpoint.rs
@@ -7,7 +7,10 @@ use pin_project::pin_project;
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::socket::HeaderMessage;
-use crate::{self as base, socket::Response};
+use crate::{
+    self as base, Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, Key, nash::NameHash,
+    socket::Response,
+};
 
 macro_rules! endpoint_server {
     ($sto: ty, $($arr: ident)?) => {
@@ -104,6 +107,7 @@ macro_rules! endpoint_server {
 macro_rules! endpoint_client {
     ($sto: ty, $($arr: ident)?) => {
         /// An endpoint Client socket, typically used for receiving a response
+        #[repr(transparent)]
         #[pin_project]
         pub struct Client<E, NS, $(const $arr: usize)?>
         where
@@ -137,6 +141,22 @@ macro_rules! endpoint_client {
                 let hdl: super::raw::ClientHandle<'_, _, _, NS> = this.sock.attach();
                 ClientHandle { hdl }
             }
+
+            /// Attach a pinned boxed Client and return an owned, `'static`
+            /// handle. This is useful when the response wait must be moved to
+            /// another task after the request has already been sent.
+            #[cfg(feature = "std")]
+            pub fn attach_boxed(
+                self: std::pin::Pin<Box<Self>>,
+            ) -> ClientHandle<'static, E, NS, $($arr)?> {
+                // SAFETY: `Client` only wraps the pinned raw Client, and the
+                // projection is representation-transparent for this field.
+                let raw: std::pin::Pin<Box<super::raw::Client<$sto, E, NS>>> =
+                    unsafe { core::mem::transmute(self) };
+                ClientHandle {
+                    hdl: raw.attach_boxed(),
+                }
+            }
         }
 
         impl<E, NS, $(const $arr: usize)?> ClientHandle<'_, E, NS, $($arr)?>
@@ -148,6 +168,49 @@ macro_rules! endpoint_client {
             /// The port of this Client socket
             pub fn port(&self) -> u8 {
                 self.hdl.port()
+            }
+
+            /// Send an endpoint request synchronously without waiting for its
+            /// response.
+            ///
+            /// Once this returns `Ok`, the request has been committed to the
+            /// netstack. Call [`Self::recv`] later to await the response. A
+            /// Client socket identifies responses by its unique source port,
+            /// so callers must keep at most one request outstanding per
+            /// handle.
+            pub fn send_request(
+                &mut self,
+                dst: Address,
+                req: &E::Request,
+                name: Option<&str>,
+            ) -> Result<(), base::net_stack::ReqRespError>
+            where
+                E::Request: Serialize + Clone + DeserializeOwned + 'static,
+            {
+                let any_all = match dst.port_id {
+                    0 => Some(AnyAllAppendix {
+                        key: Key(E::REQ_KEY.to_bytes()),
+                        nash: name.map(NameHash::new),
+                    }),
+                    255 => return Err(base::net_stack::ReqRespError::NoBroadcast),
+                    _ => None,
+                };
+                let hdr = Header {
+                    src: Address {
+                        network_id: 0,
+                        node_id: 0,
+                        port_id: self.port(),
+                    },
+                    dst,
+                    any_all,
+                    seq_no: None,
+                    kind: FrameKind::ENDPOINT_REQ,
+                    ttl: DEFAULT_TTL,
+                };
+                self.hdl
+                    .stack()
+                    .send_ty(&hdr, req)
+                    .map_err(base::net_stack::ReqRespError::Local)
             }
 
             /// Receive a single response
@@ -184,6 +247,7 @@ pub mod raw {
     }
 
     #[pin_project]
+    #[repr(transparent)]
     pub struct Client<S, E, NS>
     where
         S: Storage<Response<E::Response>>,
@@ -395,6 +459,17 @@ pub mod raw {
             let hdl: raw_owned::SocketHdl<'_, S, E::Response, NS> = this.sock.attach();
             ClientHandle { hdl }
         }
+
+        #[cfg(feature = "std")]
+        pub fn attach_boxed(self: Pin<Box<Self>>) -> ClientHandle<'static, S, E, NS> {
+            // SAFETY: `Client` is representation-transparent over the raw
+            // owned socket and pinning the wrapper pins that socket.
+            let socket: Pin<Box<raw_owned::Socket<S, E::Response, NS>>> =
+                unsafe { core::mem::transmute(self) };
+            ClientHandle {
+                hdl: socket.attach_boxed(),
+            }
+        }
     }
 
     impl<S, E, NS> ClientHandle<'_, S, E, NS>
@@ -406,6 +481,10 @@ pub mod raw {
     {
         pub fn port(&self) -> u8 {
             self.hdl.port()
+        }
+
+        pub fn stack(&self) -> NS::Target {
+            self.hdl.stack()
         }
 
         pub async fn recv(&mut self) -> Response<E::Response> {

--- a/crates/ergot/src/socket/endpoint.rs
+++ b/crates/ergot/src/socket/endpoint.rs
@@ -127,6 +127,7 @@ macro_rules! endpoint_client {
             NS: crate::net_stack::NetStackHandle,
         {
             hdl: super::raw::ClientHandle<'a, $sto, E, NS>,
+            request_pending: bool,
         }
 
         impl<E, NS, $(const $arr: usize)?> Client<E, NS, $($arr)?>
@@ -139,7 +140,10 @@ macro_rules! endpoint_client {
             pub fn attach<'a>(self: Pin<&'a mut Self>) -> ClientHandle<'a, E, NS, $($arr)?> {
                 let this = self.project();
                 let hdl: super::raw::ClientHandle<'_, _, _, NS> = this.sock.attach();
-                ClientHandle { hdl }
+                ClientHandle {
+                    hdl,
+                    request_pending: false,
+                }
             }
 
             /// Attach a pinned boxed Client and return an owned, `'static`
@@ -155,6 +159,7 @@ macro_rules! endpoint_client {
                     unsafe { core::mem::transmute(self) };
                 ClientHandle {
                     hdl: raw.attach_boxed(),
+                    request_pending: false,
                 }
             }
         }
@@ -176,8 +181,9 @@ macro_rules! endpoint_client {
             /// Once this returns `Ok`, the request has been committed to the
             /// netstack. Call [`Self::recv`] later to await the response. A
             /// Client socket identifies responses by its unique source port,
-            /// so callers must keep at most one request outstanding per
-            /// handle.
+            /// so a second request is rejected until [`Self::recv`] receives
+            /// the response to the outstanding request. A failed send does not
+            /// mark a request as pending and may be retried.
             pub fn send_request(
                 &mut self,
                 dst: Address,
@@ -185,8 +191,12 @@ macro_rules! endpoint_client {
                 name: Option<&str>,
             ) -> Result<(), base::net_stack::ReqRespError>
             where
-                E::Request: Serialize + Clone + DeserializeOwned + 'static,
+                E::Request: Serialize + Clone + 'static,
             {
+                if self.request_pending {
+                    return Err(base::net_stack::ReqRespError::RequestPending);
+                }
+
                 let any_all = match dst.port_id {
                     0 => Some(AnyAllAppendix {
                         key: Key(E::REQ_KEY.to_bytes()),
@@ -210,12 +220,16 @@ macro_rules! endpoint_client {
                 self.hdl
                     .stack()
                     .send_ty(&hdr, req)
-                    .map_err(base::net_stack::ReqRespError::Local)
+                    .map_err(base::net_stack::ReqRespError::Local)?;
+                self.request_pending = true;
+                Ok(())
             }
 
             /// Receive a single response
             pub async fn recv(&mut self) -> Response<E::Response> {
-                self.hdl.recv().await
+                let response = self.hdl.recv().await;
+                self.request_pending = false;
+                response
             }
         }
     };

--- a/crates/ergot/tests/smoke2.rs
+++ b/crates/ergot/tests/smoke2.rs
@@ -241,6 +241,52 @@ async fn req_resp() {
 }
 
 #[tokio::test]
+async fn request_can_be_sent_before_waiting_for_response() {
+    static STACK: TestNetStack = NetStack::new();
+
+    let server = STACK.endpoints().single_server::<ExampleEndpoint>(None);
+    let server = pin!(server);
+    let mut server = server.attach();
+
+    let client = STACK.endpoints().single_client::<ExampleEndpoint>();
+    let client = pin!(client);
+    let mut client = client.attach();
+    client
+        .send_request(Address::unknown(), &Example { a: 7, b: 35 }, None)
+        .unwrap();
+
+    server
+        .serve(async |req| req.b + u32::from(req.a))
+        .await
+        .unwrap();
+    let response = client.recv().await.unwrap();
+    assert_eq!(response.t, 42);
+}
+
+#[cfg(feature = "std")]
+#[tokio::test]
+async fn boxed_client_handle_can_move_after_synchronous_send() {
+    static STACK: TestNetStack = NetStack::new();
+
+    let server = STACK.endpoints().single_server::<ExampleEndpoint>(None);
+    let server = pin!(server);
+    let mut server = server.attach();
+
+    let client = STACK.endpoints().single_client::<ExampleEndpoint>();
+    let mut client = Box::pin(client).attach_boxed();
+    client
+        .send_request(Address::unknown(), &Example { a: 2, b: 40 }, None)
+        .unwrap();
+
+    let response_task = tokio::spawn(async move { client.recv().await });
+    server
+        .serve(async |req| req.b + u32::from(req.a))
+        .await
+        .unwrap();
+    assert_eq!(response_task.await.unwrap().unwrap().t, 42);
+}
+
+#[tokio::test]
 async fn req_resp_stack_vec() {
     static STACK: TestNetStack = NetStack::new();
 

--- a/crates/ergot/tests/smoke2.rs
+++ b/crates/ergot/tests/smoke2.rs
@@ -4,7 +4,7 @@ use std::{pin::pin, time::Duration};
 
 use ergot::{
     Address, AnyAllAppendix, DEFAULT_TTL, FrameKind, Header, HeaderSeq, Key, NetStack, endpoint,
-    interface_manager::profiles::null::Null, traits::Endpoint,
+    interface_manager::profiles::null::Null, net_stack::ReqRespError, traits::Endpoint,
 };
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 
@@ -27,8 +27,14 @@ pub struct Other {
     b: i32,
 }
 
+#[derive(Serialize, Debug, PartialEq, Schema, Clone)]
+pub struct SerializeOnly {
+    value: u32,
+}
+
 endpoint!(ExampleEndpoint, Example, u32, "example");
 endpoint!(OtherEndpoint, Other, u32, "other");
+endpoint!(SerializeOnlyEndpoint, SerializeOnly, u32, "serialize-only");
 
 type TestNetStack = NetStack<CriticalSectionRawMutex, Null>;
 
@@ -261,6 +267,60 @@ async fn request_can_be_sent_before_waiting_for_response() {
         .unwrap();
     let response = client.recv().await.unwrap();
     assert_eq!(response.t, 42);
+}
+
+#[test]
+fn split_client_accepts_serialize_only_requests() {
+    static STACK: TestNetStack = NetStack::new();
+
+    let client = STACK.endpoints().single_client::<SerializeOnlyEndpoint>();
+    let client = pin!(client);
+    let mut client = client.attach();
+
+    // There is intentionally no server. This only needs to reach the send
+    // path: clients serialize requests but never deserialize them.
+    for value in [42, 43] {
+        assert!(matches!(
+            client.send_request(Address::unknown(), &SerializeOnly { value }, None),
+            Err(ReqRespError::Local(_)),
+        ));
+    }
+}
+
+#[tokio::test]
+async fn client_rejects_a_second_outstanding_request() {
+    static STACK: TestNetStack = NetStack::new();
+
+    let server = STACK.endpoints().bounded_server::<ExampleEndpoint, 2>(None);
+    let server = pin!(server);
+    let mut server = server.attach();
+
+    let client = STACK.endpoints().single_client::<ExampleEndpoint>();
+    let client = pin!(client);
+    let mut client = client.attach();
+    client
+        .send_request(Address::unknown(), &Example { a: 1, b: 20 }, None)
+        .unwrap();
+
+    assert_eq!(
+        client.send_request(Address::unknown(), &Example { a: 2, b: 40 }, None),
+        Err(ReqRespError::RequestPending),
+    );
+
+    server
+        .serve(async |req| req.b + u32::from(req.a))
+        .await
+        .unwrap();
+    assert_eq!(client.recv().await.unwrap().t, 21);
+
+    client
+        .send_request(Address::unknown(), &Example { a: 2, b: 40 }, None)
+        .unwrap();
+    server
+        .serve(async |req| req.b + u32::from(req.a))
+        .await
+        .unwrap();
+    assert_eq!(client.recv().await.unwrap().t, 42);
 }
 
 #[cfg(feature = "std")]

--- a/crates/ergot/tests/state_notify.rs
+++ b/crates/ergot/tests/state_notify.rs
@@ -1,0 +1,25 @@
+#![cfg(feature = "std")]
+
+use core::sync::atomic::{AtomicU8, Ordering};
+
+use maitake_sync::WaitQueue;
+
+#[tokio::test]
+async fn wait_for_value_observes_transition_before_waiter_registration() {
+    let notify = WaitQueue::new();
+    let state = AtomicU8::new(0);
+
+    // Model an interface transition that races just ahead of the monitor.
+    // A bare `wait().await` would now sleep until an unrelated later change.
+    state.store(1, Ordering::Release);
+    notify.wake_all();
+
+    let observed = notify
+        .wait_for_value(|| {
+            let current = state.load(Ordering::Acquire);
+            (current == 1).then_some(current)
+        })
+        .await
+        .unwrap();
+    assert_eq!(observed, 1);
+}

--- a/crates/ergot/tests/state_notify.rs
+++ b/crates/ergot/tests/state_notify.rs
@@ -5,9 +5,10 @@ use core::sync::atomic::{AtomicU8, Ordering};
 use maitake_sync::WaitQueue;
 
 #[tokio::test]
-async fn wait_for_value_observes_transition_before_waiter_registration() {
+async fn wait_for_value_observes_a_state_change_before_waiter_registration() {
     let notify = WaitQueue::new();
     let state = AtomicU8::new(0);
+    let last_state = state.load(Ordering::Acquire);
 
     // Model an interface transition that races just ahead of the monitor.
     // A bare `wait().await` would now sleep until an unrelated later change.
@@ -17,7 +18,7 @@ async fn wait_for_value_observes_transition_before_waiter_registration() {
     let observed = notify
         .wait_for_value(|| {
             let current = state.load(Ordering::Acquire);
-            (current == 1).then_some(current)
+            (current != last_state).then_some(current)
         })
         .await
         .unwrap();


### PR DESCRIPTION
Splits `Endpoints::request()` into a synchronous send and a separate response wait, so a caller can commit a request without holding its task for the round trip. The motivating case is a periodic setpoint loop that feeds a device-side deadman: one slow response must not delay the next setpoint, and awaiting the request inline either blocks the loop or forces the caller to poke the future through a single poll and detach it, which leans on an implementation detail.

- `ClientHandle::send_request(dst, req, name)` commits the request to the netstack and returns; `recv()` awaits the response separately. `Endpoints::request()` is now built on top of it.
- `Client::attach_boxed()` (std) turns a `Pin<Box<Client>>` into a `'static` handle so the response wait can move to another task after the send.
- A second `send_request` before `recv()` returns the new `ReqRespError::RequestPending`: responses are correlated by source port, so two requests in flight on one handle would be indistinguishable. A failed send leaves nothing pending and can be retried.
- `E::Request` no longer needs `DeserializeOwned` on the client paths (clients only serialize requests).
- Book: the liveness loop now recommends `wait_for_value()` with a remembered last state (a bare `wait()` followed by a state read has a lost-wakeup window, and wakeups coalesce). Tests for the split send, the pending check, serialize-only requests and the boxed handle.